### PR TITLE
Make Proxmox workstation address detection portable

### DIFF
--- a/hyops/init/targets/proxmox.py
+++ b/hyops/init/targets/proxmox.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import re
 import shlex
 import shutil
+import socket
 from urllib.parse import urlparse
 
 from hyops.runtime.config import write_template_if_missing
@@ -132,30 +133,29 @@ def _read_first_pubkey() -> str:
 
 
 def _detect_workstation_ip(target_host: str) -> str:
-    r = run_proc(["ip", "route", "get", target_host], timeout_s=5)
-    if r.rc == 0:
-        m = re.search(r"\bsrc\s+([0-9.]+)\b", r.stdout or "")
-        if m:
-            return m.group(1)
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as route:
+            route.connect((target_host, 9))
+            selected = str(route.getsockname()[0] or "").strip()
+            if selected and selected != "0.0.0.0":
+                return selected
+    except OSError:
+        pass
 
-    r = run_proc(["hostname", "-I"], timeout_s=5)
-    if r.rc == 0:
-        parts = (r.stdout or "").strip().split()
-        if parts:
-            return parts[0]
+    if _need_cmd("ip"):
+        r = run_proc(["ip", "route", "get", target_host], timeout_s=5)
+        if r.rc == 0:
+            m = re.search(r"\bsrc\s+([0-9.]+)\b", r.stdout or "")
+            if m:
+                return m.group(1)
+
+    if _need_cmd("hostname"):
+        r = run_proc(["hostname", "-I"], timeout_s=5)
+        if r.rc == 0:
+            parts = (r.stdout or "").strip().split()
+            if parts:
+                return parts[0]
     return ""
-
-
-def _local_ipv4_addresses() -> set[str]:
-    r = run_proc(["ip", "-4", "-o", "addr", "show", "scope", "global"], timeout_s=5)
-    if r.rc != 0:
-        return set()
-    ips: set[str] = set()
-    for raw in (r.stdout or "").splitlines():
-        m = re.search(r"\binet\s+([0-9.]+)/\d+\b", raw)
-        if m:
-            ips.add(m.group(1))
-    return ips
 
 
 def _is_valid_http_bind_address(value: str) -> bool:
@@ -164,7 +164,12 @@ def _is_valid_http_bind_address(value: str) -> bool:
         return False
     if addr == "0.0.0.0":
         return True
-    return addr in _local_ipv4_addresses()
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind((addr, 0))
+    except OSError:
+        return False
+    return True
 
 
 def _parse_exports(text: str) -> dict[str, str]:

--- a/hyops/init/tests/__init__.py
+++ b/hyops/init/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for provider initialisation targets."""

--- a/hyops/init/tests/test_proxmox_address.py
+++ b/hyops/init/tests/test_proxmox_address.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch
+
+from hyops.init.targets.proxmox import (
+    _detect_workstation_ip,
+    _is_valid_http_bind_address,
+)
+
+
+class _RouteSocket:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def connect(self, target):
+        self.target = target
+
+    def getsockname(self):
+        return ("192.168.0.50", 49152)
+
+
+class ProxmoxWorkstationAddressTest(unittest.TestCase):
+    def test_detects_operating_system_route_without_ip_command(self):
+        route = _RouteSocket()
+        with patch("hyops.init.targets.proxmox.socket.socket", return_value=route):
+            detected = _detect_workstation_ip("192.168.0.27")
+
+        self.assertEqual(detected, "192.168.0.50")
+        self.assertEqual(route.target, ("192.168.0.27", 9))
+
+    def test_loopback_is_a_valid_local_bind_address(self):
+        self.assertTrue(_is_valid_http_bind_address("127.0.0.1"))
+
+    def test_unassigned_address_is_not_a_valid_bind_address(self):
+        self.assertFalse(_is_valid_http_bind_address("192.0.2.123"))
+
+    def test_wildcard_remains_valid(self):
+        self.assertTrue(_is_valid_http_bind_address("0.0.0.0"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #57

## What changed

- detect the workstation source address from the operating system's socket route
- retain guarded Linux command fallbacks
- validate explicit bind addresses by attempting a local socket bind
- avoid invoking optional commands that are not installed
- add platform-neutral detection and validation tests

## Why

Proxmox init completed SSH onboarding and token bootstrap on macOS, then crashed while running Linux-only `ip route`. Address detection is required before credentials and readiness are written.

## Validation

- focused tests for route selection, local binding, unassigned addresses and wildcard binding
- Ruff on the changed Python files
- diff-format check
- failure reproduced from the packaged Apple Silicon consumer flow