### PR TITLE
chore: add contributor templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,59 @@
+name: Runtime or module defect
+description: Report a reproducible problem in HybridOps Core.
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include credentials, tokens, private addresses, customer data, or unredacted run records.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI or runtime
+        - Module or blueprint
+        - Driver or pack
+        - Installer or setup
+        - CI or release bundle
+        - Documentation or example
+    validations:
+      required: true
+  - type: input
+    id: reference
+    attributes:
+      label: Relevant reference
+      description: Module, blueprint, command, file, or release version involved.
+      placeholder: platform/onprem/netbox, onprem/rke2@v1, hyops apply, v0.1.0
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behaviour
+      description: Include the exact error or result, with sensitive data removed.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run ...
+        2. Provide ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, provider or platform version, and relevant tool versions.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: mailto:security@hybridops.tech
+    about: Report suspected vulnerabilities privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,48 @@
+name: Focused improvement
+description: Propose a bounded improvement to HybridOps Core.
+title: "[improvement] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Direct pull requests are welcome for contained improvements. Use this form when the change needs agreement before implementation.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI or runtime
+        - Module or blueprint
+        - Driver or pack
+        - Preflight, probe, or run record
+        - Installer, CI, or release bundle
+        - Documentation or example
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the operator or contributor problem this would solve.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Keep the proposal bounded. Link related modules, blueprints, or documents where useful.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What should be demonstrably true when the change is complete?
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I can work on a pull request for this change.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What problem does this change solve? -->
+
+## Validation
+
+<!-- List the checks or commands you ran. -->
+
+## Scope
+
+- [ ] This pull request is focused on one change.
+- [ ] I have not included credentials, tokens, private addresses, or customer data.
+- [ ] I updated documentation, examples, or tests where the change needs them.


### PR DESCRIPTION
## Summary

- add a pull request template and a private security-report contact
- add structured defect and focused-improvement issue forms for Core
- route reports to the existing `bug` and `enhancement` labels

## Why

Core now welcomes direct contributions. These forms collect the practical context needed to review defects and larger proposals without making small pull requests harder to open.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" bash tools/ci/check-yaml.sh`
- issue-form YAML structure check with PyYAML
- `git diff --check`
