### PR TITLE
Capture install, setup, and preflight run records

### DIFF
--- a/hyops/cli.py
+++ b/hyops/cli.py
@@ -10,6 +10,9 @@ import os
 import sys
 
 from hyops.runtime.exitcodes import CANCELLED
+from hyops.runtime.command_evidence import PythonCommandEvidence, command_evidence_dir
+from hyops.runtime.layout import ensure_layout
+from hyops.runtime.paths import resolve_runtime_paths
 from hyops.init.command import add_init_subparser
 from hyops.inventory.command import add_inventory_subparser
 from hyops.module.command import add_module_subparser
@@ -134,6 +137,13 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     try:
+        if ns.cmd == "preflight":
+            paths = resolve_runtime_paths(getattr(ns, "root", None), getattr(ns, "env", None))
+            ensure_layout(paths)
+            evidence_dir = command_evidence_dir(paths.logs_dir, "preflight")
+            with PythonCommandEvidence(evidence_dir, command="preflight", argv=argv) as evidence:
+                evidence.exit_code = int(ns._handler(ns))
+                return evidence.exit_code
         return int(ns._handler(ns))
     except KeyboardInterrupt:
         print("Cancelled by user.", file=sys.stderr)

--- a/hyops/runtime/command_evidence.py
+++ b/hyops/runtime/command_evidence.py
@@ -1,0 +1,155 @@
+"""Secure, streaming evidence capture for operator-facing commands."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import platform
+import subprocess
+import sys
+from typing import IO, Mapping, Sequence
+
+from hyops.runtime.evidence import init_evidence_dir, new_run_id
+from hyops.runtime.redact import redact_text
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def command_evidence_dir(logs_dir: Path, command: str, scope: str = "") -> Path:
+    root = logs_dir / command
+    if scope:
+        root /= scope
+    evidence_dir = init_evidence_dir(root, new_run_id(command.replace("-", "_")))
+    evidence_dir.chmod(0o700)
+    return evidence_dir
+
+
+def write_result(
+    evidence_dir: Path,
+    *,
+    command: str,
+    argv: Sequence[str],
+    started_at: str,
+    exit_code: int,
+) -> None:
+    payload = {
+        "command": command,
+        "argv": [redact_text(str(token)) for token in argv],
+        "started_at": started_at,
+        "finished_at": _utc_now(),
+        "exit_code": int(exit_code),
+        "status": "ok" if int(exit_code) == 0 else "failed",
+        "platform": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+    }
+    path = evidence_dir / "result.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+def run_streamed(
+    argv: Sequence[str],
+    *,
+    env: Mapping[str, str],
+    evidence_dir: Path,
+    command: str,
+) -> int:
+    started_at = _utc_now()
+    output_path = evidence_dir / "output.log"
+    with output_path.open("w", encoding="utf-8") as output:
+        output_path.chmod(0o600)
+        process = subprocess.Popen(
+            list(argv),
+            env=dict(env),
+            stdin=None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            errors="replace",
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for raw_line in process.stdout:
+            safe_line = redact_text(raw_line)
+            sys.stdout.write(safe_line)
+            sys.stdout.flush()
+            output.write(safe_line)
+            output.flush()
+        exit_code = int(process.wait())
+    write_result(
+        evidence_dir,
+        command=command,
+        argv=argv,
+        started_at=started_at,
+        exit_code=exit_code,
+    )
+    print(f"run record: {evidence_dir}")
+    return exit_code
+
+
+class _TeeStream:
+    def __init__(self, terminal: IO[str], output: IO[str]) -> None:
+        self.terminal = terminal
+        self.output = output
+
+    def write(self, text: str) -> int:
+        safe_text = redact_text(text)
+        self.terminal.write(safe_text)
+        self.terminal.flush()
+        self.output.write(safe_text)
+        self.output.flush()
+        return len(text)
+
+    def flush(self) -> None:
+        self.terminal.flush()
+        self.output.flush()
+
+    def isatty(self) -> bool:
+        return self.terminal.isatty()
+
+    def fileno(self) -> int:
+        return self.terminal.fileno()
+
+
+class PythonCommandEvidence(AbstractContextManager["PythonCommandEvidence"]):
+    def __init__(self, evidence_dir: Path, *, command: str, argv: Sequence[str]) -> None:
+        self.evidence_dir = evidence_dir
+        self.command = command
+        self.argv = list(argv)
+        self.started_at = _utc_now()
+        self.exit_code = 1
+        self._output: IO[str] | None = None
+        self._stdout = sys.stdout
+        self._stderr = sys.stderr
+
+    def __enter__(self) -> "PythonCommandEvidence":
+        path = self.evidence_dir / "output.log"
+        self._output = path.open("w", encoding="utf-8")
+        path.chmod(0o600)
+        sys.stdout = _TeeStream(self._stdout, self._output)  # type: ignore[assignment]
+        sys.stderr = _TeeStream(self._stderr, self._output)  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        sys.stdout = self._stdout
+        sys.stderr = self._stderr
+        if self._output is not None:
+            self._output.close()
+        if exc_type is not None and self.exit_code == 0:
+            self.exit_code = 1
+        write_result(
+            self.evidence_dir,
+            command=self.command,
+            argv=self.argv,
+            started_at=self.started_at,
+            exit_code=self.exit_code,
+        )
+        print(f"run record: {self.evidence_dir}")
+        return False

--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 import argparse
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from hyops.runtime.exitcodes import OK, INTERNAL_ERROR, OPERATOR_ERROR
-from hyops.runtime.command_evidence import command_evidence_dir, run_streamed
+from hyops.runtime.command_evidence import PythonCommandEvidence, command_evidence_dir, run_streamed
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
 
@@ -190,10 +191,6 @@ def _run_check() -> int:
 
 def run(ns) -> int:
     action = ns._setup_action
-
-    if action == "check":
-        return _run_check()
-
     canonical_action = "ansible" if action in ("config-mgmt", "config-management") else action
 
     runtime_root: Path | None = None
@@ -204,6 +201,18 @@ def run(ns) -> int:
     force = bool(getattr(ns, "force", False))
     hybridops_source = getattr(ns, "hybridops_source", None)
     hybridops_git_manifest = getattr(ns, "hybridops_git_manifest", None)
+
+    if action == "check":
+        evidence_paths = resolve_runtime_paths(root=runtime_root_arg, env=env_arg)
+        ensure_layout(evidence_paths)
+        evidence_dir = command_evidence_dir(evidence_paths.logs_dir, "setup", canonical_action)
+        with PythonCommandEvidence(
+            evidence_dir,
+            command="setup check",
+            argv=sys.argv[1:],
+        ) as evidence:
+            evidence.exit_code = _run_check()
+            return evidence.exit_code
 
     if canonical_action in ("ansible", "all"):
         if runtime_root_arg and env_arg:

--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -12,6 +12,8 @@ import subprocess
 from pathlib import Path
 
 from hyops.runtime.exitcodes import OK, INTERNAL_ERROR, OPERATOR_ERROR
+from hyops.runtime.command_evidence import command_evidence_dir, run_streamed
+from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
 
 
@@ -256,5 +258,12 @@ def run(ns) -> int:
         argv += ["--hybridops-git-manifest", hybridops_git_manifest]
     if sudo:
         argv = ["sudo", "-E"] + argv
-    rc = subprocess.call(argv, env=env)
-    return int(rc)
+    evidence_paths = resolve_runtime_paths(root=runtime_root_arg, env=env_arg)
+    ensure_layout(evidence_paths)
+    evidence_dir = command_evidence_dir(evidence_paths.logs_dir, "setup", canonical_action)
+    return run_streamed(
+        argv,
+        env=env,
+        evidence_dir=evidence_dir,
+        command=f"setup {canonical_action}",
+    )

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ FORCE="false"
 NO_WRAPPER="false"
 SYSTEM_LINK="true"
 SETUP_ALL="auto"
+INSTALL_ORIGINAL_ARGV=("$@")
 
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
@@ -51,4 +52,23 @@ fi
 
 # shellcheck source=/dev/null
 source "${INSTALL_LIB}"
+
+INSTALL_RUN_ID="install-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+INSTALL_EVIDENCE_DIR="${HOME}/.hybridops/logs/install/${INSTALL_RUN_ID}"
+INSTALL_EVIDENCE_HELPER="${SRC_ROOT}/tools/install/install_evidence.py"
+INSTALL_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+mkdir -p "${INSTALL_EVIDENCE_DIR}"
+chmod 0700 "${INSTALL_EVIDENCE_DIR}"
+
+_hyops_install_record_exit() {
+  local rc="$?"
+  trap - EXIT
+  PYTHONPATH="${SRC_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" python3 "${INSTALL_EVIDENCE_HELPER}" result \
+    "${INSTALL_EVIDENCE_DIR}/result.json" "${INSTALL_STARTED_AT}" "${rc}" "$@" >/dev/null 2>&1 || true
+  echo "run record: ${INSTALL_EVIDENCE_DIR}"
+  exit "${rc}"
+}
+
+trap '_hyops_install_record_exit "${INSTALL_ORIGINAL_ARGV[@]}"' EXIT
+exec > >(PYTHONPATH="${SRC_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" python3 "${INSTALL_EVIDENCE_HELPER}" stream "${INSTALL_EVIDENCE_DIR}/output.log") 2>&1
 hyops_install_run

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -79,6 +79,49 @@ assert stat.S_IMODE((root / "output.log").stat().st_mode) == 0o600
 assert json.loads((root / "result.json").read_text())["exit_code"] == 0
 PY
 
+set +e
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup check >"${WORK_DIR}/setup-check.out" 2>&1
+SETUP_CHECK_RC=$?
+set -e
+SETUP_CHECK_EVIDENCE="$(find "${USER_HOME}/.hybridops/logs/setup/check" -mindepth 1 -maxdepth 1 -type d | sort | tail -n1)"
+python3 - "${SETUP_CHECK_EVIDENCE}" "${SETUP_CHECK_RC}" <<'PY'
+import json
+from pathlib import Path
+import stat
+import sys
+
+root = Path(sys.argv[1])
+expected_rc = int(sys.argv[2])
+assert stat.S_IMODE(root.stat().st_mode) == 0o700
+assert stat.S_IMODE((root / "output.log").stat().st_mode) == 0o600
+result = json.loads((root / "result.json").read_text())
+assert result["exit_code"] == expected_rc
+assert result["status"] == ("ok" if expected_rc == 0 else "failed")
+PY
+
+set +e
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" \
+  preflight --target evidence-target-does-not-exist >"${WORK_DIR}/preflight-failure.out" 2>&1
+PREFLIGHT_FAILURE_RC=$?
+set -e
+[[ "${PREFLIGHT_FAILURE_RC}" -ne 0 ]]
+PREFLIGHT_FAILURE_EVIDENCE="$(find "${USER_HOME}/.hybridops/logs/preflight" -mindepth 1 -maxdepth 1 -type d | sort | tail -n1)"
+python3 - "${PREFLIGHT_FAILURE_EVIDENCE}/result.json" "${PREFLIGHT_FAILURE_RC}" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+result = json.loads(Path(sys.argv[1]).read_text())
+assert result["exit_code"] == int(sys.argv[2])
+assert result["status"] == "failed"
+PY
+
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" \
+  preflight --vault-password-command 'token=evidence-argv-secret' >/dev/null
+PREFLIGHT_ARGV_EVIDENCE="$(find "${USER_HOME}/.hybridops/logs/preflight" -mindepth 1 -maxdepth 1 -type d | sort | tail -n1)"
+! grep -Fq 'evidence-argv-secret' "${PREFLIGHT_ARGV_EVIDENCE}/result.json"
+grep -Fq 'token=***REDACTED***' "${PREFLIGHT_ARGV_EVIDENCE}/result.json"
+
 FAKE_SETUP_ROOT="${WORK_DIR}/fake-setup-core"
 mkdir -p "${FAKE_SETUP_ROOT}/tools/setup"
 cat >"${FAKE_SETUP_ROOT}/tools/setup/setup-base.sh" <<'EOF'

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -45,6 +45,68 @@ env HOME="${USER_HOME}" "${common_env[@]}" \
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" --help >/dev/null
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup ansible --help >/dev/null
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup ansible --runtime-root "${USER_HOME}/.hybridops" --dry-run >/dev/null
+
+INSTALL_EVIDENCE="$(find "${USER_HOME}/.hybridops/logs/install" -mindepth 1 -maxdepth 1 -type d | sort | tail -n1)"
+python3 - "${INSTALL_EVIDENCE}" <<'PY'
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+
+root = Path(sys.argv[1])
+assert stat.S_IMODE(root.stat().st_mode) == 0o700
+for name in ("output.log", "result.json"):
+    path = root / name
+    assert path.is_file()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+result = json.loads((root / "result.json").read_text())
+assert result["exit_code"] == 0
+assert result["status"] == "ok"
+PY
+
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" preflight >/dev/null
+PREFLIGHT_EVIDENCE="$(find "${USER_HOME}/.hybridops/logs/preflight" -mindepth 1 -maxdepth 1 -type d | sort | tail -n1)"
+python3 - "${PREFLIGHT_EVIDENCE}" <<'PY'
+import json
+from pathlib import Path
+import stat
+import sys
+
+root = Path(sys.argv[1])
+assert stat.S_IMODE(root.stat().st_mode) == 0o700
+assert stat.S_IMODE((root / "output.log").stat().st_mode) == 0o600
+assert json.loads((root / "result.json").read_text())["exit_code"] == 0
+PY
+
+FAKE_SETUP_ROOT="${WORK_DIR}/fake-setup-core"
+mkdir -p "${FAKE_SETUP_ROOT}/tools/setup"
+cat >"${FAKE_SETUP_ROOT}/tools/setup/setup-base.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "token=evidence-test-secret"
+echo "expected setup failure"
+exit 7
+EOF
+chmod 0755 "${FAKE_SETUP_ROOT}/tools/setup/setup-base.sh"
+set +e
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup base --root "${FAKE_SETUP_ROOT}" >"${WORK_DIR}/setup-failure.out" 2>&1
+SETUP_RC=$?
+set -e
+[[ "${SETUP_RC}" -eq 7 ]]
+! grep -Fq 'evidence-test-secret' "${WORK_DIR}/setup-failure.out"
+grep -Fq 'token=***REDACTED***' "${WORK_DIR}/setup-failure.out"
+SETUP_EVIDENCE="$(find "${USER_HOME}/.hybridops/logs/setup/base" -mindepth 1 -maxdepth 1 -type d | sort | tail -n1)"
+! grep -Fq 'evidence-test-secret' "${SETUP_EVIDENCE}/output.log"
+grep -Fq 'token=***REDACTED***' "${SETUP_EVIDENCE}/output.log"
+python3 - "${SETUP_EVIDENCE}/result.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+result = json.loads(Path(sys.argv[1]).read_text())
+assert result["exit_code"] == 7
+assert result["status"] == "failed"
+PY
 env HOME="${USER_HOME}" "${common_env[@]}" \
   bash "${HYOPS_REPO_ROOT}/install.sh" --force --no-system-link --no-setup-all >/dev/null
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" show --help >/dev/null

--- a/tools/install/install_evidence.py
+++ b/tools/install/install_evidence.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Stream redacted installer output and write a small result record."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import platform
+from pathlib import Path
+import sys
+
+from hyops.runtime.redact import redact_text
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def stream(log_path: Path) -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as log:
+        log_path.chmod(0o600)
+        for line in sys.stdin:
+            safe_line = redact_text(line)
+            sys.stdout.write(safe_line)
+            sys.stdout.flush()
+            log.write(safe_line)
+            log.flush()
+    return 0
+
+
+def result(path: Path, started_at: str, exit_code: int, argv: list[str]) -> int:
+    payload = {
+        "command": "install",
+        "argv": [redact_text(token) for token in argv],
+        "started_at": started_at,
+        "finished_at": _now(),
+        "exit_code": exit_code,
+        "status": "ok" if exit_code == 0 else "failed",
+        "platform": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.chmod(0o600)
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) >= 3 and sys.argv[1] == "stream":
+        return stream(Path(sys.argv[2]))
+    if len(sys.argv) >= 5 and sys.argv[1] == "result":
+        return result(Path(sys.argv[2]), sys.argv[3], int(sys.argv[4]), sys.argv[5:])
+    print("usage: install_evidence.py stream <log> | result <json> <started> <code> [argv...]", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- capture private run records for install, setup, setup check, and preflight commands
- stream redacted output while preserving the original command exit code
- write `output.log` and `result.json`, then print the saved record path

## Why

The released commands currently report only to the terminal. Operators must add shell-specific pipelines to retain output, and the resulting transcript has no structured status, consistent permissions, or stable location.

## Validation

- successful installer capture
- successful and non-zero setup check capture
- successful and failed preflight capture
- failed setup script exit-code preservation
- terminal, persisted-output, and argument redaction
- `0700` evidence directories and `0600` record files
- Python compilation
- existing Linux installer smoke test

Local shellcheck and Ruff were not available in the workspace; the repository CI jobs will run those checks.

Closes #32
