### PR TITLE
Explain the blueprint inspection boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ pip install .
 Inspect a shipped blueprint before configuring a provider:
 
 ```bash
-hyops blueprint validate --ref gcp/eve-ng@v1
-hyops blueprint plan --ref gcp/eve-ng@v1
+hyops blueprint validate --ref onprem/authoritative-foundation@v1
+hyops blueprint plan --ref onprem/authoritative-foundation@v1
 ```
 
 `validate` checks the blueprint manifest. `plan` validates the manifest and
 prints the ordered steps. Neither command selects a runtime, invokes a driver,
-or contacts the provider. See the [GCP EVE-NG blueprint](blueprints/gcp/eve-ng@v1/README.md)
+or contacts the provider. See the
+[authoritative foundation blueprint](blueprints/onprem/authoritative-foundation@v1/README.md)
 for the complete operating sequence.
 
 Initialise a target environment:
@@ -76,7 +77,7 @@ credential requirements, state, and driver checks. Some module paths may inspect
 live state, but preflight does not deploy resources:
 
 ```bash
-hyops blueprint preflight --env dev --ref gcp/eve-ng@v1
+hyops blueprint preflight --env dev --ref onprem/authoritative-foundation@v1
 ```
 
 Run a module:
@@ -89,7 +90,7 @@ hyops apply --env dev --module org/gcp/project-factory
 Run a full blueprint (ordered multi-step deployment):
 
 ```bash
-hyops blueprint deploy --env dev --ref onprem/rke2@v1 --execute
+hyops blueprint deploy --env dev --ref onprem/authoritative-foundation@v1 --execute
 ```
 
 The runtime root defaults to `~/.hybridops`. Override with `--root <path>` or `$HYOPS_RUNTIME_ROOT`.

--- a/README.md
+++ b/README.md
@@ -52,11 +52,31 @@ python3 -m venv .venv && . .venv/bin/activate
 pip install .
 ```
 
+Inspect a shipped blueprint before configuring a provider:
+
+```bash
+hyops blueprint validate --ref gcp/eve-ng@v1
+hyops blueprint plan --ref gcp/eve-ng@v1
+```
+
+`validate` checks the blueprint manifest. `plan` validates the manifest and
+prints the ordered steps. Neither command selects a runtime, invokes a driver,
+or contacts the provider. See the [GCP EVE-NG blueprint](blueprints/gcp/eve-ng@v1/README.md)
+for the complete operating sequence.
+
 Initialise a target environment:
 
 ```bash
 hyops init proxmox --env dev
 hyops init gcp --env dev
+```
+
+After initialization, preflight resolves the environment, runtime, contracts,
+credential requirements, state, and driver checks. Some module paths may inspect
+live state, but preflight does not deploy resources:
+
+```bash
+hyops blueprint preflight --env dev --ref gcp/eve-ng@v1
 ```
 
 Run a module:

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -71,16 +71,40 @@ Each shipped blueprint directory contains a `blueprint.yml` contract and a local
 | [`dr/postgresql-cloudsql-failback-onprem@v1`](dr/postgresql-cloudsql-failback-onprem@v1) | Explicit managed-cloud failback gate and DNS cutback. |
 
 ## CLI Usage
-- Validate:
-  - `hyops blueprint validate --ref onprem/bootstrap-netbox@v1 --blueprints-root blueprints`
-- Preflight:
-  - `hyops blueprint preflight --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints --root /tmp/hyops-runtime`
-- Plan:
-  - `hyops blueprint plan --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints`
-- Deploy (execute):
-  - `hyops blueprint deploy --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints --execute`
-- Deploy with explicit runtime root:
-  - `hyops blueprint deploy --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints --execute --root /tmp/hyops-runtime`
+
+Inspect a blueprint locally before configuring a runtime or provider:
+
+```bash
+hyops blueprint validate --ref gcp/eve-ng@v1 --blueprints-root blueprints
+hyops blueprint plan --ref gcp/eve-ng@v1 --blueprints-root blueprints
+```
+
+`validate` checks the manifest. `plan` validates it and prints the ordered
+steps. Neither command selects a runtime, invokes a driver, or contacts the
+provider.
+
+Preflight is the next boundary. It resolves the runtime, module contracts,
+credential requirements, state, and driver checks. Some paths may inspect live
+state, but preflight does not deploy resources:
+
+```bash
+hyops blueprint preflight --env dev \
+  --ref gcp/eve-ng@v1 \
+  --blueprints-root blueprints
+```
+
+Execution begins only when `deploy` is given `--execute`:
+
+```bash
+hyops blueprint deploy --env dev \
+  --ref gcp/eve-ng@v1 \
+  --blueprints-root blueprints \
+  --execute
+```
+
+Use `--root /tmp/hyops-runtime` when an explicit runtime root is required. The
+[GCP EVE-NG blueprint](gcp/eve-ng@v1/README.md) contains the complete operating
+sequence.
 
 ## Shipped Blueprint Boundary
 


### PR DESCRIPTION
## Summary

- add the inspection-only blueprint steps to the main Quick start
- distinguish local validation and planning from runtime preflight
- identify `deploy --execute` as the execution boundary
- link the existing GCP EVE-NG blueprint README

## Validation

- checked commands against the Core CLI implementation
- checked Markdown links and rendered code blocks

Closes #33 