### PR TITLE
Make Proxmox template preflight portable

### DIFF
--- a/hyops/drivers/images/packer/driver.py
+++ b/hyops/drivers/images/packer/driver.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import socket
 import time
 from pathlib import Path
 from typing import Any
@@ -85,25 +86,18 @@ def _as_dict(value: Any) -> dict[str, Any]:
     return {}
 
 
-def _local_ipv4_addresses() -> set[str]:
-    r = _run_proc(["ip", "-4", "-o", "addr", "show", "scope", "global"], timeout_s=5)
-    if r.rc != 0:
-        return set()
-    ips: set[str] = set()
-    for raw in (r.stdout or "").splitlines():
-        m = re.search(r"\binet\s+([0-9.]+)/\d+\b", raw)
-        if m:
-            ips.add(m.group(1))
-    return ips
-
-
 def _http_bind_address_is_valid(value: str) -> bool:
     addr = str(value or "").strip()
     if not addr:
         return False
     if addr == "0.0.0.0":
         return True
-    return addr in _local_ipv4_addresses()
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind((addr, 0))
+    except OSError:
+        return False
+    return True
 
 
 def _parse_proxmox_host(proxmox_url: str) -> str:
@@ -120,17 +114,28 @@ def _parse_proxmox_host(proxmox_url: str) -> str:
 def _detect_workstation_ip(target_host: str) -> str:
     host = str(target_host or "").strip()
     if host:
-        r = _run_proc(["ip", "route", "get", host], timeout_s=5)
-        if r.rc == 0:
-            m = re.search(r"\bsrc\s+([0-9.]+)\b", r.stdout or "")
-            if m:
-                return m.group(1)
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as route:
+                route.connect((host, 9))
+                selected = str(route.getsockname()[0] or "").strip()
+                if selected and selected != "0.0.0.0":
+                    return selected
+        except OSError:
+            pass
 
-    r = _run_proc(["hostname", "-I"], timeout_s=5)
-    if r.rc == 0:
-        parts = (r.stdout or "").strip().split()
-        if parts:
-            return parts[0]
+        if shutil.which("ip"):
+            r = _run_proc(["ip", "route", "get", host], timeout_s=5)
+            if r.rc == 0:
+                m = re.search(r"\bsrc\s+([0-9.]+)\b", r.stdout or "")
+                if m:
+                    return m.group(1)
+
+    if shutil.which("hostname"):
+        r = _run_proc(["hostname", "-I"], timeout_s=5)
+        if r.rc == 0:
+            parts = (r.stdout or "").strip().split()
+            if parts:
+                return parts[0]
     return ""
 
 

--- a/hyops/drivers/images/packer/tests/__init__.py
+++ b/hyops/drivers/images/packer/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Packer image driver."""

--- a/hyops/drivers/images/packer/tests/test_proxmox_address.py
+++ b/hyops/drivers/images/packer/tests/test_proxmox_address.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch
+
+from hyops.drivers.images.packer.driver import (
+    _detect_workstation_ip,
+    _http_bind_address_is_valid,
+)
+
+
+class _RouteSocket:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def connect(self, target):
+        self.target = target
+
+    def getsockname(self):
+        return ("192.168.0.50", 49152)
+
+
+class ProxmoxPackerAddressTest(unittest.TestCase):
+    def test_detects_operating_system_route_without_ip_command(self):
+        route = _RouteSocket()
+        with patch("hyops.drivers.images.packer.driver.socket.socket", return_value=route):
+            detected = _detect_workstation_ip("192.168.0.27")
+        self.assertEqual(detected, "192.168.0.50")
+        self.assertEqual(route.target, ("192.168.0.27", 9))
+
+    def test_loopback_is_a_valid_local_bind_address(self):
+        self.assertTrue(_http_bind_address_is_valid("127.0.0.1"))
+
+    def test_unassigned_address_is_not_a_valid_bind_address(self):
+        self.assertFalse(_http_bind_address_is_valid("192.0.2.123"))
+
+    def test_wildcard_remains_valid(self):
+        self.assertTrue(_http_bind_address_is_valid("0.0.0.0"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #59

## What changed

- detect the workstation source address from the operating system socket route
- validate local bind addresses through a socket bind
- retain guarded Linux command fallbacks
- avoid invoking optional commands that are not installed
- add focused Packer-driver regression tests

## Why

The packaged Proxmox init path completed on macOS, but `onprem/eve-ng@v1` preflight then failed because the template-image driver invoked the Linux-only `ip` command.

## Operator impact

Template preflight now uses the same platform-neutral address selection principle as Proxmox init. Linux fallbacks remain available without being required on macOS.

## Validation

- four focused route and bind-address tests
- successful packaged Apple Silicon Proxmox blueprint preflight
- full fresh-template EVE-NG deployment completed during consumer acceptance
- diff-format check