### PR TITLE
Add macOS installer support

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -65,7 +65,10 @@ jobs:
         run: bash tools/ci/check-ruff.sh
 
   install-quality:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,6 +66,7 @@ jobs:
 
   install-quality:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/hyops/preflight/command.py
+++ b/hyops/preflight/command.py
@@ -165,6 +165,7 @@ def run(ns) -> int:
                 command_label="hyops preflight",
             )
         paths = resolve_runtime_paths(ns.root, getattr(ns, "env", None))
+        ensure_layout(paths)
     except Exception as e:
         if ns.json:
             print(_json_dumps({"ok": False, "error": str(e)}))

--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -88,6 +88,8 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
     # Aliases (operator-friendly)
     _add(ssp, "config-mgmt", "Alias for: ansible.", parents=[common])
     _add(ssp, "config-management", "Alias for: ansible.", parents=[common])
+    _add(ssp, "azure", "Alias for: cloud-azure.", parents=[common])
+    _add(ssp, "gcp", "Alias for: cloud-gcp.", parents=[common])
 
     p.set_defaults(_handler=run)
 
@@ -140,6 +142,10 @@ def _find_core_root(ns_root: str | None) -> Path | None:
 def _script_for(action: str) -> str | None:
     if action in ("config-mgmt", "config-management"):
         action = "ansible"
