### PR TITLE
Add concise lifecycle progress

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -14,6 +14,7 @@ from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
+from hyops.runtime.progress import ProgressDisplay
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.source_roots import resolve_blueprints_root
 
@@ -576,6 +577,14 @@ def run_deploy(ns) -> int:
     required_failures: list[str] = []
     optional_failures: list[str] = []
     cancelled = False
+    progress = ProgressDisplay(
+        enabled=bool(
+            sys.stdout
+            and sys.stdout.isatty()
+            and not json_mode
+            and not os.getenv("HYOPS_VERBOSE")
+        )
+    )
 
     for step_id in payload["order"]:
         step = by_id[step_id]
@@ -615,7 +624,13 @@ def run_deploy(ns) -> int:
                     result = dict(base)
                     result.update({"status": "skipped", "reason": "state-ok", "rc": 0})
                     step_results.append(result)
-                    print(f"step={step_id} status=skipped reason=state-ok")
+                    progress.finish(
+                        step_id,
+                        step_id,
+                        "skipped",
+                        plain=f"step={step_id} status=skipped reason=state-ok",
+                        detail="state-ok",
+                    )
                     continue
 
                 try:
@@ -631,7 +646,13 @@ def run_deploy(ns) -> int:
                     result = dict(base)
                     result.update({"status": "skipped", "reason": detail, "rc": 0})
                     step_results.append(result)
-                    print(f"step={step_id} status=skipped reason={detail}")
+                    progress.finish(
+                        step_id,
+                        step_id,
+                        "skipped",
+                        plain=f"step={step_id} status=skipped reason={detail}",
+                        detail=detail,
+                    )
                     continue
 
                 if skip_status == "error":
@@ -681,7 +702,17 @@ def run_deploy(ns) -> int:
                 break
             continue
 
-        print(f"step={step_id} status=running action={step['action']} module={step['module_ref']}")
+        progress.start(
+            step_id,
+            step_id,
+            plain=(
+                f"step={step_id} status=running action={step['action']} "
+                f"module={step['module_ref']}"
+            ),
+        )
+        previous_child = os.environ.get("HYOPS_PROGRESS_CHILD")
+        if not os.getenv("HYOPS_VERBOSE"):
+            os.environ["HYOPS_PROGRESS_CHILD"] = "1"
         try:
             rc = run_step_module_command(step, payload, ns, paths)
         except KeyboardInterrupt:
@@ -692,12 +723,17 @@ def run_deploy(ns) -> int:
             err = str(exc)
         else:
             err = ""
+        finally:
+            if previous_child is None:
+                os.environ.pop("HYOPS_PROGRESS_CHILD", None)
+            else:
+                os.environ["HYOPS_PROGRESS_CHILD"] = previous_child
 
         if rc == 0:
             result = dict(base)
             result.update({"status": "ok", "rc": 0})
             step_results.append(result)
-            print(f"step={step_id} status=ok")
+            progress.finish(step_id, step_id, "ok", plain=f"step={step_id} status=ok")
             continue
 
         result = dict(base)
@@ -706,18 +742,35 @@ def run_deploy(ns) -> int:
             result["status"] = "cancelled"
             step_results.append(result)
             cancelled = True
-            print(f"step={step_id} status=cancelled rc={rc}")
+            progress.finish(
+                step_id,
+                step_id,
+                "cancelled",
+                plain=f"step={step_id} status=cancelled rc={rc}",
+            )
             break
         if step["optional"]:
             result["status"] = "failed-optional"
             optional_failures.append(step_id)
             step_results.append(result)
-            print(f"step={step_id} status=failed-optional rc={rc}")
+            progress.finish(
+                step_id,
+                step_id,
+                "failed-optional",
+                plain=f"step={step_id} status=failed-optional rc={rc}",
+            )
             continue
 
         required_failures.append(step_id)
         step_results.append(result)
-        print(f"step={step_id} status=failed rc={rc}")
+        failure_detail = err or "see module run record"
+        progress.finish(
+            step_id,
+            step_id,
+            "failed",
+            plain=f"step={step_id} status=failed rc={rc} reason={failure_detail}",
+            detail=failure_detail,
+        )
         if fail_fast:
             break
 
@@ -845,6 +898,14 @@ def run_destroy(ns) -> int:
     required_failures: list[str] = []
     optional_failures: list[str] = []
     cancelled = False
+    progress = ProgressDisplay(
+        enabled=bool(
+            sys.stdout
+            and sys.stdout.isatty()
+            and not json_mode
+            and not os.getenv("HYOPS_VERBOSE")
+        )
+    )
 
     for step_id in destroy_order:
         step = by_id[step_id]
