### PR TITLE
Add an isolated GCP lab network module

### DIFF
--- a/hyops/validators/builtin/register.py
+++ b/hyops/validators/builtin/register.py
@@ -42,7 +42,7 @@ from hyops.validators.platform.network import (
     vyos_edge_wan,
 )
 from hyops.validators.platform.gcp import platform_vm as gcp_platform_vm
-from hyops.validators.platform.gcp import gke_cluster, gke_kubeconfig
+from hyops.validators.platform.gcp import gke_cluster, gke_kubeconfig, lab_network
 from hyops.validators.platform.k8s import gcp_secret_store, gsm_bootstrap
 from hyops.validators.platform.linux import (
     eve_ng as linux_eve_ng,
@@ -100,6 +100,7 @@ def register_all() -> None:
     register("platform/gcp/platform-vm", gcp_platform_vm.validate)
     register("platform/gcp/gke-cluster", gke_cluster.validate)
     register("platform/gcp/gke-kubeconfig", gke_kubeconfig.validate)
+    register("platform/gcp/lab-network", lab_network.validate)
     register("platform/linux/eve-ng", linux_eve_ng.validate)
     register("platform/linux/eve-ng-images", eve_ng_images.validate)
     register("platform/linux/eve-ng-labs", eve_ng_labs.validate)

--- a/hyops/validators/platform/gcp/lab_network.py
+++ b/hyops/validators/platform/gcp/lab_network.py
@@ -1,0 +1,143 @@
+"""
+purpose: Validate inputs for platform/gcp/lab-network.
+Architecture Decision: ADR-0206 (module execution contract v1)
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from typing import Any
+
+from hyops.validators.common import require_non_empty_str
+from hyops.validators.registry import ModuleValidationError
+
+
+_PROJECT_ID_RE = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
+_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{1,61}[a-z0-9]$")
+_REGION_RE = re.compile(r"^[a-z]+-[a-z0-9]+[0-9]$")
+_RFC1918_NETWORKS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+)
+
+
+def _req_str(inputs: dict[str, Any], key: str) -> str:
+    return require_non_empty_str(inputs.get(key), f"inputs.{key}")
+
+
+def _reject_placeholder(value: str, key: str) -> None:
+    if "CHANGE_ME" in value.strip().upper():
+        raise ModuleValidationError(f"inputs.{key} must not contain placeholder values")
+
+
+def _req_name(inputs: dict[str, Any], key: str) -> str:
+    value = _req_str(inputs, key)
+    _reject_placeholder(value, key)
+    if not _NAME_RE.fullmatch(value):
+        raise ModuleValidationError(
+            f"inputs.{key} must be DNS-safe and match ^[a-z][a-z0-9-]{{1,61}}[a-z0-9]$"
+        )
+    return value
+
+
+def _req_bool(inputs: dict[str, Any], key: str) -> bool:
+    value = inputs.get(key)
+    if not isinstance(value, bool):
+        raise ModuleValidationError(f"inputs.{key} must be a boolean")
+    return value
+
+
+def _req_ipv4_network(inputs: dict[str, Any], key: str) -> ipaddress.IPv4Network:
+    value = _req_str(inputs, key)
+    _reject_placeholder(value, key)
+    try:
+        network = ipaddress.ip_network(value, strict=True)
+    except ValueError as exc:
+        raise ModuleValidationError(f"inputs.{key} must be a canonical IPv4 CIDR") from exc
+    if not isinstance(network, ipaddress.IPv4Network):
+        raise ModuleValidationError(f"inputs.{key} must be an IPv4 CIDR")
+    return network
+
+
+def _req_cidr_list(inputs: dict[str, Any], key: str) -> list[ipaddress.IPv4Network]:
+    value = inputs.get(key)
+    if not isinstance(value, list) or not value:
+        raise ModuleValidationError(f"inputs.{key} must be a non-empty list")
+
+    networks: list[ipaddress.IPv4Network] = []
+    for idx, item in enumerate(value, start=1):
+        token = str(item or "").strip()
+        try:
+            network = ipaddress.ip_network(token, strict=True)
+        except ValueError as exc:
+            raise ModuleValidationError(f"inputs.{key}[{idx}] must be a canonical IPv4 CIDR") from exc
+        if not isinstance(network, ipaddress.IPv4Network):
+            raise ModuleValidationError(f"inputs.{key}[{idx}] must be an IPv4 CIDR")
+        networks.append(network)
+
+    if len(set(networks)) != len(networks):
+        raise ModuleValidationError(f"inputs.{key} must not contain duplicate CIDRs")
+    return networks
+
+
+def _req_tag_list(inputs: dict[str, Any], key: str) -> list[str]:
+    value = inputs.get(key)
+    if not isinstance(value, list) or not value:
+        raise ModuleValidationError(f"inputs.{key} must be a non-empty list")
+    tags: list[str] = []
+    for idx, item in enumerate(value, start=1):
+        token = str(item or "").strip()
+        if not token or not _NAME_RE.fullmatch(token):
+            raise ModuleValidationError(f"inputs.{key}[{idx}] must be a DNS-safe network tag")
+        tags.append(token)
+    if len(set(tags)) != len(tags):
+        raise ModuleValidationError(f"inputs.{key} must not contain duplicate tags")
+    return tags
+
+
+def validate(inputs: dict[str, Any]) -> None:
+    project_id = str(inputs.get("project_id") or "").strip()
+    if project_id:
+        _reject_placeholder(project_id, "project_id")
+        if not _PROJECT_ID_RE.fullmatch(project_id):
+            raise ModuleValidationError("inputs.project_id is not a valid GCP project id format")
+
+    region = _req_str(inputs, "region")
+    _reject_placeholder(region, "region")
+    if not _REGION_RE.fullmatch(region):
+        raise ModuleValidationError("inputs.region is not a valid GCP region format")
+
+    _req_name(inputs, "network_name")
+    _req_name(inputs, "subnetwork_name")
+    _req_name(inputs, "router_name")
+    _req_name(inputs, "nat_name")
+
+    routing_mode = _req_str(inputs, "routing_mode").upper()
+    if routing_mode not in {"REGIONAL", "GLOBAL"}:
+        raise ModuleValidationError("inputs.routing_mode must be REGIONAL or GLOBAL")
+
+    subnetwork = _req_ipv4_network(inputs, "subnetwork_cidr")
+    if not any(subnetwork.subnet_of(parent) for parent in _RFC1918_NETWORKS):
+        raise ModuleValidationError("inputs.subnetwork_cidr must be within an RFC1918 private range")
+
+    _req_bool(inputs, "enable_private_google_access")
+    enable_iap = _req_bool(inputs, "enable_iap_ssh")
+    if enable_iap:
+        _req_cidr_list(inputs, "iap_source_cidrs")
+        _req_tag_list(inputs, "iap_target_tags")
+
+    raw_ports = inputs.get("nat_min_ports_per_vm")
+    if isinstance(raw_ports, bool) or not isinstance(raw_ports, int):
+        raise ModuleValidationError("inputs.nat_min_ports_per_vm must be an integer")
+    if raw_ports < 32 or raw_ports > 65536:
+        raise ModuleValidationError("inputs.nat_min_ports_per_vm must be between 32 and 65536")
+
+    _req_bool(inputs, "nat_enable_endpoint_independent_mapping")
+    log_filter = _req_str(inputs, "nat_log_filter").upper()
+    if log_filter not in {"ERRORS_ONLY", "TRANSLATIONS_ONLY", "ALL"}:
+        raise ModuleValidationError(
+            "inputs.nat_log_filter must be ERRORS_ONLY, TRANSLATIONS_ONLY, or ALL"
+        )

--- a/hyops/validators/platform/gcp/tests/__init__.py
+++ b/hyops/validators/platform/gcp/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for built-in GCP module validators."""

--- a/hyops/validators/platform/gcp/tests/test_lab_network.py
+++ b/hyops/validators/platform/gcp/tests/test_lab_network.py
@@ -1,0 +1,68 @@
+"""
+purpose: Test platform/gcp/lab-network input validation.
+Architecture Decision: ADR-0206 (module execution contract v1)
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from hyops.validators.platform.gcp.lab_network import validate
+from hyops.validators.registry import ModuleValidationError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MODULE_ROOT = REPO_ROOT / "modules" / "platform" / "gcp" / "lab-network"
+
+
+def valid_inputs() -> dict:
+    spec = yaml.safe_load((MODULE_ROOT / "spec.yml").read_text(encoding="utf-8"))
+    example = yaml.safe_load(
+        (MODULE_ROOT / "examples" / "inputs.min.yml").read_text(encoding="utf-8")
+    )
+    inputs = deepcopy(spec["inputs"]["defaults"])
+    inputs.update(example)
+    return inputs
+
+
+class LabNetworkValidatorTests(unittest.TestCase):
+    def test_minimal_example_is_valid(self) -> None:
+        validate(valid_inputs())
+
+    def test_invalid_inputs_are_rejected(self) -> None:
+        cases = {
+            "missing region": ("region", ""),
+            "placeholder region": ("region", "CHANGE_ME_GCP_REGION"),
+            "invalid project": ("project_id", "Not_A_Project"),
+            "invalid network name": ("network_name", "Lab_Network"),
+            "host address cidr": ("subnetwork_cidr", "10.80.0.1/24"),
+            "public cidr": ("subnetwork_cidr", "8.8.8.0/24"),
+            "empty iap ranges": ("iap_source_cidrs", []),
+            "ipv6 iap range": ("iap_source_cidrs", ["2001:db8::/32"]),
+            "empty iap tags": ("iap_target_tags", []),
+            "small nat port allocation": ("nat_min_ports_per_vm", 16),
+            "invalid nat log filter": ("nat_log_filter", "VERBOSE"),
+        }
+
+        for label, (key, value) in cases.items():
+            with self.subTest(label=label):
+                inputs = valid_inputs()
+                inputs[key] = value
+                with self.assertRaises(ModuleValidationError):
+                    validate(inputs)
+
+    def test_iap_lists_are_optional_when_iap_is_disabled(self) -> None:
+        inputs = valid_inputs()
+        inputs["enable_iap_ssh"] = False
+        inputs["iap_source_cidrs"] = []
+        inputs["iap_target_tags"] = []
+        validate(inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/platform/gcp/lab-network/README.md
+++ b/modules/platform/gcp/lab-network/README.md
@@ -1,0 +1,78 @@
+# platform/gcp/lab-network
+
+Create a private GCP network for a disposable training or simulation lab.
+
+The module owns one custom VPC, one regional subnet, IAP SSH ingress, one Cloud
+Router, and Cloud NAT for the owned subnet. It is intended for isolated lab
+environments that should not depend on the broader `org/gcp/wan-hub-network`
+contract.
+
+## Prerequisites
+
+- `hyops init gcp --env <env>` is ready.
+- The selected project has billing enabled and the required Compute Engine APIs.
+- The operator can create VPC, firewall, router, and NAT resources.
+
+## Security boundary
+
+- The subnet does not provide a public IP to VMs by itself.
+- IAP ingress permits TCP/22 only from the configured source CIDRs and only to
+  instances with one of the configured target tags.
+- Cloud NAT covers only the subnet owned by this module.
+- No broad internal RFC1918 ingress rule is created.
+
+The default IAP source range is Google's TCP-forwarding range. Change it only
+when the provider contract changes and the replacement has been verified.
+
+## Usage
+
+Validate and run preflight:
+
+```bash
+hyops validate --env <env> \
+  --module platform/gcp/lab-network \
+  --inputs "$HYOPS_CORE_ROOT/modules/platform/gcp/lab-network/examples/inputs.min.yml"
+
+hyops preflight --env <env> --strict \
+  --module platform/gcp/lab-network \
+  --inputs "$HYOPS_CORE_ROOT/modules/platform/gcp/lab-network/examples/inputs.min.yml"
+```
+
+Create the network:
+
+```bash
+hyops apply --env <env> \
+  --module platform/gcp/lab-network \
+  --inputs "$HYOPS_CORE_ROOT/modules/platform/gcp/lab-network/examples/inputs.min.yml"
+```
+
+Destroy the network after all dependent VMs have been removed:
+
+```bash
+hyops destroy --env <env> \
+  --module platform/gcp/lab-network \
+  --inputs "$HYOPS_CORE_ROOT/modules/platform/gcp/lab-network/examples/inputs.min.yml"
+```
+
+## Consuming the network state
+
+`platform/gcp/platform-vm` can consume this module without driver-specific
+logic:
+
+```yaml
+network_state_ref: "platform/gcp/lab-network"
+subnetwork_output_key: "subnetwork_name"
+assign_public_ip: false
+tags:
+  - "allow-iap-ssh"
+```
+
+## Outputs
+
+The module publishes project, region, network, subnetwork, router, NAT, and IAP
+firewall identities. Outputs contain no credentials.
+
+## Non-goals
+
+This module does not create projects, billing links, VMs, EVE-NG, device images,
+teaching labs, VPNs, WAN routing, GKE secondary ranges, or NetBox state.

--- a/modules/platform/gcp/lab-network/examples/inputs.min.yml
+++ b/modules/platform/gcp/lab-network/examples/inputs.min.yml
@@ -1,0 +1,3 @@
+region: "europe-west2"
+name_prefix: "student"
+context_id: "network-lab"

--- a/modules/platform/gcp/lab-network/spec.yml
+++ b/modules/platform/gcp/lab-network/spec.yml
@@ -1,0 +1,66 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/gcp/lab-network"
+
+metadata:
+  title: "GCP Private Lab Network"
+  description: "Create an isolated GCP VPC, subnet, IAP SSH access, and private outbound egress for a disposable lab."
+
+requirements:
+  credentials: ["gcp"]
+
+inputs:
+  defaults:
+    name_prefix: ""
+    context_id: ""
+    project_id: ""
+    region: ""
+
+    network_name: "lab-network"
+    routing_mode: "REGIONAL"
+    subnetwork_name: "lab"
+    subnetwork_cidr: "10.80.0.0/24"
+    enable_private_google_access: true
+
+    enable_iap_ssh: true
+    iap_source_cidrs:
+      - "35.235.240.0/20"
+    iap_target_tags:
+      - "allow-iap-ssh"
+
+    router_name: "lab-router"
+    nat_name: "lab-nat"
+    nat_min_ports_per_vm: 64
+    nat_enable_endpoint_independent_mapping: true
+    nat_log_filter: "ERRORS_ONLY"
+
+execution:
+  driver: "iac/terragrunt"
+  profile: "gcp@v1.0"
+  pack_ref:
+    id: "gcp/platform/10-platform/20-lab-network@v1.0"
+  hooks:
+    export_infra:
+      enabled: true
+      target: "cloud-gcp"
+      strict: false
+      push_to_netbox: false
+
+outputs:
+  publish:
+    - project_id
+    - region
+    - network_name
+    - network_self_link
+    - subnetwork_name
+    - subnetwork_self_link
+    - subnetwork_cidr
+    - router_name
+    - router_self_link
+    - nat_name
+    - nat_self_link
+    - iap_firewall_rule_name
+
+probes: []
+constraints: []

--- a/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/main.tf
+++ b/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/main.tf
@@ -1,0 +1,76 @@
+locals {
+  prefix_raw = join("-", compact([trimspace(var.name_prefix), trimspace(var.context_id)]))
+  prefix_1   = lower(replace(local.prefix_raw, "/[^0-9a-z-]/", "-"))
+  prefix_2   = replace(local.prefix_1, "/-+/", "-")
+  prefix     = trim(local.prefix_2, "-")
+
+  network_name      = local.prefix != "" ? "${local.prefix}-${var.network_name}" : var.network_name
+  subnetwork_name   = local.prefix != "" ? "${local.prefix}-${var.subnetwork_name}-${var.region}" : "${var.subnetwork_name}-${var.region}"
+  router_name       = local.prefix != "" ? "${local.prefix}-${var.router_name}-${var.region}" : "${var.router_name}-${var.region}"
+  nat_name          = local.prefix != "" ? "${local.prefix}-${var.nat_name}-${var.region}" : "${var.nat_name}-${var.region}"
+  iap_firewall_name = "${local.network_name}-allow-iap-ssh"
+  effective_project = trimspace(var.project_id) != "" ? var.project_id : null
+}
+
+resource "google_compute_network" "lab" {
+  project                 = local.effective_project
+  name                    = local.network_name
+  auto_create_subnetworks = false
+  routing_mode            = upper(var.routing_mode)
+}
+
+resource "google_compute_subnetwork" "lab" {
+  project                  = local.effective_project
+  name                     = local.subnetwork_name
+  region                   = var.region
+  network                  = google_compute_network.lab.id
+  ip_cidr_range            = var.subnetwork_cidr
+  private_ip_google_access = var.enable_private_google_access
+}
+
+resource "google_compute_firewall" "allow_iap_ssh" {
+  count   = var.enable_iap_ssh ? 1 : 0
+  project = local.effective_project
+  name    = local.iap_firewall_name
+  network = google_compute_network.lab.name
+
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_ranges = var.iap_source_cidrs
+  target_tags   = var.iap_target_tags
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_router" "lab" {
+  project = local.effective_project
+  name    = local.router_name
+  region  = var.region
+  network = google_compute_network.lab.id
+}
+
+resource "google_compute_router_nat" "lab" {
+  project = local.effective_project
+  name    = local.nat_name
+  region  = var.region
+  router  = google_compute_router.lab.name
+
+  nat_ip_allocate_option              = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
+  min_ports_per_vm                    = var.nat_min_ports_per_vm
+  enable_endpoint_independent_mapping = var.nat_enable_endpoint_independent_mapping
+
+  subnetwork {
+    name                    = google_compute_subnetwork.lab.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  log_config {
+    enable = true
+    filter = upper(var.nat_log_filter)
+  }
+}

--- a/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/outputs.tf
+++ b/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/outputs.tf
@@ -1,0 +1,47 @@
+output "project_id" {
+  value = google_compute_network.lab.project
+}
+
+output "region" {
+  value = google_compute_subnetwork.lab.region
+}
+
+output "network_name" {
+  value = google_compute_network.lab.name
+}
+
+output "network_self_link" {
+  value = google_compute_network.lab.self_link
+}
+
+output "subnetwork_name" {
+  value = google_compute_subnetwork.lab.name
+}
+
+output "subnetwork_self_link" {
+  value = google_compute_subnetwork.lab.self_link
+}
+
+output "subnetwork_cidr" {
+  value = google_compute_subnetwork.lab.ip_cidr_range
+}
+
+output "router_name" {
+  value = google_compute_router.lab.name
+}
+
+output "router_self_link" {
+  value = google_compute_router.lab.self_link
+}
+
+output "nat_name" {
+  value = google_compute_router_nat.lab.name
+}
+
+output "nat_self_link" {
+  value = google_compute_router_nat.lab.id
+}
+
+output "iap_firewall_rule_name" {
+  value = try(google_compute_firewall.allow_iap_ssh[0].name, "")
+}

--- a/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/variables.tf
+++ b/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/variables.tf
@@ -1,0 +1,83 @@
+variable "name_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "context_id" {
+  type    = string
+  default = ""
+}
+
+variable "project_id" {
+  type    = string
+  default = ""
+}
+
+variable "region" {
+  type = string
+}
+
+variable "network_name" {
+  type    = string
+  default = "lab-network"
+}
+
+variable "routing_mode" {
+  type    = string
+  default = "REGIONAL"
+}
+
+variable "subnetwork_name" {
+  type    = string
+  default = "lab"
+}
+
+variable "subnetwork_cidr" {
+  type    = string
+  default = "10.80.0.0/24"
+}
+
+variable "enable_private_google_access" {
+  type    = bool
+  default = true
+}
+
+variable "enable_iap_ssh" {
+  type    = bool
+  default = true
+}
+
+variable "iap_source_cidrs" {
+  type    = list(string)
+  default = ["35.235.240.0/20"]
+}
+
+variable "iap_target_tags" {
+  type    = list(string)
+  default = ["allow-iap-ssh"]
+}
+
+variable "router_name" {
+  type    = string
+  default = "lab-router"
+}
+
+variable "nat_name" {
+  type    = string
+  default = "lab-nat"
+}
+
+variable "nat_min_ports_per_vm" {
+  type    = number
+  default = 64
+}
+
+variable "nat_enable_endpoint_independent_mapping" {
+  type    = bool
+  default = true
+}
+
+variable "nat_log_filter" {
+  type    = string
+  default = "ERRORS_ONLY"
+}

--- a/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/versions.tf
+++ b/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terragrunt.hcl
+++ b/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terragrunt.hcl
@@ -1,0 +1,10 @@
+include "root" {
+  path   = "${get_terragrunt_dir()}/root.hcl"
+  expose = true
+}
+
+terraform {
+  source = "${get_terragrunt_dir()}/terraform"
+}
+
+# inputs come from root.hcl (hyops.inputs.json). Do not override here.

--- a/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terragrunt.hcl
+++ b/packs/iac/terragrunt/gcp/platform/10-platform/20-lab-network@v1.0/stack/terragrunt.hcl
@@ -7,4 +7,12 @@ terraform {
   source = "${get_terragrunt_dir()}/terraform"
 }
 
-# inputs come from root.hcl (hyops.inputs.json). Do not override here.
+# Preserve module inputs while passing through the GCP coordinates resolved by
+# the profile from explicit inputs, init tfvars, or environment variables.
+inputs = merge(
+  include.root.locals.inputs,
+  {
+    project_id = include.root.locals.gcp.project_id
+    region     = include.root.locals.gcp.region
+  },
+)

--- a/tools/ci/check-python.sh
+++ b/tools/ci/check-python.sh
@@ -13,6 +13,10 @@ hyops_ci::require_cmd python3
 
 python3 -m compileall "${HYOPS_REPO_ROOT}/hyops"
 
+python3 -m unittest discover \
+  -s "${HYOPS_REPO_ROOT}/hyops/validators" \
+  -p 'test_*.py'
+
 python3 - "${HYOPS_REPO_ROOT}" <<'PY'
 import importlib
 import pkgutil


### PR DESCRIPTION
Closes #36

## Summary

Adds a small GCP network module for disposable lab environments. The module owns one custom VPC, one regional subnet, an IAP SSH rule, Cloud Router and subnet-scoped Cloud NAT.

The network publishes the identifiers needed by the existing platform VM state resolver. It does not take ownership of project creation, VM provisioning or the EVE-NG lifecycle.

## Validation

- Python validator tests pass
- Terraform formatting and validation pass
- The module and Terraform pack were applied and destroyed in a disposable GCP project during local acceptance testing
- The release bundle build and isolated verification include the new module and pack
