### PR TITLE
Guide first-time Proxmox SSH key onboarding

### DIFF
--- a/hyops/init/targets/proxmox.py
+++ b/hyops/init/targets/proxmox.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import re
 import shlex
 import shutil
+import subprocess
+import sys
 from urllib.parse import urlparse
 
 from hyops.runtime.config import write_template_if_missing
@@ -540,6 +542,96 @@ def _bootstrap_ssh_opts(values: dict[str, str]) -> list[str]:
     return ["-i", str(resolved), *opts]
 
 
+def _bootstrap_public_key_path(values: dict[str, str]) -> Path | None:
+    configured = str(values.get("ssh_public_key") or "").strip()
+    if configured:
+        candidate = Path(configured).expanduser()
+        if candidate.is_file():
+            return candidate
+    private_key = str(values.get("ssh_private_key") or "").strip()
+    if not private_key:
+        return None
+    candidate = Path(f"{Path(private_key).expanduser()}.pub")
+    return candidate if candidate.is_file() else None
+
+
+def _ensure_bootstrap_ssh_access(
+    values: dict[str, str],
+    *,
+    evidence_dir: Path,
+    non_interactive: bool,
+) -> bool:
+    ssh_username = (values.get("ssh_username") or "root").strip() or "root"
+    target = f"{ssh_username}@{values['host']}"
+    ssh_probe = ["ssh", *_bootstrap_ssh_opts(values), target, "true"]
+    first = run_capture(
+        ssh_probe,
+        evidence_dir=evidence_dir,
+        label="ssh_key_preflight",
+        timeout_s=30,
+        redact=True,
+    )
+    if first.rc == 0:
+        return True
+
+    public_key = _bootstrap_public_key_path(values)
+    command_hint = (
+        f"ssh-copy-id -i {shlex.quote(str(public_key))} {shlex.quote(target)}"
+        if public_key
+        else f"ssh-copy-id {shlex.quote(target)}"
+    )
+    if non_interactive or not (sys.stdin.isatty() and sys.stdout.isatty()):
+        print(f"ERR: Proxmox key authentication failed for {target}.")
+        print(f"hint: run: {command_hint}")
+        print(f"run record: {evidence_dir}")
+        return False
+    if public_key is None:
+        print("ERR: no SSH public key file was found for the configured private key.")
+        print("hint: create the matching .pub file or set ssh_public_key to its path.")
+        print(f"run record: {evidence_dir}")
+        return False
+    if not _need_cmd("ssh-copy-id"):
+        print("ERR: ssh-copy-id is required for first-time Proxmox key authorisation.")
+        print(f"hint: run manually: {command_hint}")
+        print(f"run record: {evidence_dir}")
+        return False
+
+    print(f"Proxmox key authentication is not configured for {target}.")
+    try:
+        answer = input(f"Install {public_key} using ssh-copy-id? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        print(f"run record: {evidence_dir}")
+        return False
+    if answer not in {"y", "yes"}:
+        print("SSH key installation declined; Proxmox was not changed.")
+        print(f"run record: {evidence_dir}")
+        return False
+
+    copy_result = subprocess.run(
+        ["ssh-copy-id", "-i", str(public_key), target],
+        check=False,
+    )
+    if copy_result.returncode != 0:
+        print("ERR: ssh-copy-id failed; key-only Proxmox access is still unavailable.")
+        print(f"run record: {evidence_dir}")
+        return False
+
+    retry = run_capture(
+        ssh_probe,
+        evidence_dir=evidence_dir,
+        label="ssh_key_preflight_retry",
+        timeout_s=30,
+        redact=True,
+    )
+    if retry.rc != 0:
+        print("ERR: Proxmox key authentication still fails after ssh-copy-id.")
+        print(f"run record: {evidence_dir}")
+        return False
+    print("Proxmox key authentication ready")
+    return True
+
+
 def _write_tfvars(
     path: Path,
     values: dict[str, str],
@@ -878,6 +970,12 @@ def run(ns) -> int:
         return OK
 
     if want_remote:
+        if not _ensure_bootstrap_ssh_access(
+            values,
+            evidence_dir=evidence_dir,
+            non_interactive=bool(getattr(ns, "non_interactive", False)),
+        ):
+            return REMOTE_FAILED
         remote_dst = f"{ssh_username}@{values['host']}:{_REMOTE_BOOTSTRAP_DEST}"
 
         if getattr(ns, "remote_bootstrap", None):

--- a/hyops/init/tests/__init__.py
+++ b/hyops/init/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for provider initialisation targets."""

--- a/hyops/init/tests/test_proxmox_ssh.py
+++ b/hyops/init/tests/test_proxmox_ssh.py
@@ -1,0 +1,107 @@
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hyops.init.targets.proxmox import _ensure_bootstrap_ssh_access
+
+
+class ProxmoxSshOnboardingTest(unittest.TestCase):
+    def _values(self, root: Path):
+        private_key = root / "id_ed25519"
+        public_key = root / "id_ed25519.pub"
+        private_key.write_text("private-test-placeholder", encoding="utf-8")
+        public_key.write_text("ssh-ed25519 test", encoding="utf-8")
+        return {
+            "host": "192.0.2.10",
+            "ssh_username": "root",
+            "ssh_private_key": str(private_key),
+            "ssh_public_key": "",
+        }
+
+    def test_existing_key_access_needs_no_onboarding(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            values = self._values(Path(tmp))
+            with patch(
+                "hyops.init.targets.proxmox.run_capture",
+                return_value=SimpleNamespace(rc=0),
+            ) as probe:
+                result = _ensure_bootstrap_ssh_access(
+                    values,
+                    evidence_dir=Path(tmp),
+                    non_interactive=False,
+                )
+        self.assertTrue(result)
+        self.assertEqual(probe.call_count, 1)
+
+    def test_non_interactive_failure_prints_remediation(self):
+        output = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmp:
+            values = self._values(Path(tmp))
+            with (
+                patch("hyops.init.targets.proxmox.run_capture", return_value=SimpleNamespace(rc=255)),
+                patch("sys.stdout", output),
+            ):
+                result = _ensure_bootstrap_ssh_access(
+                    values,
+                    evidence_dir=Path(tmp),
+                    non_interactive=True,
+                )
+        self.assertFalse(result)
+        self.assertIn("ssh-copy-id", output.getvalue())
+        self.assertIn("run record:", output.getvalue())
+
+    def test_interactive_onboarding_retries_key_access(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            values = self._values(Path(tmp))
+            terminal = io.StringIO()
+            terminal.isatty = lambda: True
+            with (
+                patch(
+                    "hyops.init.targets.proxmox.run_capture",
+                    side_effect=[SimpleNamespace(rc=255), SimpleNamespace(rc=0)],
+                ) as probe,
+                patch("hyops.init.targets.proxmox._need_cmd", return_value=True),
+                patch("hyops.init.targets.proxmox.sys.stdin", terminal),
+                patch("hyops.init.targets.proxmox.sys.stdout", terminal),
+                patch("builtins.input", return_value="y"),
+                patch(
+                    "hyops.init.targets.proxmox.subprocess.run",
+                    return_value=SimpleNamespace(returncode=0),
+                ) as copy_id,
+            ):
+                result = _ensure_bootstrap_ssh_access(
+                    values,
+                    evidence_dir=Path(tmp),
+                    non_interactive=False,
+                )
+        self.assertTrue(result)
+        self.assertEqual(probe.call_count, 2)
+        copy_id.assert_called_once()
+
+    def test_declining_onboarding_makes_no_remote_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            values = self._values(Path(tmp))
+            terminal = io.StringIO()
+            terminal.isatty = lambda: True
+            with (
+                patch("hyops.init.targets.proxmox.run_capture", return_value=SimpleNamespace(rc=255)),
+                patch("hyops.init.targets.proxmox._need_cmd", return_value=True),
+                patch("hyops.init.targets.proxmox.sys.stdin", terminal),
+                patch("hyops.init.targets.proxmox.sys.stdout", terminal),
+                patch("builtins.input", return_value="n"),
+                patch("hyops.init.targets.proxmox.subprocess.run") as copy_id,
+            ):
+                result = _ensure_bootstrap_ssh_access(
+                    values,
+                    evidence_dir=Path(tmp),
+                    non_interactive=False,
+                )
+        self.assertFalse(result)
+        copy_id.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #55

## What changed

- test key-only Proxmox SSH before attempting SCP
- offer `ssh-copy-id` during an interactive first-time init
- leave password entry directly between `ssh-copy-id` and the terminal
- retry key-only SSH automatically before continuing bootstrap
- print the exact remediation command and run-record path in non-interactive mode
- avoid any remote change when the operator declines

## Why

First-time consumers could authenticate with a password manually but HybridOps failed later at SCP because its bootstrap correctly requires non-interactive key access. The failure did not explain the missing authorisation step.

## Validation

- focused tests for existing access, interactive onboarding, refusal and non-interactive failure
- Ruff on the changed Python files
- diff-format check
- reproduced from the packaged Apple Silicon consumer path against the existing Proxmox host