### PR TITLE
Gate GCP deployments on billing readiness

### DIFF
--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -38,6 +38,9 @@ This blueprint assumes the GCP foundation for the target environment already exi
 
 - `hyops init gcp --env <env>` has been run.
 - A GCP project is selected for the environment.
+- Billing is enabled on the selected project. `hyops init gcp` and GCP module
+  preflight stop when billing is disabled or cannot be confirmed. The deployment
+  and running VM can consume free-trial credit or incur charges.
 - The WAN hub network state exists at `org/gcp/wan-hub-network`.
 - The workload subnet output is available as `subnet_workloads_name`.
 - IAP TCP forwarding is allowed for VMs tagged `allow-iap-ssh`.

--- a/hyops/drivers/iac/terragrunt/_internal/preflight.py
+++ b/hyops/drivers/iac/terragrunt/_internal/preflight.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 
 from hyops.runtime.coerce import as_int
+from hyops.runtime.credentials import parse_tfvars
+from hyops.runtime.gcp import diagnose_project_billing
 from hyops.runtime.module_state import read_module_state
 from hyops.runtime.terraform_cloud import preflight_cloud_backend
 
@@ -37,6 +39,59 @@ def _resolve_gke_project_id(*, runtime_root: Path, inputs: dict[str, Any]) -> st
     if not isinstance(outputs, dict):
         return ""
     return str(outputs.get("project_id") or "").strip()