@@ -867,7 +928,13 @@ def run_destroy(ns) -> int:
             result = dict(base)
             result.update({"status": "skipped", "reason": reason, "rc": 0})
             step_results.append(result)
-            print(f"step={step_id} status=skipped reason={reason}")
+            progress.finish(
+                step_id,
+                step_id,
+                "skipped",
+                plain=f"step={step_id} status=skipped reason={reason}",
+                detail=reason,
+            )
             continue
 
         # Materialize inputs only for a step that still has state to destroy.
@@ -880,7 +947,17 @@ def run_destroy(ns) -> int:
             if inputs_file:
                 base["inputs_file"] = str(inputs_file)
 
-        print(f"step={step_id} status=running action=destroy module={step['module_ref']}")
+        progress.start(
+            step_id,
+            step_id,
+            plain=(
+                f"step={step_id} status=running action=destroy "
+                f"module={step['module_ref']}"
+            ),
+        )
+        previous_child = os.environ.get("HYOPS_PROGRESS_CHILD")
+        if not os.getenv("HYOPS_VERBOSE"):
+            os.environ["HYOPS_PROGRESS_CHILD"] = "1"
         try:
             rc = run_step_module_command(destroy_step, payload, ns, paths)
         except KeyboardInterrupt:
@@ -891,12 +968,17 @@ def run_destroy(ns) -> int:
             err = str(exc)
         else:
             err = ""
+        finally:
+            if previous_child is None:
+                os.environ.pop("HYOPS_PROGRESS_CHILD", None)
+            else:
+                os.environ["HYOPS_PROGRESS_CHILD"] = previous_child
 
         if rc == 0:
             result = dict(base)
             result.update({"status": "ok", "rc": 0})
             step_results.append(result)
-            print(f"step={step_id} status=ok")
+            progress.finish(step_id, step_id, "ok", plain=f"step={step_id} status=ok")
             continue
 
         result = dict(base)
@@ -905,18 +987,35 @@ def run_destroy(ns) -> int:
             result["status"] = "cancelled"
             step_results.append(result)
             cancelled = True
-            print(f"step={step_id} status=cancelled rc={rc}")
+            progress.finish(
+                step_id,
+                step_id,
+                "cancelled",
+                plain=f"step={step_id} status=cancelled rc={rc}",
+            )
             break
         if step["optional"]:
             result["status"] = "failed-optional"
             optional_failures.append(step_id)
             step_results.append(result)
-            print(f"step={step_id} status=failed-optional rc={rc}")
+            progress.finish(
+                step_id,
+                step_id,
+                "failed-optional",
+                plain=f"step={step_id} status=failed-optional rc={rc}",
+            )
             continue
 
         required_failures.append(step_id)
         step_results.append(result)
-        print(f"step={step_id} status=failed rc={rc}")
+        failure_detail = err or "see module run record"
+        progress.finish(
+            step_id,
+            step_id,
+            "failed",
+            plain=f"step={step_id} status=failed rc={rc} reason={failure_detail}",
+            detail=failure_detail,
+        )
         if fail_fast:
             break
 

