### PR TITLE
Document runtime-root retention guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ Every `hyops` command writes a non-secret structured run record:
 ~/.hybridops/logs/init/<target>/<run_id>/
 ```
 
+### Runtime retention and cleanup
+
+The runtime root is local operator state, not repository content. HybridOps does
+not impose a retention period: keep run records while they are needed for
+debugging, audit, or handoff, then remove them according to the operator's own
+retention policy.
+
+For a local review, this command lists files under the default log directory
+that are older than seven days without deleting them:
+
+```bash
+find ~/.hybridops/logs -type f -mtime +7 -print
+```
+
+Review the output before removing anything. Do not treat the whole runtime root
+as disposable: `config/`, `credentials/`, `vault/`, `meta/`, and `state/` may
+contain active or sensitive environment data. Never commit runtime logs,
+credentials, vault material, private addresses, or unredacted evidence.
+
 ## Requirements
 
 - Python ≥ 3.11

--- a/hyops/runtime/README.md
+++ b/hyops/runtime/README.md
@@ -23,6 +23,31 @@ Runtime root is operator state (not repo state). Commands MUST NOT infer repo ro
 - Module: `<root>/logs/module/<module_id>/<run_id>/`
 - Driver: `<root>/logs/driver/<driver_id>/<run_id>/`
 
+## Retention and cleanup
+
+The runtime root belongs to the operator. HybridOps does not delete run records
+on a fixed schedule, because retention needs differ between local evaluation,
+debugging, audit, and operational handoff.
+
+Files under `<root>/logs/` are run evidence and may be reviewed for removal when
+they are no longer needed. The other runtime directories are not routine cleanup
+targets:
+
+- `config/`, `credentials/`, and `vault/` may contain environment configuration
+  or secret material.
+- `meta/` may contain readiness and runtime metadata.
+- `state/` may contain active environment state.
+
+For the default runtime root, list log files older than seven days with:
+
+```bash
+find ~/.hybridops/logs -type f -mtime +7 -print
+```
+
+This is a review command, not a retention policy or deletion command. Check the
+output before removing files, preserve evidence required for audit or debugging,
+and never commit runtime logs or sensitive runtime state to the repository.
+
 ## Readiness
 
 - `<root>/meta/<target>.ready.json`


### PR DESCRIPTION
## Summary

- add runtime-root retention guidance to the main README
- distinguish old run evidence from active runtime state
- add a preview-only example for reviewing old local logs

## Validation

- checked Markdown rendering
- no code changes

Closes #24