+
+
+def _resolve_gcp_project_id(
+    *,
+    runtime: dict[str, Any],
+    inputs: dict[str, Any],
+) -> str:
+    direct = str(inputs.get("project_id") or inputs.get("network_project_id") or "").strip()
+    if direct:
+        return direct
+
+    credentials_dir_raw = str(runtime.get("credentials_dir") or "").strip()
+    if not credentials_dir_raw:
+        return ""
+    tfvars_path = Path(credentials_dir_raw).expanduser().resolve() / "gcp.credentials.tfvars"
+    try:
+        tfvars = parse_tfvars(tfvars_path)
+    except Exception:
+        return ""
+    return str(tfvars.get("project_id") or "").strip()
+
+
+def _preflight_gcp_billing(
+    *,
+    lifecycle_command: str,
+    module_ref: str,
+    profile_ref: str,
+    runtime: dict[str, Any],
+    inputs: dict[str, Any],
+) -> str:
+    if not str(profile_ref or "").strip().lower().startswith("gcp"):
+        return ""
+    if str(lifecycle_command or "").strip().lower() == "destroy":
+        return ""
+    if str(module_ref or "").strip() == "org/gcp/project-factory":
+        return ""
+
+    project_id = _resolve_gcp_project_id(runtime=runtime, inputs=inputs)
+    if not project_id:
+        return "GCP billing preflight failed: project id could not be resolved from module inputs or init credentials."
+
+    validated, enabled, detail = diagnose_project_billing(project_id)
+    if not validated:
+        return (
+            f"GCP billing preflight failed: could not validate billing for project {project_id}. "
+            + (detail or "Confirm the active gcloud identity can view project billing.")
+        )
+    if not enabled:
+        return (
+            f"GCP billing preflight failed: billing is not enabled for project {project_id}. "
+            "Enable billing before creating or updating resources. Destroy remains available."
+        )
+    return ""
 
 
 def _preflight_gke_default_compute_sa(
@@ -146,6 +201,16 @@ def run_preflight_phase(
         tfc_error = preflight_cloud_backend(env=env, runtime_root=runtime_root, env_name=env_name)
         if tfc_error:
             return True, tfc_error
+
+    billing_error = _preflight_gcp_billing(
+        lifecycle_command=str(runtime.get("lifecycle_command") or ""),
+        module_ref=module_ref,
+        profile_ref=profile_ref,
+        runtime=runtime,
+        inputs=inputs,
+    )
+    if billing_error:
+        return True, billing_error
 
     if module_ref == "platform/gcp/gke-cluster":
         gke_default_sa_error = _preflight_gke_default_compute_sa(

--- a/hyops/drivers/iac/terragrunt/tests/test_gcp_billing_preflight.py
+++ b/hyops/drivers/iac/terragrunt/tests/test_gcp_billing_preflight.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.drivers.iac.terragrunt._internal.preflight import _preflight_gcp_billing
+
+
+class GcpBillingPreflightTest(TestCase):
+    @patch(
+        "hyops.drivers.iac.terragrunt._internal.preflight.diagnose_project_billing",
+        return_value=(True, True, ""),
+    )
+    def test_apply_allows_enabled_billing(self, diagnose):
+        error = _preflight_gcp_billing(
+            lifecycle_command="apply",
+            module_ref="platform/gcp/lab-network",
+            profile_ref="gcp@v1.0",
+            runtime={},
+            inputs={"project_id": "student-project"},
+        )
+        self.assertEqual(error, "")
+        diagnose.assert_called_once_with("student-project")
+
+    @patch(
+        "hyops.drivers.iac.terragrunt._internal.preflight.diagnose_project_billing",
+        return_value=(True, False, "billing disabled"),
+    )
+    def test_apply_blocks_disabled_billing(self, _diagnose):
+        error = _preflight_gcp_billing(
+            lifecycle_command="apply",
+            module_ref="platform/gcp/lab-network",
+            profile_ref="gcp@v1.0",
+            runtime={},
+            inputs={"project_id": "student-project"},
+        )
+        self.assertIn("billing is not enabled", error)
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight.diagnose_project_billing")
+    def test_destroy_skips_billing_check(self, diagnose):
+        error = _preflight_gcp_billing(
+            lifecycle_command="destroy",
+            module_ref="platform/gcp/lab-network",
+            profile_ref="gcp@v1.0",
+            runtime={},
+            inputs={"project_id": "student-project"},
+        )
+        self.assertEqual(error, "")
+        diagnose.assert_not_called()
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight.diagnose_project_billing")
+    def test_non_gcp_profile_skips_billing_check(self, diagnose):
+        error = _preflight_gcp_billing(
+            lifecycle_command="apply",
+            module_ref="platform/onprem/platform-vm",
+            profile_ref="proxmox@v1.0",
+            runtime={},
+            inputs={},
+        )
+        self.assertEqual(error, "")
+        diagnose.assert_not_called()

--- a/hyops/init/targets/gcp.py
+++ b/hyops/init/targets/gcp.py
@@ -25,6 +25,7 @@ from hyops.init.shared_args import add_init_shared_args
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.gcp import (
     diagnose_billing_association_permission,
+    diagnose_project_billing,
     diagnose_private_service_access_permissions,
     normalize_billing_account_id,
 )
@@ -618,6 +619,23 @@ def run(ns) -> int:
             print(f"run record: {evidence_dir}")
             return OPERATOR_ERROR
 
+    billing_validated = False
+    billing_enabled = False
+    if project_access_validated:
+        billing_validated, billing_enabled, billing_detail = diagnose_project_billing(project_id)
+        if not billing_validated:
+            print(f"ERR: could not validate billing for GCP project {project_id}")
+            if billing_detail:
+                print(f"detail: {billing_detail}")
+            print("hint: confirm the active gcloud identity can view project billing, then re-run init.")
+            print(f"run record: {evidence_dir}")
+            return OPERATOR_ERROR
+        if not billing_enabled:
+            print(f"ERR: billing is not enabled for GCP project {project_id}")
+            print("hint: enable billing in Google Cloud, then re-run init before deploying resources.")
+            print(f"run record: {evidence_dir}")
+            return OPERATOR_ERROR
+
     if adc_quota_project_id:
         run_capture(
             ["gcloud", "auth", "application-default", "set-quota-project", adc_quota_project_id],
@@ -782,6 +800,8 @@ def run(ns) -> int:
                     "impersonation_validated": bool(impersonation_validated),
                     "project_access_validated": bool(project_access_validated),
                     "project_bootstrap_pending": bool(project_bootstrap_pending),
+                    "billing_validated": bool(billing_validated),
+                    "billing_enabled": bool(billing_enabled),
                     "ssh_public_key": ssh_public_key,
                     "eso_sa_email": eso_sa_email,
                 },

--- a/hyops/runtime/gcp.py
+++ b/hyops/runtime/gcp.py
@@ -29,6 +29,35 @@ def _gcloud_capture(argv: list[str]) -> tuple[int, str, str]:
     return int(proc.returncode), str(proc.stdout or "").strip(), str(proc.stderr or "").strip()
 
 
+def diagnose_project_billing(project_id: str | None) -> tuple[bool, bool, str]:
+    """Return whether project billing was validated and whether it is enabled."""
+
+    target_project_id = str(project_id or "").strip()
+    if not target_project_id:
+        return False, False, "project id is missing"
+
+    rc, stdout, stderr = _gcloud_capture(
+        [
+            "gcloud",
+            "billing",
+            "projects",
+            "describe",
+            target_project_id,
+            "--format=value(billingEnabled)",
+        ]
+    )
+    if rc != 0:
+        detail = stderr or stdout or "billing status query failed"
+        return False, False, detail
+
+    value = stdout.strip().lower()
+    if value == "true":
+        return True, True, ""
+    if value == "false":
+        return True, False, f"billing is not enabled for project {target_project_id}"
+    return False, False, f"unexpected billingEnabled value for project {target_project_id}: {stdout!r}"
+
+
 def _test_billing_permission_with_token(token: str, billing_account_id: str, permission: str) -> tuple[bool, str]:
     body = json.dumps({"permissions": [permission]}).encode("utf-8")
     req = urllib.request.Request(

--- a/hyops/runtime/tests/__init__.py
+++ b/hyops/runtime/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for shared runtime helpers."""

--- a/hyops/runtime/tests/test_gcp.py
+++ b/hyops/runtime/tests/test_gcp.py
@@ -1,0 +1,32 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.runtime.gcp import diagnose_project_billing
+
+
+class ProjectBillingTest(TestCase):
+    @patch("hyops.runtime.gcp._gcloud_capture", return_value=(0, "True", ""))
+    def test_enabled(self, capture):
+        self.assertEqual(diagnose_project_billing("student-project"), (True, True, ""))
+        capture.assert_called_once()
+
+    @patch("hyops.runtime.gcp._gcloud_capture", return_value=(0, "False", ""))
+    def test_disabled(self, _capture):
+        validated, enabled, detail = diagnose_project_billing("student-project")
+        self.assertTrue(validated)
+        self.assertFalse(enabled)
+        self.assertIn("not enabled", detail)
+
+    @patch("hyops.runtime.gcp._gcloud_capture", return_value=(1, "", "permission denied"))
+    def test_inaccessible(self, _capture):
+        self.assertEqual(
+            diagnose_project_billing("student-project"),
+            (False, False, "permission denied"),
+        )
+
+    @patch("hyops.runtime.gcp._gcloud_capture", return_value=(0, "unknown", ""))
+    def test_malformed(self, _capture):
+        validated, enabled, detail = diagnose_project_billing("student-project")
+        self.assertFalse(validated)
+        self.assertFalse(enabled)
+        self.assertIn("unexpected billingEnabled value", detail)

--- a/modules/platform/gcp/lab-network/README.md
+++ b/modules/platform/gcp/lab-network/README.md
@@ -11,6 +11,8 @@ contract.
 
 - `hyops init gcp --env <env>` is ready.
 - The selected project has billing enabled and the required Compute Engine APIs.
+  GCP init and module preflight validate billing before create/update operations;
+  destroy remains available when billing is disabled.
 - The operator can create VPC, firewall, router, and NAT resources.
 
 ## Security boundary


### PR DESCRIPTION
Closes #44

## What changed

- check project billing readiness during GCP init
- enforce the same check before GCP Terraform create and update operations
- distinguish enabled, disabled, inaccessible and malformed responses
- skip the billing gate for destroy
- record only boolean readiness and add focused runtime/driver tests

## Why

An existing project could appear ready and fail only when the provider attempted to create resources. The earlier gate gives a novice operator a direct explanation while ensuring billing state can never block cleanup.

## Validation

- `python3 -m unittest hyops.runtime.tests.test_gcp hyops.drivers.iac.terragrunt.tests.test_gcp_billing_preflight`
- live init against the packaged Mac/GCP acceptance environment
- successful five-stage deploy, rebuild and destroy paths during acceptance testing