### PR TITLE
Add Core question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,46 @@
+name: Usage question or documentation clarification
+description: Ask a focused question about Core usage, docs, modules, blueprints, or safe evaluation.
+title: "[question] "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for focused questions and documentation clarification. Do not include credentials, tokens, private addresses, customer data, or unredacted run records.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI or runtime
+        - Module or blueprint
+        - Driver or pack
+        - Preflight, probe, or run record
+        - Installer, CI, or release bundle
+        - Documentation or example
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Ask the specific thing you need clarified.
+    validations:
+      required: true
+  - type: input
+    id: reference
+    attributes:
+      label: Relevant reference
+      description: Module, blueprint, command, docs path, or release version involved.
+      placeholder: README.md, blueprints/README.md, hyops apply, onprem/rke2@v1
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Add enough context to make the question answerable. Say if this is based on docs review rather than a command you ran.
+  - type: textarea
+    id: checked
+    attributes:
+      label: What you checked
+      description: Link the README section, docs page, issue, command output, or file you already reviewed.


### PR DESCRIPTION
## Summary

Adds a Core issue form for usage questions and documentation clarification. This keeps quick clarification cases out of the bug form, where required expected/observed/reproduce fields do not fit.

Closes #9

## Validation

- Parsed all issue template YAML files with PyYAML.
- Ran `git diff --check` for the new template.

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.