### PR TITLE
Defer checks for planned blueprint dependencies

### DIFF
--- a/hyops/blueprint/planner.py
+++ b/hyops/blueprint/planner.py
@@ -164,6 +164,28 @@ def preflight_step(
         result["checks"].append({"name": "contracts", "ok": False, "detail": str(exc)})
         return result
 
+    if deferred_driver_preflight_refs:
+        refs = ", ".join(sorted(deferred_driver_preflight_refs))
+        result["checks"].append(
+            {
+                "name": "module_resolve",
+                "ok": True,
+                "detail": f"deferred until upstream blueprint state exists: {refs}",
+            }
+        )
+        result["checks"].append(
+            {
+                "name": "module_preflight",
+                "ok": True,
+                "detail": f"deferred until upstream blueprint state exists: {refs}",
+            }
+        )
+        result["driver_preflight"] = {
+            "status": "deferred",
+            "deferred_state_refs": sorted(deferred_driver_preflight_refs),
+        }
+        return result
+
     try:
         module_root = resolve_module_root(getattr(ns, "module_root", "modules"))
         resolved = resolve_module(
@@ -181,21 +203,6 @@ def preflight_step(
     except Exception as exc:
         result["status"] = "blocked"
         result["checks"].append({"name": "module_resolve", "ok": False, "detail": str(exc)})
-        return result
-
-    if deferred_driver_preflight_refs:
-        refs = ", ".join(sorted(deferred_driver_preflight_refs))
-        result["checks"].append(
-            {
-                "name": "module_preflight",
-                "ok": True,
-                "detail": f"deferred until upstream blueprint state exists: {refs}",
-            }
-        )
-        result["driver_preflight"] = {
-            "status": "deferred",
-            "deferred_state_refs": sorted(deferred_driver_preflight_refs),
-        }
         return result
 
     try:
@@ -242,6 +249,7 @@ def compute_preflight(
     # Existing on-disk states are resolved normally so preflight keeps real
     # safety checks for non-blueprint dependencies.
     assumed_state_ok: set[str] = set()
+    step_status_by_id: dict[str, str] = {}
 
     for step_id in payload["order"]:
         step = by_id[step_id]
@@ -254,7 +262,10 @@ def compute_preflight(
             if not isinstance(dep_step, dict):
                 continue
             dep_state_ref = step_state_ref(dep_step)
-            if dep_state_ref in assumed_state_ok and not module_state_ok(paths.state_dir, dep_state_ref):
+            if (
+                dep_state_ref in assumed_state_ok
+                and step_status_by_id.get(str(dep_id)) == "ready"
+            ):
                 deferred_driver_preflight_refs.add(dep_state_ref)
         result = preflight_step(
             step,
@@ -265,6 +276,7 @@ def compute_preflight(
             deferred_driver_preflight_refs=deferred_driver_preflight_refs,
         )
         step_results.append(result)
+        step_status_by_id[step_id] = str(result.get("status") or "")
 
         if result["status"] == "blocked":
             if result.get("optional", False):

--- a/hyops/blueprint/tests/__init__.py
+++ b/hyops/blueprint/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for blueprint planning and preflight."""

--- a/hyops/blueprint/tests/test_planner.py
+++ b/hyops/blueprint/tests/test_planner.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.blueprint.planner import compute_preflight
+
+
+class PlannedDependencyPreflightTest(TestCase):
+    @patch("hyops.blueprint.planner.module_state_ok", return_value=True)
+    @patch("hyops.blueprint.planner.preflight_step")
+    def test_changed_upstream_state_defers_downstream_checks(
+        self,
+        preflight_step,
+        _module_state_ok,
+    ):
+        payload = {
+            "order": ["network", "vm"],
+            "steps": [
+                {
+                    "id": "network",
+                    "module_ref": "platform/gcp/lab-network",
+                    "state_instance": "student_network",
+                    "action": "deploy",
+                    "phase": "bootstrap",
+                    "optional": False,
+                },
+                {
+                    "id": "vm",
+                    "module_ref": "platform/gcp/platform-vm",
+                    "state_instance": "student_vm",
+                    "action": "deploy",
+                    "phase": "bootstrap",
+                    "optional": False,
+                    "requires": ["network"],
+                },
+            ],
+        }
+        preflight_step.side_effect = [
+            {"id": "network", "status": "ready", "optional": False},
+            {"id": "vm", "status": "ready", "optional": False},
+        ]
+
+        results, required_failures, optional_failures = compute_preflight(
+            payload,
+            SimpleNamespace(),
+            SimpleNamespace(state_dir="/tmp/state"),
+        )
+
+        self.assertEqual([item["status"] for item in results], ["ready", "ready"])
+        self.assertEqual(required_failures, [])
+        self.assertEqual(optional_failures, [])
+        vm_call = preflight_step.call_args_list[1]
+        self.assertEqual(
+            vm_call.kwargs["deferred_driver_preflight_refs"],
+            {"platform/gcp/lab-network#student_network"},
+        )


### PR DESCRIPTION
Closes #42

## What changed

- defer driver checks that require state from an upstream step planned in the same blueprint run
- keep normal readiness results and required/optional failure handling intact
- add regression coverage for changed upstream state and the downstream deferred reference

## Why

First-run compositions could fail preflight because downstream state did not exist yet, even though an earlier ordered step was responsible for creating it.

## Validation

- `python3 -m unittest hyops.blueprint.tests.test_planner`
- exercised by the five-stage EVE-NG deployment and rebuild