### PR TITLE
Validate GCP ADC readiness and private access APIs

### DIFF
--- a/hyops/init/targets/gcp.py
+++ b/hyops/init/targets/gcp.py
@@ -1171,6 +1171,8 @@ def _ensure_terraform_sa_project_roles(
     All gcloud operations are idempotent: re-running produces the same state.
 
     APIs enabled:
+      compute.googleapis.com         — required for Compute Engine resources
+      iap.googleapis.com             — required for private VM SSH through IAP
       orgpolicy.googleapis.com       — required for `gcloud resource-manager org-policies` calls
       secretmanager.googleapis.com   — required for Secret Manager resources
 
@@ -1195,6 +1197,8 @@ def _ensure_terraform_sa_project_roles(
     member = f"serviceAccount:{terraform_sa_email}"
 
     apis = [
+        "compute.googleapis.com",
+        "iap.googleapis.com",
         "orgpolicy.googleapis.com",
         "secretmanager.googleapis.com",
     ]

--- a/hyops/init/targets/gcp.py
+++ b/hyops/init/targets/gcp.py
@@ -639,13 +639,11 @@ def run(ns) -> int:
         print("note: GCP_TERRAFORM_SA_EMAIL not set; skipping impersonation validation.")
         print("hint: after running org/gcp/project-factory, re-run: hyops init gcp --env <env> --force")
     else:
-        imp_ok = _shell_ok(
-            "gcloud auth print-access-token "
-            f"--impersonate-service-account={shlex.quote(terraform_sa_email)} "
-            f"--project={shlex.quote(project_id)} "
-            ">/dev/null",
-            evidence_dir,
-            "impersonation_check",
+        imp_ok = _adc_impersonation_ok(
+            terraform_sa_email=terraform_sa_email,
+            project_id=project_id,
+            evidence_dir=evidence_dir,
+            label="adc_impersonation_check",
         )
         if (
             (not imp_ok)
@@ -660,28 +658,37 @@ def run(ns) -> int:
                 terraform_sa_email=terraform_sa_email,
                 evidence_dir=evidence_dir,
             ):
-                imp_ok = _shell_ok(
-                    "gcloud auth print-access-token "
-                    f"--impersonate-service-account={shlex.quote(terraform_sa_email)} "
-                    f"--project={shlex.quote(project_id)} "
-                    ">/dev/null",
-                    evidence_dir,
-                    "impersonation_check_after_bootstrap_grant",
+                imp_ok = _adc_impersonation_ok(
+                    terraform_sa_email=terraform_sa_email,
+                    project_id=project_id,
+                    evidence_dir=evidence_dir,
+                    label="adc_impersonation_check_after_bootstrap_grant",
+                )
+        if (
+            (not imp_ok)
+            and (not non_interactive)
+            and bool(getattr(ns, "with_cli_login", False))
+        ):
+            if _run_interactive_adc_login(
+                evidence_dir,
+                reason=(
+                    "ADC cannot impersonate the Terraform service account. "
+                    "Refresh ADC with the confirmed gcloud identity."
+                ),
+            ):
+                imp_ok = _adc_impersonation_ok(
+                    terraform_sa_email=terraform_sa_email,
+                    project_id=project_id,
+                    evidence_dir=evidence_dir,
+                    label="adc_impersonation_check_after_adc_login",
                 )
         if not imp_ok:
-            if not terraform_sa_email_explicit:
-                print("WARN: derived Terraform service account failed impersonation validation; continuing without impersonation.")
-                print(
-                    "hint: set GCP_TERRAFORM_SA_EMAIL explicitly once caller permissions are correct, "
-                    "or keep using direct ADC for this environment."
-                )
-                terraform_sa_email = ""
-            else:
-                print("ERR: impersonation validation failed; see run record")
-                print("hint: caller must have roles/iam.serviceAccountTokenCreator on the target service account.")
-                print("hint: ensure iamcredentials.googleapis.com is enabled in the target project.")
-                print(f"run record: {evidence_dir}")
-                return TARGET_EXEC_FAILURE
+            print("ERR: ADC impersonation validation failed; see run record")
+            print("hint: the ADC principal must have roles/iam.serviceAccountTokenCreator on the target service account.")
+            print("hint: if ADC is stale, run: gcloud auth application-default login")
+            print("hint: ensure iamcredentials.googleapis.com is enabled in the target project.")
+            print(f"run record: {evidence_dir}")
+            return TARGET_EXEC_FAILURE
         impersonation_validated = bool(terraform_sa_email)
         if impersonation_validated:
             auth_mode = "impersonation"
@@ -1014,6 +1021,25 @@ def _ensure_org_policy_admin(*, account: str, evidence_dir: Path) -> None:
 
 def _require_tty() -> bool:
     return os.isatty(0) and os.isatty(1)
+
+
+def _adc_impersonation_ok(
+    *,
+    terraform_sa_email: str,
+    project_id: str,
+    evidence_dir: Path,
+    label: str,
+) -> bool:
+    """Verify the same ADC-to-service-account path used by Terraform."""
+
+    return _shell_ok(
+        "gcloud auth application-default print-access-token "
+        f"--impersonate-service-account={shlex.quote(terraform_sa_email)} "
+        f"--project={shlex.quote(project_id)} "
+        ">/dev/null",
+        evidence_dir,
+        label,
+    )
 
 
 def _run_interactive_adc_login(evidence_dir: Path, *, reason: str) -> bool:

--- a/hyops/init/tests/__init__.py
+++ b/hyops/init/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for init target behaviour."""

--- a/hyops/init/tests/test_gcp.py
+++ b/hyops/init/tests/test_gcp.py
@@ -1,8 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from hyops.init.targets.gcp import _adc_impersonation_ok
+from hyops.init.targets.gcp import (
+    _adc_impersonation_ok,
+    _ensure_terraform_sa_project_roles,
+)
 
 
 class AdcImpersonationTest(TestCase):
@@ -39,3 +43,27 @@ class AdcImpersonationTest(TestCase):
 
         self.assertFalse(result)
         shell_ok.assert_called_once()
+
+
+class TerraformServiceAccountSetupTest(TestCase):
+    @patch("hyops.init.targets.gcp.diagnose_private_service_access_permissions", return_value=(True, ""))
+    @patch("hyops.init.targets.gcp.run_capture")
+    def test_enables_compute_and_iap_apis(self, run_capture, _diagnose):
+        run_capture.return_value = SimpleNamespace(rc=0, stderr="")
+        evidence_dir = Path("/tmp/evidence")
+
+        _ensure_terraform_sa_project_roles(
+            project_id="student-project",
+            terraform_sa_email="terraform@example.iam.gserviceaccount.com",
+            evidence_dir=evidence_dir,
+        )
+
+        commands = [entry.args[0] for entry in run_capture.call_args_list]
+        self.assertIn(
+            ["gcloud", "services", "enable", "compute.googleapis.com", "--project", "student-project"],
+            commands,
+        )
+        self.assertIn(
+            ["gcloud", "services", "enable", "iap.googleapis.com", "--project", "student-project"],
+            commands,
+        )

--- a/hyops/init/tests/test_gcp.py
+++ b/hyops/init/tests/test_gcp.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.init.targets.gcp import _adc_impersonation_ok
+
+
+class AdcImpersonationTest(TestCase):
+    @patch("hyops.init.targets.gcp._shell_ok", return_value=True)
+    def test_uses_application_default_credentials(self, shell_ok):
+        evidence_dir = Path("/tmp/evidence")
+
+        result = _adc_impersonation_ok(
+            terraform_sa_email="terraform@example.iam.gserviceaccount.com",
+            project_id="student-project",
+            evidence_dir=evidence_dir,
+            label="adc_impersonation_check",
+        )
+
+        self.assertTrue(result)
+        command, actual_evidence_dir, label = shell_ok.call_args.args
+        self.assertIn("gcloud auth application-default print-access-token", command)
+        self.assertIn(
+            "--impersonate-service-account=terraform@example.iam.gserviceaccount.com",
+            command,
+        )
+        self.assertIn("--project=student-project", command)
+        self.assertEqual(actual_evidence_dir, evidence_dir)
+        self.assertEqual(label, "adc_impersonation_check")
+
+    @patch("hyops.init.targets.gcp._shell_ok", return_value=False)
+    def test_propagates_adc_impersonation_failure(self, shell_ok):
+        result = _adc_impersonation_ok(
+            terraform_sa_email="terraform@example.iam.gserviceaccount.com",
+            project_id="student-project",
+            evidence_dir=Path("/tmp/evidence"),
+            label="adc_impersonation_check",
+        )
+
+        self.assertFalse(result)
+        shell_ok.assert_called_once()

--- a/tools/ci/check-python.sh
+++ b/tools/ci/check-python.sh
@@ -14,7 +14,7 @@ hyops_ci::require_cmd python3
 python3 -m compileall "${HYOPS_REPO_ROOT}/hyops"
 
 python3 -m unittest discover \
-  -s "${HYOPS_REPO_ROOT}/hyops/validators" \
+  -s "${HYOPS_REPO_ROOT}/hyops" \
   -p 'test_*.py'
 
 python3 - "${HYOPS_REPO_ROOT}" <<'PY'


### PR DESCRIPTION
Closes #41

## What changed

- validate Terraform service-account impersonation through Application Default Credentials
- refresh ADC through the existing interactive login path when validation fails
- prepare the Compute Engine and IAP APIs used by private VM deployment and access
- cover the authentication and API preparation paths with tests

## Why

The active gcloud account and ADC principal can differ. Init previously validated the former and could write ready state even though Terraform could not impersonate the configured service account.

## Validation

- `bash tools/ci/check-python.sh`
- exercised during the packaged macOS-to-GCP EVE-NG deployment