### PR TITLE
Prevent implicit Proxmox API token rotation

### DIFF
--- a/hyops/assets/init/proxmox/bootstrap-proxmox-remote.sh
+++ b/hyops/assets/init/proxmox/bootstrap-proxmox-remote.sh
@@ -46,6 +46,11 @@ if [[ -n "${SKIP_TOKEN_GEN:-}" ]]; then
   log_info "SKIP_TOKEN_GEN set; reusing existing vault secret"
 else
   if pveum user token list "${USER_FQ}" --output-format json 2>/dev/null | grep -q "\"tokenid\":\"${TOKEN_NAME}\""; then
+    if [[ "${ALLOW_TOKEN_ROTATION:-}" != "1" ]]; then
+      log_error "Token ${TOKEN_ID} already exists and rotation was not authorised"
+      log_error "Choose a different token name or re-run with explicit --force authority"
+      exit 3
+    fi
     log_info "Rotating token"
     pveum user token remove "${USER_FQ}" "${TOKEN_NAME}" 2>/dev/null || true
   fi

--- a/hyops/init/targets/proxmox.py
+++ b/hyops/init/targets/proxmox.py
@@ -540,6 +540,14 @@ def _bootstrap_ssh_opts(values: dict[str, str]) -> list[str]:
     return ["-i", str(resolved), *opts]
 
 
+def _remote_token_controls(*, token_secret: str, force: bool) -> list[str]:
+    if force:
+        return ["ALLOW_TOKEN_ROTATION=1"]
+    if token_secret:
+        return ["SKIP_TOKEN_GEN=1"]
+    return []
+
+
 def _write_tfvars(
     path: Path,
     values: dict[str, str],
@@ -922,8 +930,10 @@ def run(ns) -> int:
             f"FALLBACK_STORAGE_SNIPPETS={shlex.quote(values['fallback_storage_snippets'])}",
             f"FALLBACK_BRIDGE={shlex.quote(values['fallback_bridge'])}",
         ]
-        if token_secret and not bool(getattr(ns, "force", False)):
-            env_parts.insert(0, "SKIP_TOKEN_GEN=1")
+        env_parts[0:0] = _remote_token_controls(
+            token_secret=token_secret,
+            force=bool(getattr(ns, "force", False)),
+        )
 
         ssh_cmd = [
             "ssh",
@@ -939,6 +949,12 @@ def run(ns) -> int:
         )
 
         if ssh_res.rc != 0:
+            remote_detail = f"{ssh_res.stdout or ''}\n{ssh_res.stderr or ''}"
+            if "already exists and rotation was not authorised" in remote_detail:
+                print(f"ERR: Proxmox token {token_id} already exists, but its secret is not available locally.")
+                print("hint: choose a different token_name for this workstation.")
+                print("hint: use --force only to deliberately replace the token and invalidate its current users.")
+                return SECRETS_FAILED
             print("remote bootstrap failed; see evidence")
             return REMOTE_FAILED
 

--- a/hyops/init/tests/__init__.py
+++ b/hyops/init/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for provider initialisation targets."""

--- a/hyops/init/tests/test_proxmox.py
+++ b/hyops/init/tests/test_proxmox.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from hyops.init.targets.proxmox import _remote_token_controls
+
+
+class ProxmoxTokenRotationTest(unittest.TestCase):
+    def test_known_secret_reuses_token(self):
+        self.assertEqual(
+            _remote_token_controls(token_secret="known", force=False),
+            ["SKIP_TOKEN_GEN=1"],
+        )
+
+    def test_force_explicitly_allows_rotation(self):
+        self.assertEqual(
+            _remote_token_controls(token_secret="", force=True),
+            ["ALLOW_TOKEN_ROTATION=1"],
+        )
+
+    def test_unknown_existing_token_is_not_rotated(self):
+        script = (
+            Path(__file__).parents[2]
+            / "assets"
+            / "init"
+            / "proxmox"
+            / "bootstrap-proxmox-remote.sh"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_pveum = Path(tmp) / "pveum"
+            fake_pveum.write_text(
+                """#!/usr/bin/env bash
+if [[ "$*" == *"user list"* ]]; then
+  printf '%s\n' '[{"userid":"automation@pam"}]'
+elif [[ "$*" == *"token list"* ]]; then
+  printf '%s\n' '[{"tokenid":"infra-token"}]'
+else
+  exit 99
+fi
+""",
+                encoding="utf-8",
+            )
+            fake_pveum.chmod(0o755)
+            fake_pvesh = Path(tmp) / "pvesh"
+            fake_pvesh.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
+            fake_pvesh.chmod(0o755)
+            env = dict(os.environ)
+            env.update(
+                {
+                    "PATH": f"{tmp}:{env['PATH']}",
+                    "USER_FQ": "automation@pam",
+                    "TOKEN_NAME": "infra-token",
+                }
+            )
+            result = subprocess.run(
+                ["bash", str(script)],
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 3)
+        self.assertIn("rotation was not authorised", result.stderr)
+        self.assertNotIn("Rotating token", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #53

## What changed

- refuse to remove an existing Proxmox API token unless rotation is explicitly authorised
- send remote rotation authority only when the operator uses `--force`
- continue reusing an existing token when its secret is already available and validated locally
- report a token-name collision with safe remediation for another workstation
- enforce the same guard inside the remote bootstrap script

## Why

Proxmox cannot reveal an existing token secret after creation. A second workstation using the same token name could therefore rotate the token silently and invalidate every current consumer of its old secret.

## Validation

- focused tests for reuse, explicit rotation and collision refusal
- remote-script syntax check
- Ruff on the changed Python files
- diff-format check