### PR TITLE
Check blueprint secrets before deferred steps

### DIFF
--- a/hyops/blueprint/planner.py
+++ b/hyops/blueprint/planner.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import argparse
 import os
+from pathlib import Path
 from typing import Any
 
+from hyops.drivers.config.ansible.config import resolve_required_env
+from hyops.drivers.config.ansible.runtime_env import merge_vault_env, missing_env
 from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.module_resolve import resolve_module
 from hyops.runtime.source_roots import resolve_module_root
@@ -18,6 +21,31 @@ from .contracts import (
     resolved_step_inputs_file,
     step_state_ref,
 )
+
+
+def _required_env_error(
+    *, inputs: dict[str, Any], action: str, env_name: str, runtime_root: Path
+) -> str:
+    key = "required_env_destroy" if action == "destroy" else "required_env"
+    required, config_error = resolve_required_env(inputs, key=key)
+    if config_error:
+        return config_error
+    if not required:
+        return ""
+
+    env = {str(k): str(v) for k, v in os.environ.items()}
+    _, vault_error = merge_vault_env(env, runtime_root)
+    missing = sorted(missing_env(env, required))
+    if not missing:
+        return ""
+
+    names = ", ".join(missing)
+    hint = f"missing required env vars: {names}. "
+    if vault_error:
+        hint += f"{vault_error}. "
+    hint += "Generate them before deployment: "
+    hint += f"hyops secrets ensure --env {env_name or '<env>'} " + " ".join(missing)
+    return hint
 
 
 def run_step_module_command(step: dict[str, Any], payload: dict[str, Any], ns, paths) -> int:
@@ -164,28 +192,6 @@ def preflight_step(
         result["checks"].append({"name": "contracts", "ok": False, "detail": str(exc)})
         return result
 
-    if deferred_driver_preflight_refs:
-        refs = ", ".join(sorted(deferred_driver_preflight_refs))
-        result["checks"].append(
-            {
-                "name": "module_resolve",
-                "ok": True,
-                "detail": f"deferred until upstream blueprint state exists: {refs}",
-            }
-        )
-        result["checks"].append(
-            {
-                "name": "module_preflight",
-                "ok": True,
-                "detail": f"deferred until upstream blueprint state exists: {refs}",
-            }
-        )
-        result["driver_preflight"] = {
-            "status": "deferred",
-            "deferred_state_refs": sorted(deferred_driver_preflight_refs),
-        }
-        return result
-
     try:
         module_root = resolve_module_root(getattr(ns, "module_root", "modules"))
         resolved = resolve_module(
@@ -203,6 +209,40 @@ def preflight_step(
     except Exception as exc:
         result["status"] = "blocked"
         result["checks"].append({"name": "module_resolve", "ok": False, "detail": str(exc)})
+        return result
+
+    required_env_error = _required_env_error(
+        inputs=resolved.inputs,
+        action=str(step.get("action") or "").strip().lower(),
+        env_name=str(getattr(ns, "env", None) or "").strip(),
+        runtime_root=Path(paths.root),
+    )
+    if required_env_error:
+        result["status"] = "blocked"
+        result["checks"].append(
+            {"name": "required_env", "ok": False, "detail": required_env_error}
+        )
+        return result
+    result["checks"].append(
+        {"name": "required_env", "ok": True, "detail": "ok"}
+    )
+
+    if deferred_driver_preflight_refs:
+        refs = ", ".join(sorted(deferred_driver_preflight_refs))
+        result["checks"].append(
+            {
+                "name": "module_preflight",
+                "ok": True,
+                "detail": (
+                    "driver checks deferred until upstream blueprint state exists: "
+                    f"{refs}"
+                ),
+            }
+        )
+        result["driver_preflight"] = {
+            "status": "deferred",
+            "deferred_state_refs": sorted(deferred_driver_preflight_refs),
+        }
         return result
 
     try:

--- a/hyops/blueprint/tests/test_planner.py
+++ b/hyops/blueprint/tests/test_planner.py
@@ -1,8 +1,60 @@
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
-from hyops.blueprint.planner import compute_preflight
+from hyops.blueprint.planner import _required_env_error, compute_preflight
+
+
+class RequiredEnvironmentPreflightTest(TestCase):
+    def test_missing_secrets_include_recovery_command(self):
+        with patch.dict("hyops.blueprint.planner.os.environ", {}, clear=True):
+            error = _required_env_error(
+                inputs={
+                    "required_env": ["EVENG_ROOT_PASSWORD", "EVENG_ADMIN_PASSWORD"],
+                    "load_vault_env": True,
+                },
+                action="deploy",
+                env_name="student-lab",
+                runtime_root=Path("/tmp/hyops-required-env-test"),
+            )
+
+        self.assertIn("EVENG_ADMIN_PASSWORD, EVENG_ROOT_PASSWORD", error)
+        self.assertIn(
+            "hyops secrets ensure --env student-lab "
+            "EVENG_ADMIN_PASSWORD EVENG_ROOT_PASSWORD",
+            error,
+        )
+
+    def test_destroy_does_not_require_deploy_secrets(self):
+        error = _required_env_error(
+            inputs={
+                "required_env": ["EVENG_ROOT_PASSWORD"],
+                "required_env_destroy": [],
+            },
+            action="destroy",
+            env_name="student-lab",
+            runtime_root=Path("/tmp/hyops-required-env-test"),
+        )
+        self.assertEqual(error, "")
+
+    def test_vault_backed_values_satisfy_requirement(self):
+        def load_vault(env, _runtime_root):
+            env["EVENG_ROOT_PASSWORD"] = "stored"
+            return {"EVENG_ROOT_PASSWORD": "stored"}, ""
+
+        with patch.dict(
+            "hyops.blueprint.planner.os.environ", {}, clear=True
+        ), patch(
+            "hyops.blueprint.planner.merge_vault_env", side_effect=load_vault
+        ):
+            error = _required_env_error(
+                inputs={"required_env": ["EVENG_ROOT_PASSWORD"]},
+                action="deploy",
+                env_name="student-lab",
+                runtime_root=Path("/tmp/hyops-required-env-test"),
+            )
+        self.assertEqual(error, "")
 
 
 class PlannedDependencyPreflightTest(TestCase):


### PR DESCRIPTION
Closes #60

## What changed

- resolve static required environment variables before driver preflight is deferred
- load vault-backed values through the Ansible runtime path
- print the exact `hyops secrets ensure` recovery command
- use `required_env_destroy` so application secrets never block cleanup

## Validation

- `bash tools/ci/check-python.sh`
- missing, vault-backed, and destroy-specific requirement tests
