### PR TITLE
Add EVE-NG blueprint landing READMEs

### DIFF
--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -1,0 +1,120 @@
+# GCP EVE-NG Lab Host
+
+Build a private EVE-NG lab host on Google Cloud using a nested-virtualization-capable Compute Engine VM.
+
+This blueprint provisions the VM, connects to it over GCP IAP, configures EVE-NG, and runs a health check so the host proves it is reachable. It is the cloud-friendly EVE-NG path for users who want a reproducible lab host but do not have a Proxmox environment.
+
+Use this when you want the EVE-NG host lifecycle to be rebuildable from infrastructure code instead of manually creating and patching a lab server.
+
+## What This Delivers
+
+- a private GCP Compute Engine VM for EVE-NG
+- nested virtualization enabled for KVM-backed lab workloads
+- no public IP by default
+- SSH access through GCP IAP
+- VM provisioning through `platform/gcp/platform-vm`
+- EVE-NG installation and configuration through `platform/linux/eve-ng`
+- a basic EVE-NG health check through `platform/linux/eve-ng-healthcheck`
+- structured run records for each module step
+
+## Execution Chain
+
+```text
+platform/gcp/platform-vm
+  -> platform/linux/eve-ng
+  -> platform/linux/eve-ng-healthcheck
+```
+
+The blueprint file is [blueprint.yml](blueprint.yml).
+
+## Documentation
+
+- [Deploy EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
+- [Reusable EVE-NG Lab Foundation reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/)
+
+## Prerequisites
+
+This blueprint assumes the GCP foundation for the target environment already exists:
+
+- `hyops init gcp --env <env>` has been run.
+- A GCP project is selected for the environment.
+- The WAN hub network state exists at `org/gcp/wan-hub-network`.
+- The workload subnet output is available as `subnet_workloads_name`.
+- IAP TCP forwarding is allowed for VMs tagged `allow-iap-ssh`.
+- EVE-NG secrets are seeded for the target environment.
+- The placeholder `CHANGE_ME_GCP_ZONE` in [blueprint.yml](blueprint.yml) has been copied or overridden with a real zone that supports the selected machine family.
+
+Seed the EVE-NG secrets before deployment:
+
+```bash
+hyops secrets ensure --env dev EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
+```
+
+## Usage
+
+Validate the blueprint:
+
+```bash
+hyops blueprint validate \
+  --ref gcp/eve-ng@v1 \
+  --blueprints-root blueprints
+```
+
+Run preflight:
+
+```bash
+hyops blueprint preflight \
+  --env dev \
+  --ref gcp/eve-ng@v1 \
+  --blueprints-root blueprints
+```
+
+Deploy:
+
+```bash
+hyops blueprint deploy \
+  --env dev \
+  --ref gcp/eve-ng@v1 \
+  --blueprints-root blueprints \
+  --execute
+```
+
+## Default Shape
+
+The shipped blueprint provisions one VM:
+
+- logical name: `eve-ng-01`
+- role: `eve-ng`
+- machine type: `n2-standard-8`
+- boot disk: `256` GB `pd-standard`
+- source image: Ubuntu 22.04 LTS
+- public IP: disabled
+- nested virtualization: enabled
+- SSH user: `opsadmin`
+- network tag: `allow-iap-ssh`
+
+The VM is placed on the workload subnet exported by the selected GCP network state.
+
+## Why This Exists
+
+Not every networking learner or lab operator has a Proxmox cluster available. A cloud-hosted EVE-NG path makes the host lifecycle easier to reproduce from a clean state while still keeping access private and controlled.
+
+This blueprint turns the lab host into a normal platform outcome:
+
+- the VM is provisioned from a declared contract
+- nested virtualization is explicitly enabled
+- access goes through IAP instead of exposing SSH publicly
+- EVE-NG configuration is a module step, not a manual shell session
+- the final health check produces evidence that the lab host is reachable
+
+That makes the EVE-NG host disposable enough to rebuild and predictable enough to share as part of a training or network-emulation workflow.
+
+## Related Modules
+
+- [platform/gcp/platform-vm](../../../modules/platform/gcp/platform-vm)
+- [platform/linux/eve-ng](../../../modules/platform/linux/eve-ng)
+- [platform/linux/eve-ng-healthcheck](../../../modules/platform/linux/eve-ng-healthcheck)
+
+## On-Prem Alternative
+
+If you run Proxmox, the sibling [onprem/eve-ng@v1](../../onprem/eve-ng@v1) blueprint builds EVE-NG from a Proxmox template-image and VM provisioning chain.

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -1,0 +1,123 @@
+# On-Prem EVE-NG Platform Stack
+
+Build a rebuildable EVE-NG lab host on Proxmox instead of hand-maintaining a long-lived VM.
+
+This blueprint consumes the shared on-prem SDN and NetBox authority, builds a verified Ubuntu Jammy template image, provisions an EVE-NG VM from that template, configures EVE-NG, and runs a health check so the host proves it is reachable.
+
+Use this when you want the lab platform itself to be reproducible, not just the topologies that run inside EVE-NG.
+
+## What This Delivers
+
+- a Proxmox-hosted EVE-NG VM
+- an Ubuntu 22.04 template image built through `core/onprem/template-image`
+- post-build template smoke validation before the VM consumes the image
+- IPAM-first VM provisioning through `platform/onprem/platform-vm`
+- EVE-NG installation and configuration through `platform/linux/eve-ng`
+- a basic EVE-NG health check through `platform/linux/eve-ng-healthcheck`
+- structured run records for each module step
+
+## Execution Chain
+
+```text
+core/onprem/template-image
+  -> platform/onprem/platform-vm
+  -> platform/linux/eve-ng
+  -> platform/linux/eve-ng-healthcheck
+```
+
+The blueprint file is [blueprint.yml](blueprint.yml).
+
+## Documentation
+
+- [Deploy EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
+- [Reusable EVE-NG Lab Foundation reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/)
+
+## Prerequisites
+
+This is a day-1 on-prem blueprint. It assumes the platform foundation already exists:
+
+- Proxmox access is configured for HybridOps.
+- The shared Proxmox SDN authority is ready.
+- NetBox is available as IPAM and inventory authority.
+- The `vnetmgmt` bridge exists in the SDN authority state.
+- EVE-NG secrets are seeded for the target environment.
+
+Seed the EVE-NG secrets before deployment:
+
+```bash
+hyops secrets ensure --env dev EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
+```
+
+## Usage
+
+Validate the blueprint:
+
+```bash
+hyops blueprint validate \
+  --ref onprem/eve-ng@v1 \
+  --blueprints-root blueprints
+```
+
+Run preflight:
+
+```bash
+hyops blueprint preflight \
+  --env dev \
+  --ref onprem/eve-ng@v1 \
+  --blueprints-root blueprints
+```
+
+Deploy:
+
+```bash
+hyops blueprint deploy \
+  --env dev \
+  --ref onprem/eve-ng@v1 \
+  --blueprints-root blueprints \
+  --execute
+```
+
+## Default Shape
+
+The shipped blueprint provisions one VM:
+
+- logical name: `eve-ng-01`
+- role: `eve-ng`
+- CPU: `8` cores
+- memory: `32768` MB
+- disk: `256` GB
+- network: `vnetmgmt`
+- SSH user: `opsadmin`
+
+The VM consumes the template state from:
+
+```text
+core/onprem/template-image#template_image_ubuntu_22_04
+```
+
+Addressing is IPAM-driven. The VM module reads NetBox and the shared SDN authority instead of hardcoding an address into the blueprint.
+
+## Why This Exists
+
+EVE-NG is often treated as a manually built lab box: install it once, patch it carefully, and hope nobody needs to recreate it from scratch.
+
+This blueprint turns that host into a normal platform outcome:
+
+- the base image is built from a repeatable definition
+- the template is smoke-checked before use
+- the VM is provisioned from state, not from a remembered VMID
+- EVE-NG configuration is a module step, not a manual shell session
+- the final health check produces evidence that the lab host is reachable
+
+That makes the lab host disposable enough to rebuild and predictable enough to use as part of a wider training or network-emulation platform.
+
+## Related Modules
+
+- [core/onprem/template-image](../../../modules/core/onprem/template-image)
+- [platform/onprem/platform-vm](../../../modules/platform/onprem/platform-vm)
+- [platform/linux/eve-ng](../../../modules/platform/linux/eve-ng)
+- [platform/linux/eve-ng-healthcheck](../../../modules/platform/linux/eve-ng-healthcheck)
+
+## Cloud Alternative
+
+If you do not have Proxmox, the sibling [gcp/eve-ng@v1](../../gcp/eve-ng@v1) blueprint provisions a private nested-virtualization-capable GCP VM, configures EVE-NG over IAP, and runs the same health-check pattern.


### PR DESCRIPTION
## Summary
- Add a GCP EVE-NG blueprint README with outcome, prerequisites, usage, docs links, and related modules
- Add an on-prem EVE-NG blueprint README with the Proxmox/template-image execution chain and cloud alternative
- Link both README pages to the EVE-NG blueprint runbook and reference scenario

## Validation
- `./bin/hyops blueprint validate --ref gcp/eve-ng@v1 --blueprints-root blueprints`
- `./bin/hyops blueprint validate --ref onprem/eve-ng@v1 --blueprints-root blueprints`