--- a/hyops/cli.py
+++ b/hyops/cli.py
@@ -80,6 +80,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="hyops", add_help=True)
     p.add_argument("--version", action="store_true", help="Print version and exit.")
     p.add_argument(
+        "-v",
         "--verbose",
         action="store_true",
         help="Stream tool output to terminal while also writing run records.",

--- a/hyops/commands/_apply_execute.py
+++ b/hyops/commands/_apply_execute.py
@@ -4,6 +4,7 @@ Execution path for single-module apply/deploy/plan/validate/destroy/import.
 
 from __future__ import annotations
 
+import os
 import sys
 import yaml
 from datetime import datetime, timezone
@@ -26,6 +27,7 @@ from hyops.runtime.evidence import EvidenceWriter, init_evidence_dir, new_run_id
 from hyops.runtime.exitcodes import CANCELLED
 from hyops.runtime.module_resolve import resolve_module
 from hyops.runtime.module_state import write_module_state
+from hyops.runtime.progress import ProgressDisplay
 from hyops.runtime.stamp import stamp_runtime
 
 
@@ -95,9 +97,26 @@ def run_single(
     evidence_dir = init_evidence_dir(root, run_id)
     ev = EvidenceWriter(evidence_dir)
 
-    print(f"module={module_ref} status=running run_id={run_id}")
-    print(f"run record: {evidence_dir}")
-    print(f"progress: logs={progress_log_hint(driver_ref, evidence_dir)}")
+    child_progress = (
+        str(os.getenv("HYOPS_PROGRESS_CHILD") or "").strip() == "1"
+        and not os.getenv("HYOPS_VERBOSE")
+    )
+    progress = ProgressDisplay(
+        enabled=(
+            not child_progress
+            and bool(sys.stdout and sys.stdout.isatty())
+            and not os.getenv("HYOPS_VERBOSE")
+        )
+    )
+    if not child_progress:
+        progress.start(
+            module_ref,
+            f"{command_name} {module_ref}",
+            plain=f"module={module_ref} status=running run_id={run_id}",
+        )
+        print(f"run record: {evidence_dir}")
+        if not progress.enabled:
+            print(f"progress: logs={progress_log_hint(driver_ref, evidence_dir)}")
 
     def persist_status_error_state(error_message: str) -> None:
         if command_name not in ("apply", "deploy"):
@@ -226,8 +245,16 @@ def run_single(
         ev.write_json("guard_failure.json", {"error": str(exc)})
         persist_status_error_state(str(exc))
         print(f"error: {exc}", file=sys.stderr)
-        print(f"module={module_ref} status=error run_id={run_id}")
-        print(f"run record: {evidence_dir}")
+        if not child_progress:
+            progress.finish(
+                module_ref,
+                f"{command_name} {module_ref}",
+                "error",
+                plain=f"module={module_ref} status=error run_id={run_id}",
+            )
+            print(f"run record: {evidence_dir}")
+        else:
+            print(f"run record: {evidence_dir}", file=sys.stderr)
         return 1
 
     try:
@@ -265,7 +292,8 @@ def run_single(
 
     try:
         if not skip_preflight:
-            print(f"progress: phase=preflight driver={driver_ref}")
+            if not child_progress and not progress.enabled:
+                print(f"progress: phase=preflight driver={driver_ref}")
             preflight_request = dict(request)
             preflight_request["command"] = "preflight"
             preflight_request["lifecycle_command"] = command_name
@@ -280,23 +308,39 @@ def run_single(
                     print(f"error: preflight failed: {preflight_error}", file=sys.stderr)
                 else:
                     print("error: preflight failed", file=sys.stderr)
-                print(f"module={module_ref} status=error run_id={run_id}")
-                print(f"run record: {evidence_dir}")
+                if not child_progress:
+                    progress.finish(
+                        module_ref,
+                        f"{command_name} {module_ref}",
+                        "error",
+                        plain=f"module={module_ref} status=error run_id={run_id}",
+                    )
+                    print(f"run record: {evidence_dir}")
+                else:
+                    print(f"run record: {evidence_dir}", file=sys.stderr)
                 return 1
 
-        print(f"progress: phase={command_name} driver={driver_ref}")
+        if not child_progress and not progress.enabled:
+            print(f"progress: phase={command_name} driver={driver_ref}")
         result = driver_fn(request)
         ev.write_json("result.json", result)
 
         status = str(result.get("status", "unknown")).strip().lower()
-        print(f"module={module_ref} status={status or 'unknown'} run_id={run_id}")
-        print(f"run record: {evidence_dir}")
-
+        if not child_progress:
+            progress.finish(
+                module_ref,
+                f"{command_name} {module_ref}",
+                status or "unknown",
+                plain=f"module={module_ref} status={status or 'unknown'} run_id={run_id}",
+            )
+            print(f"run record: {evidence_dir}")
         if status != "ok":
             err = str(result.get("error") or "").strip()
             persist_status_error_state(err or f"driver returned status={status or 'unknown'}")
             if err:
                 print(f"error: {err}", file=sys.stderr)
+            if child_progress:
+                print(f"run record: {evidence_dir}", file=sys.stderr)
             return 1
     except KeyboardInterrupt:
         ev.write_json(
@@ -309,15 +353,31 @@ def run_single(
                 "reason": "cancelled by user",
             },
         )
-        print(f"module={module_ref} status=cancelled run_id={run_id}")
-        print(f"run record: {evidence_dir}")
+        if not child_progress:
+            progress.finish(
+                module_ref,
+                f"{command_name} {module_ref}",
+                "cancelled",
+                plain=f"module={module_ref} status=cancelled run_id={run_id}",
+            )
+            print(f"run record: {evidence_dir}")
+        else:
+            print(f"run record: {evidence_dir}", file=sys.stderr)
         print("error: cancelled by user", file=sys.stderr)
         return CANCELLED
     except Exception as exc:
         persist_status_error_state(str(exc))
         print(f"error: {exc}", file=sys.stderr)
-        print(f"module={module_ref} status=error run_id={run_id}")
-        print(f"run record: {evidence_dir}")
+        if not child_progress:
+            progress.finish(
+                module_ref,
+                f"{command_name} {module_ref}",
+                "error",
+                plain=f"module={module_ref} status=error run_id={run_id}",
+            )
+            print(f"run record: {evidence_dir}")
+        else:
+            print(f"run record: {evidence_dir}", file=sys.stderr)
         return 1
 
     if command_name in ("apply", "deploy", "destroy", "import"):

--- a/hyops/runtime/proc.py
+++ b/hyops/runtime/proc.py
@@ -270,17 +270,12 @@ def run_capture_stream(
                 return cleaned
         return ""
 
-    if sys.stdout and sys.stdout.isatty():
-        print(
-            f"[hyops] {label}: watch logs: tail -f {progress_path}",
-            file=sys.stdout,
-            flush=True,
-        )
-
     def heartbeat() -> None:
         if interval <= 0:
             return
         if verbose_terminal:
+            return
+        if str(os.getenv("HYOPS_PROGRESS_CHILD") or "").strip() == "1":
             return
         if not sys.stdout or not sys.stdout.isatty():
             return

--- a/hyops/runtime/progress.py
+++ b/hyops/runtime/progress.py
@@ -1,0 +1,69 @@
+"""Concise terminal progress without changing execution or run-record capture."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+
+
+def verbose_enabled() -> bool:
+    return str(os.getenv("HYOPS_VERBOSE") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def concise_enabled() -> bool:
+    return bool(sys.stdout and sys.stdout.isatty() and not verbose_enabled())
+
+
+def _elapsed(started: float) -> str:
+    seconds = max(0, int(time.monotonic() - started))
+    minutes, seconds = divmod(seconds, 60)
+    return f"{minutes}m {seconds:02d}s" if minutes else f"{seconds}s"
+
+
+@dataclass
+class ProgressDisplay:
+    """Render stable plain output or concise interactive status lines."""
+
+    enabled: bool = field(default_factory=concise_enabled)
+    _started: dict[str, float] = field(default_factory=dict)
+
+    def start(self, key: str, label: str, *, plain: str) -> None:
+        self._started[key] = time.monotonic()
+        if self.enabled:
+            print(f"… {label}", flush=True)
+        else:
+            print(plain, flush=True)
+
+    def finish(
+        self,
+        key: str,
+        label: str,
+        status: str,
+        *,
+        plain: str,
+        detail: str = "",
+    ) -> None:
+        started = self._started.pop(key, None)
+        if started is None:
+            started = time.monotonic()
+        if not self.enabled:
+            print(plain, flush=True)
+            return
+        symbol = {
+            "ok": "✓",
+            "skipped": "○",
+            "retained": "○",
+            "cancelled": "!",
+            "failed-optional": "!",
+        }.get(status, "✗")
+        suffix = f"  {_elapsed(started)}"
+        if detail:
+            suffix += f"  {detail}"
+        print(f"{symbol} {label}{suffix}", flush=True)

--- a/hyops/runtime/tests/test_progress.py
+++ b/hyops/runtime/tests/test_progress.py
@@ -1,0 +1,54 @@
+"""Tests for terminal progress selection and stable output."""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from hyops.runtime.progress import ProgressDisplay, concise_enabled
+
+
+class _Stream(io.StringIO):
+    def __init__(self, tty: bool) -> None:
+        super().__init__()
+        self.tty = tty
+
+    def isatty(self) -> bool:
+        return self.tty
+
+
+class ProgressDisplayTests(unittest.TestCase):
+    def test_non_tty_uses_stable_plain_lines(self) -> None:
+        output = _Stream(False)
+        display = ProgressDisplay(enabled=False)
+        with redirect_stdout(output):
+            display.start("network", "Network", plain="step=network status=running")
+            display.finish("network", "Network", "ok", plain="step=network status=ok")
+        self.assertEqual(
+            output.getvalue().splitlines(),
+            ["step=network status=running", "step=network status=ok"],
+        )
+
+    def test_tty_uses_concise_status(self) -> None:
+        output = _Stream(True)
+        display = ProgressDisplay(enabled=True)
+        with redirect_stdout(output), patch(
+            "hyops.runtime.progress.time.monotonic", side_effect=[10.0, 15.0]
+        ):
+            display.start("network", "Network", plain="ignored")
+            display.finish("network", "Network", "ok", plain="ignored")
+        self.assertEqual(output.getvalue().splitlines(), ["… Network", "✓ Network  5s"])
+
+    def test_verbose_disables_concise_output(self) -> None:
+        output = _Stream(True)
+        with patch("hyops.runtime.progress.sys.stdout", output), patch.dict(
+            os.environ, {"HYOPS_VERBOSE": "1"}
+        ):
+            self.assertFalse(concise_enabled())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #38

## What changed

- show concise elapsed step progress on interactive terminals
- keep stable line-oriented output for redirected and CI runs
- make `-v` and `--verbose` stream complete nested output
- suppress duplicate child lifecycle lines while retaining run records
- include the failure reason and module run-record path

## Validation

- `bash tools/ci/check-python.sh`
- focused progress and resumable-destroy tests
