### PR TITLE
Compose GCP EVE-NG with isolated lab networking

### DIFF
--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -9,6 +9,7 @@ Use this when you want the EVE-NG host lifecycle to be rebuildable from infrastr
 ## What This Delivers
 
 - a private GCP Compute Engine VM for EVE-NG
+- an isolated VPC, subnet, IAP SSH rule, router, and subnet-scoped Cloud NAT
 - nested virtualization enabled for KVM-backed network simulation workloads
 - no public IP by default
 - SSH access through GCP IAP
@@ -20,7 +21,8 @@ Use this when you want the EVE-NG host lifecycle to be rebuildable from infrastr
 ## Execution Chain
 
 ```text
-platform/gcp/platform-vm
+platform/gcp/lab-network
+  -> platform/gcp/platform-vm
   -> platform/linux/eve-ng
   -> platform/linux/eve-ng-healthcheck
 ```
@@ -34,13 +36,15 @@ The blueprint file is [blueprint.yml](blueprint.yml).
 
 ## Prerequisites
 
-This blueprint assumes the GCP foundation for the target environment already exists:
+This blueprint creates its own lab network. It assumes the GCP account and
+target environment are ready:
 
 - `hyops init gcp --env <env>` has been run.
 - A GCP project is selected for the environment.
-- The WAN hub network state exists at `org/gcp/wan-hub-network`.
-- The workload subnet output is available as `subnet_workloads_name`.
-- IAP TCP forwarding is allowed for VMs tagged `allow-iap-ssh`.
+- Billing is enabled on the selected project. The deployment and running VM can
+  consume free-trial credit or incur charges.
+- The operator can create Compute Engine networks, firewall rules, routers,
+  NAT configuration, and instances.
 - EVE-NG secrets are seeded for the target environment.
 - The placeholder `CHANGE_ME_GCP_ZONE` in [blueprint.yml](blueprint.yml) has been copied or overridden with a real zone that supports the selected machine family.
 
@@ -93,7 +97,8 @@ The shipped blueprint provisions one VM:
 - SSH user: `opsadmin`
 - network tag: `allow-iap-ssh`
 
-The VM is placed on the workload subnet exported by the selected GCP network state.
+The VM is placed on the private subnet created by the blueprint's lab-network
+step.
 
 ## Why This Exists
 
@@ -111,6 +116,7 @@ That makes the EVE-NG host disposable enough to rebuild and predictable enough t
 
 ## Related Modules
 
+- [platform/gcp/lab-network](../../../modules/platform/gcp/lab-network)
 - [platform/gcp/platform-vm](../../../modules/platform/gcp/platform-vm)
 - [platform/linux/eve-ng](../../../modules/platform/linux/eve-ng)
 - [platform/linux/eve-ng-healthcheck](../../../modules/platform/linux/eve-ng-healthcheck)

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -15,11 +15,28 @@ policy:
   ipam_authority: "none"
 
 steps:
+  - id: gcp_eve_ng_network
+    module_ref: "platform/gcp/lab-network"
+    state_instance: "gcp_eve_ng_network"
+    action: "deploy"
+    phase: "bootstrap"
+    with_deps: false
+    skip_if_state_ok: true
+    verify_state_on_skip: true
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      name_prefix: "platform"
+      context_id: "labs"
+      subnetwork_cidr: "10.80.50.0/24"
+
   - id: gcp_eve_ng_vm
     module_ref: "platform/gcp/platform-vm"
     state_instance: "gcp_eve_ng_vm"
     action: "deploy"
     phase: "bootstrap"
+    requires:
+      - gcp_eve_ng_network
     with_deps: true
     skip_if_state_ok: true
     verify_state_on_skip: true
@@ -28,8 +45,8 @@ steps:
     inputs:
       name_prefix: "platform"
       context_id: "labs"
-      network_state_ref: "org/gcp/wan-hub-network"
-      subnetwork_output_key: "subnet_workloads_name"
+      network_state_ref: "platform/gcp/lab-network#gcp_eve_ng_network"
+      subnetwork_output_key: "subnetwork_name"
       zone: "CHANGE_ME_GCP_ZONE"
       machine_type: "n2-standard-8"
       boot_disk_size_gb: 256

--- a/hyops/validators/platform/gcp/lab_network.py
+++ b/hyops/validators/platform/gcp/lab_network.py
@@ -105,10 +105,11 @@ def validate(inputs: dict[str, Any]) -> None:
         if not _PROJECT_ID_RE.fullmatch(project_id):
             raise ModuleValidationError("inputs.project_id is not a valid GCP project id format")
 
-    region = _req_str(inputs, "region")
-    _reject_placeholder(region, "region")
-    if not _REGION_RE.fullmatch(region):
-        raise ModuleValidationError("inputs.region is not a valid GCP region format")
+    region = str(inputs.get("region") or "").strip()
+    if region:
+        _reject_placeholder(region, "region")
+        if not _REGION_RE.fullmatch(region):
+            raise ModuleValidationError("inputs.region is not a valid GCP region format")
 
     _req_name(inputs, "network_name")
     _req_name(inputs, "subnetwork_name")

--- a/hyops/validators/platform/gcp/tests/test_lab_network.py
+++ b/hyops/validators/platform/gcp/tests/test_lab_network.py
@@ -36,7 +36,6 @@ class LabNetworkValidatorTests(unittest.TestCase):
 
     def test_invalid_inputs_are_rejected(self) -> None:
         cases = {
-            "missing region": ("region", ""),
             "placeholder region": ("region", "CHANGE_ME_GCP_REGION"),
             "invalid project": ("project_id", "Not_A_Project"),
             "invalid network name": ("network_name", "Lab_Network"),
@@ -55,6 +54,11 @@ class LabNetworkValidatorTests(unittest.TestCase):
                 inputs[key] = value
                 with self.assertRaises(ModuleValidationError):
                     validate(inputs)
+
+    def test_region_may_come_from_gcp_init(self) -> None:
+        inputs = valid_inputs()
+        inputs["region"] = ""
+        validate(inputs)
 
     def test_iap_lists_are_optional_when_iap_is_disabled(self) -> None:
         inputs = valid_inputs()

--- a/packs/iac/terragrunt/gcp/platform/10-platform/00-platform-vm@v1.0/stack/terragrunt.hcl
+++ b/packs/iac/terragrunt/gcp/platform/10-platform/00-platform-vm@v1.0/stack/terragrunt.hcl
@@ -7,5 +7,8 @@ terraform {
   source = "${get_terragrunt_dir()}/terraform"
 }
 
-# inputs come from root.hcl (hyops.inputs.json). Do not override here.
-
+# SSH readiness is a HyOps post-apply control, not a Terraform variable.
+inputs = {
+  for key, value in include.root.locals.inputs :
+  key => value if key != "post_apply_ssh_readiness"
+}


### PR DESCRIPTION
Closes #43

## What changed

- make the isolated GCP lab network the first EVE-NG blueprint step
- bind the VM to the network step's published subnet state
- remove the historical WAN-hub dependency from the blueprint contract and README
- filter the post-apply SSH readiness control before Terraform input generation

## Why

The disposable EVE-NG path should own a narrow private lab network rather than depend on a broader WAN foundation. The SSH readiness flag belongs to HybridOps orchestration and was not a Terraform input.

## Validation

- blueprint validation passes
- blueprint planning reports network, VM, configuration and health in order
- live Mac/GCP acceptance deployed the private VM without a public address and later rebuilt all stages successfully