+    elif action == "azure":
+        action = "cloud-azure"
+    elif action == "gcp":
+        action = "cloud-gcp"
 
     mapping = {
         "base": "setup-base.sh",
@@ -192,7 +198,13 @@ def run(ns) -> int:
     if action == "check":
         return _run_check()
 
-    canonical_action = "ansible" if action in ("config-mgmt", "config-management") else action
+    aliases = {
+        "config-mgmt": "ansible",
+        "config-management": "ansible",
+        "azure": "cloud-azure",
+        "gcp": "cloud-gcp",
+    }
+    canonical_action = aliases.get(action, action)
 
     runtime_root: Path | None = None
     runtime_root_arg = getattr(ns, "runtime_root", None)

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ Defaults:
   --prefix           ~/.hybridops/core
   --bin-dir          ~/.local/bin
   --system-link      enabled (installs /usr/local/bin/hyops; requires sudo)
-  --setup-all        auto (runs when --system-link is enabled; use --no-setup-all to skip)
+  --setup-all        auto (Linux: runs when --system-link is enabled; macOS: skipped)
 USAGE
 }
 

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -36,7 +36,6 @@ chmod 0755 "${ROOT_SHARED}" "${ROOT_HOME}" "${ROOT_PREFIX}" "${ROOT_BIN_DIR}" "$
 
 common_env=(
   PATH="${PATH}:/usr/bin:/bin"
-  HYOPS_INSTALL_USE_SYSTEM_DEPS=true
 )
 
 env HOME="${USER_HOME}" "${common_env[@]}" \

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -41,11 +41,18 @@ common_env=(
 env HOME="${USER_HOME}" "${common_env[@]}" \
   bash "${HYOPS_REPO_ROOT}/install.sh" --force --no-system-link --no-setup-all >/dev/null
 
+if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+  grep -Fqx 'export PATH="$HOME/.local/bin:$PATH"' "${USER_HOME}/.zprofile"
+fi
+
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" --help >/dev/null
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup ansible --help >/dev/null
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup ansible --runtime-root "${USER_HOME}/.hybridops" --dry-run >/dev/null
 env HOME="${USER_HOME}" "${common_env[@]}" \
   bash "${HYOPS_REPO_ROOT}/install.sh" --force --no-system-link --no-setup-all >/dev/null
+if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+  [[ "$(grep -Fxc 'export PATH="$HOME/.local/bin:$PATH"' "${USER_HOME}/.zprofile")" -eq 1 ]]
+fi
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" show --help >/dev/null
 
 if sudo -n true >/dev/null 2>&1; then

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -35,7 +35,7 @@ mkdir -p "${USER_HOME}" "${ROOT_SHARED}" "${ROOT_HOME}" "${ROOT_PREFIX}" "${ROOT
 chmod 0755 "${ROOT_SHARED}" "${ROOT_HOME}" "${ROOT_PREFIX}" "${ROOT_BIN_DIR}" "${ROOT_USER_BIN}" "${ROOT_CACHE_DIR}" "${ROOT_FAKE_APP}" "${ROOT_FAKE_APP}/tools" "${ROOT_FAKE_APP}/tools/setup"
 
 common_env=(
-  PATH="/usr/bin:/bin:${PATH}"
+  PATH="${PATH}:/usr/bin:/bin"
   HYOPS_INSTALL_USE_SYSTEM_DEPS=true
 )
 

--- a/tools/install/lib/common.sh
+++ b/tools/install/lib/common.sh
@@ -22,9 +22,11 @@ hyops_install_set_blueprint_payload_read_only() {
 
 hyops_install_abs_path() {
   local raw_path="$1"
-  python3 - <<PY
+  python3 - "${raw_path}" <<'PY'
 import os
-print(os.path.abspath(os.path.expanduser(${raw_path@Q})))
+import sys
+
+print(os.path.abspath(os.path.expanduser(sys.argv[1])))
 PY
 }
 

--- a/tools/install/lib/installer.sh
+++ b/tools/install/lib/installer.sh
@@ -46,7 +46,12 @@ hyops_install_run() {
   echo "[install] bin_dir=${BIN_DIR}"
 
   if [[ "${SETUP_ALL}" == "auto" ]]; then
-    if [[ "${SYSTEM_LINK}" == "true" ]]; then
+    if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+      # Homebrew refuses to run as root. Keep the CLI install smooth and leave
+      # prerequisite installation as an explicit, user-owned setup step.
+      SETUP_ALL="false"
+      echo "[install] macOS detected; automatic setup-all is disabled"
+    elif [[ "${SYSTEM_LINK}" == "true" ]]; then
       SETUP_ALL="true"
     else
       SETUP_ALL="false"

--- a/tools/install/lib/installer.sh
+++ b/tools/install/lib/installer.sh
@@ -83,13 +83,27 @@ hyops_install_run() {
 
   hyops_install_install_user_wrapper
   hyops_install_install_system_link
+  hyops_install_configure_macos_user_path
+  hyops_install_verify_command
   hyops_install_run_setup_all
 
   echo "[install] OK"
-  echo "Try:"
-  echo "  hyops --help"
-  echo "  hyops preflight"
-  if [[ -n "${WRAPPER:-}" ]]; then
+  local resolved_hyops=""
+  resolved_hyops="$(command -v hyops 2>/dev/null || true)"
+  if [[ "${resolved_hyops}" == "${SYSTEM_LINK_PATH}" || ( -n "${WRAPPER:-}" && "${resolved_hyops}" == "${WRAPPER}" ) ]]; then
+    echo "Next:"
+    echo "  hyops --help"
+    if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+      echo "  hyops setup base"
+    else
+      echo "  hyops preflight"
+    fi
+  elif [[ -n "${PATH_PROFILE:-}" ]]; then
+    echo "Open a new terminal, then run:"
+    echo "  hyops --help"
+    echo "  hyops setup base"
+  else
+    echo "Run:"
     echo "  ${WRAPPER} --help"
   fi
 }

--- a/tools/install/lib/python_env.sh
+++ b/tools/install/lib/python_env.sh
@@ -38,11 +38,15 @@ EOS
     fi
     echo "[install] installing from local wheelhouse"
     if [[ "${USE_SYSTEM_DEPS}" == "true" ]]; then
-      "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" --no-deps hybridops-core >/dev/null
+      if "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" --no-deps hybridops-core >/dev/null; then
+        return 0
+      fi
     else
-      "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" hybridops-core >/dev/null
+      if "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" hybridops-core >/dev/null; then
+        return 0
+      fi
     fi
-    return 0
+    echo "WARN: local wheelhouse is incompatible with this Python or platform; retrying with the package index" >&2
   fi
 
   if [[ "${USE_SYSTEM_DEPS}" == "true" ]]; then

--- a/tools/install/lib/python_env.sh
+++ b/tools/install/lib/python_env.sh
@@ -37,16 +37,22 @@ EOS
       exit 2
     fi
     echo "[install] installing from local wheelhouse"
+    local wheelhouse_error="${VENV_DIR}/wheelhouse-install.err"
     if [[ "${USE_SYSTEM_DEPS}" == "true" ]]; then
-      if "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" --no-deps hybridops-core >/dev/null; then
+      if "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" --no-deps hybridops-core \
+        >/dev/null 2>"${wheelhouse_error}"; then
+        rm -f "${wheelhouse_error}"
         return 0
       fi
     else
-      if "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" hybridops-core >/dev/null; then
+      if "${VENV_DIR}/bin/python3" -m pip install --no-index --find-links "${wheelhouse}" hybridops-core \
+        >/dev/null 2>"${wheelhouse_error}"; then
+        rm -f "${wheelhouse_error}"
         return 0
       fi
     fi
-    echo "WARN: local wheelhouse is incompatible with this Python or platform; retrying with the package index" >&2
+    rm -f "${wheelhouse_error}"
+    echo "[install] bundled dependencies are not available for this platform; using the package index"
   fi
 
   if [[ "${USE_SYSTEM_DEPS}" == "true" ]]; then

--- a/tools/install/lib/wrapper.sh
+++ b/tools/install/lib/wrapper.sh
@@ -70,3 +70,57 @@ exec "${VENV_DIR}/bin/hyops" "\$@"
 EOS
   sudo chmod 0755 "${SYSTEM_LINK_PATH}"
 }
+
+hyops_install_path_contains_dir() {
+  case ":${PATH}:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+hyops_install_configure_macos_user_path() {
+  PATH_PROFILE=""
+  [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]] || return 0
+  [[ -n "${WRAPPER:-}" ]] || return 0
+
+  if [[ "${SYSTEM_LINK}" == "true" ]] && hyops_install_path_contains_dir "${SYSTEM_LINK_DIR}"; then
+    return 0
+  fi
+  if hyops_install_path_contains_dir "${BIN_DIR}"; then
+    return 0
+  fi
+
+  if [[ "${BIN_DIR}" != "${HOME}/.local/bin" ]]; then
+    echo "WARN: ${BIN_DIR} is not on PATH; add it to your shell profile" >&2
+    return 0
+  fi
+
+  PATH_PROFILE="${HOME}/.zprofile"
+  local path_line='export PATH="$HOME/.local/bin:$PATH"'
+  if [[ ! -f "${PATH_PROFILE}" ]] || ! grep -Fqx "${path_line}" "${PATH_PROFILE}"; then
+    {
+      echo ""
+      echo "# HybridOps CLI"
+      echo "${path_line}"
+    } >>"${PATH_PROFILE}"
+    echo "[install] added ${BIN_DIR} to ${PATH_PROFILE}"
+  fi
+}
+
+hyops_install_verify_command() {
+  local installed_command=""
+  if [[ "${SYSTEM_LINK}" == "true" && -x "${SYSTEM_LINK_PATH}" ]]; then
+    installed_command="${SYSTEM_LINK_PATH}"
+  elif [[ -n "${WRAPPER:-}" && -x "${WRAPPER}" ]]; then
+    installed_command="${WRAPPER}"
+  fi
+
+  [[ -n "${installed_command}" ]] || {
+    echo "ERR: hyops command wrapper was not installed" >&2
+    exit 2
+  }
+  "${installed_command}" --help >/dev/null || {
+    echo "ERR: installed hyops command failed its verification check" >&2
+    exit 2
+  }
+}

--- a/tools/setup/README.md
+++ b/tools/setup/README.md
@@ -19,7 +19,13 @@ hyops setup all --sudo
 
 ## Notes
 
-- System installers require sudo.
+- On macOS, install [Homebrew](https://brew.sh/) first, then run setup commands
+  without `--sudo` (`hyops setup base`, `hyops setup gcp`, and
+  `hyops setup ansible`). Linux setup commands retain their existing `--sudo`
+  behavior.
+- `hyops setup gcp` and `hyops setup azure` are operator-friendly aliases for
+  `cloud-gcp` and `cloud-azure`.
+- Linux system installers require sudo.
 - `hyops setup cloud-gcp --sudo` installs both `gcloud` and `gke-gcloud-auth-plugin`; it also repairs older machines where `gcloud` is already present but the GKE auth plugin is missing.
 - Ansible Galaxy dependencies are installed into the selected runtime root:
   - `<runtime_root>/state/ansible/galaxy_collections`

--- a/tools/setup/setup-all.sh
+++ b/tools/setup/setup-all.sh
@@ -31,6 +31,18 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+  if [[ "${EUID}" -eq 0 ]]; then
+    echo "ERR: macOS setup-all must run as your user (omit --sudo)" >&2
+    exit 2
+  fi
+  bash "${ROOT}/setup-base.sh"
+  bash "${ROOT}/setup-cloud-azure.sh"
+  bash "${ROOT}/setup-cloud-gcp.sh"
+  bash "${ROOT}/setup-ansible.sh" "${FORCE_ARGS[@]}" "${HYBRIDOPS_ARGS[@]}"
+  exit 0
+fi
+
 if [[ "${EUID}" -ne 0 ]]; then
   exec sudo -E bash "$0" "$@"
 fi

--- a/tools/setup/setup-base-macos.sh
+++ b/tools/setup/setup-base-macos.sh
@@ -13,5 +13,14 @@ command -v brew >/dev/null 2>&1 || {
 }
 
 echo "[setup] macOS Homebrew base prerequisites"
-brew install python terraform terragrunt packer kubectl ansible pipx
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform hashicorp/tap/packer
+brew install python terragrunt kubectl ansible pipx
+
+for required_cmd in python3 terraform terragrunt packer kubectl ansible-playbook pipx; do
+  command -v "${required_cmd}" >/dev/null 2>&1 || {
+    echo "ERR: ${required_cmd} was installed but is not available on PATH" >&2
+    exit 1
+  }
+done
 echo "[setup] macOS base prerequisites installed"

--- a/tools/setup/setup-base-macos.sh
+++ b/tools/setup/setup-base-macos.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# purpose: Install base HybridOps prerequisites on macOS with Homebrew.
+set -euo pipefail
+
+if [[ "${EUID}" -eq 0 ]]; then
+  echo "ERR: Homebrew setup must run as your macOS user (omit --sudo)" >&2
+  exit 2
+fi
+
+command -v brew >/dev/null 2>&1 || {
+  echo "ERR: Homebrew is required. Install it from https://brew.sh, then rerun: hyops setup base" >&2
+  exit 2
+}
+
+echo "[setup] macOS Homebrew base prerequisites"
+brew install python terraform terragrunt packer kubectl ansible pipx
+echo "[setup] macOS base prerequisites installed"

--- a/tools/setup/setup-base.sh
+++ b/tools/setup/setup-base.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+  exec bash "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/setup-base-macos.sh" "$@"
+fi
+
 [[ "${EUID}" -eq 0 ]] || { echo "ERR: requires root (use: hyops setup base --sudo)"; exit 2; }
 
 export PATH="/usr/local/bin:/usr/local/sbin:${PATH}"

--- a/tools/setup/setup-cloud-azure-macos.sh
+++ b/tools/setup/setup-cloud-azure-macos.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# purpose: Install Azure CLI prerequisites on macOS with Homebrew.
+set -euo pipefail
+
+if [[ "${EUID}" -eq 0 ]]; then
+  echo "ERR: Homebrew setup must run as your macOS user (omit --sudo)" >&2
+  exit 2
+fi
+
+command -v brew >/dev/null 2>&1 || {
+  echo "ERR: Homebrew is required. Install it from https://brew.sh, then rerun: hyops setup azure" >&2
+  exit 2
+}
+
+brew install azure-cli
+command -v az >/dev/null 2>&1 || { echo "ERR: Azure CLI install failed" >&2; exit 1; }
+echo "[setup] Azure CLI installed"

--- a/tools/setup/setup-cloud-azure.sh
+++ b/tools/setup/setup-cloud-azure.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+  exec bash "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/setup-cloud-azure-macos.sh" "$@"
+fi
+
 command -v az >/dev/null 2>&1 && { echo "[setup] azure-cli present"; exit 0; }
 
 [[ "${EUID}" -eq 0 ]] || { echo "ERR: requires root (use: hyops setup cloud-azure --sudo)"; exit 2; }

--- a/tools/setup/setup-cloud-gcp-macos.sh
+++ b/tools/setup/setup-cloud-gcp-macos.sh
@@ -26,5 +26,24 @@ if ! command -v gke-gcloud-auth-plugin >/dev/null 2>&1; then
   }
 fi
 
+if ! command -v gke-gcloud-auth-plugin >/dev/null 2>&1; then
+  sdk_root="$(gcloud info --format='value(installation.sdk_root)' 2>/dev/null || true)"
+  plugin_path="${sdk_root}/bin/gke-gcloud-auth-plugin"
+  brew_bin="$(brew --prefix)/bin"
+  if [[ -x "${plugin_path}" ]]; then
+    mkdir -p "${brew_bin}"
+    ln -sf "${plugin_path}" "${brew_bin}/gke-gcloud-auth-plugin"
+  fi
+fi
+
+command -v gke-gcloud-auth-plugin >/dev/null 2>&1 || {
+  echo "ERR: gke-gcloud-auth-plugin was installed but is not available on PATH" >&2
+  exit 2
+}
+gke-gcloud-auth-plugin --version >/dev/null 2>&1 || {
+  echo "ERR: gke-gcloud-auth-plugin failed its version check" >&2
+  exit 2
+}
+
 echo "[setup] gcloud installed"
 echo "[setup] gke-gcloud-auth-plugin installed"

--- a/tools/setup/setup-cloud-gcp-macos.sh
+++ b/tools/setup/setup-cloud-gcp-macos.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# purpose: Install Google Cloud CLI prerequisites on macOS with Homebrew.
+set -euo pipefail
+
+if [[ "${EUID}" -eq 0 ]]; then
+  echo "ERR: Homebrew setup must run as your macOS user (omit --sudo)" >&2
+  exit 2
+fi
+
+command -v brew >/dev/null 2>&1 || {
+  echo "ERR: Homebrew is required. Install it from https://brew.sh, then rerun: hyops setup gcp" >&2
+  exit 2
+}
+
+brew install --cask google-cloud-sdk
+
+command -v gcloud >/dev/null 2>&1 || {
+  echo "ERR: gcloud was installed but is not on PATH; start a new shell and retry" >&2
+  exit 2
+}
+
+if ! command -v gke-gcloud-auth-plugin >/dev/null 2>&1; then
+  gcloud components install gke-gcloud-auth-plugin --quiet || {
+    echo "ERR: gke-gcloud-auth-plugin is unavailable; follow the Google Cloud CLI macOS component instructions" >&2
+    exit 2
+  }
+fi
+
+echo "[setup] gcloud installed"
+echo "[setup] gke-gcloud-auth-plugin installed"

--- a/tools/setup/setup-cloud-gcp.sh
+++ b/tools/setup/setup-cloud-gcp.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+  exec bash "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/setup-cloud-gcp-macos.sh" "$@"
+fi
+
 have_gcloud=false
 have_gke_auth_plugin=false
 


### PR DESCRIPTION
Closes #65

## What changed

- add Darwin dispatch for the installer and prerequisite setup scripts
- install base, Google Cloud, and Azure tooling through Homebrew on macOS
- keep the existing Linux apt, dnf, and yum paths unchanged
- add `hyops setup gcp` and `hyops setup azure` aliases
- run the installer smoke test on both Ubuntu and macOS

## Why

The CLI is portable, but prerequisite setup assumed a Linux package manager. On macOS the default installer could enter the root-level Linux setup path, while Homebrew must run as the logged-in user.

The installer now skips automatic prerequisite setup on Darwin. Operators can install the CLI normally, then run the required `hyops setup` scopes without sudo.

## Validation

- installer CI passes on Ubuntu and macOS
- release-bundle installation passed on Apple Silicon
- Homebrew base and GCP setup passed
- the GKE authentication plugin is available on `PATH`
- runtime initialization and preflight passed
- the GCP EVE-NG blueprint completed deployment, access, guest-network, and teardown checks from the Mac

Provider deployment changes found during acceptance are tracked separately and are not part of this PR.