### PR TITLE
Retain reusable blueprint dependencies

### DIFF
--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -33,6 +33,7 @@ steps:
     action: "deploy"
     phase: "bootstrap"
     with_deps: true
+    retain_on_destroy: true
     contracts:
       addressing_mode: "static"
     inputs:

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1300,7 +1300,8 @@ def run_destroy(ns) -> int:
             print("execution disabled; destroy order:")
             for step_id in destroy_order:
                 step = next(s for s in payload["steps"] if s["id"] == step_id)
-                print(f"  - {step_id}: destroy {step['module_ref']}")
+                action = "retain" if bool(step.get("retain_on_destroy", False)) else "destroy"
+                print(f"  - {step_id}: {action} {step['module_ref']}")
         return 0
 
     json_mode = bool(getattr(ns, "json", False))
@@ -1334,8 +1335,9 @@ def run_destroy(ns) -> int:
             step = by_id[step_id]
             state_ref = step_state_ref(step)
             status = module_state_status(paths.state_dir, state_ref) or "missing"
+            action = "retain" if bool(step.get("retain_on_destroy", False)) else "destroy"
             print(
-                f"  - {step_id}: destroy {step['module_ref']} "
+                f"  - {step_id}: {action} {step['module_ref']} "
                 f"(state={status} ref={state_ref})"
             )
 
@@ -1383,6 +1385,13 @@ def run_destroy(ns) -> int:
         }
 
         state_ref = step_state_ref(step)
+        if bool(step.get("retain_on_destroy", False)):
+            result = dict(base)
+            result.update({"status": "retained", "reason": "retain_on_destroy", "rc": 0})
+            step_results.append(result)
+            print(f"step={step_id} status=retained reason=retain_on_destroy")
+            continue
+
         state_status = module_state_status(paths.state_dir, state_ref)
         if not state_status or state_status in {"destroyed", "absent"}:
             reason = "no-state" if not state_status else f"state-{state_status}"
@@ -1526,7 +1535,9 @@ def run_rebuild(ns) -> int:
     )
     print("destroy_order:")
     for step_id in destroy_order:
-        print(f"  - {step_id}")
+        step = next(s for s in payload["steps"] if s["id"] == step_id)
+        suffix = " (retained)" if bool(step.get("retain_on_destroy", False)) else ""
+        print(f"  - {step_id}{suffix}")
     print("deploy_order:")
     for step_id in payload["order"]:
         print(f"  - {step_id}")

--- a/hyops/blueprint/planner.py
+++ b/hyops/blueprint/planner.py
@@ -59,7 +59,10 @@ def run_step_module_command(step: dict[str, Any], payload: dict[str, Any], ns, p
         module=step["module_ref"],
         module_root=getattr(ns, "module_root", "modules"),
         inputs=str(inputs_file) if inputs_file else None,
-        with_deps=bool(step.get("with_deps", False)),
+        with_deps=(
+            bool(step.get("with_deps", False))
+            and str(step.get("action") or "").strip().lower() in {"apply", "deploy"}
+        ),
         deps_inputs_dir=getattr(ns, "deps_inputs_dir", None),
         deps_force=bool(getattr(ns, "deps_force", False)),
         out_dir=getattr(ns, "out_dir", None),

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -357,6 +357,10 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                     step.get("verify_state_on_skip"),
                     f"steps[{idx}].verify_state_on_skip",
                 ),
+                "retain_on_destroy": bool_field(
+                    step.get("retain_on_destroy"),
+                    f"steps[{idx}].retain_on_destroy",
+                ),
                 "optional": bool_field(step.get("optional"), f"steps[{idx}].optional"),
                 "inputs": inputs if isinstance(inputs, dict) else None,
                 "inputs_file": str(inputs_file).strip() if isinstance(inputs_file, str) else "",

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -40,14 +40,18 @@ def _namespace():
 
 
 class ResumableBlueprintDestroyTest(TestCase):
-    def _run(self, statuses, run_step):
+    def _run(self, statuses, run_step, *, retained=()):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
+        payload = _payload()
+        for step in payload["steps"]:
+            if step["id"] in retained:
+                step["retain_on_destroy"] = True
 
         def state_status(_state_dir, state_ref):
             return statuses[state_ref.rsplit("#", 1)[-1]]
 
         with (
-            patch("hyops.blueprint.command._resolve_and_validate", return_value=_payload()),
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=payload),
             patch("hyops.blueprint.command.require_runtime_selection"),
             patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
             patch("hyops.blueprint.command.ensure_layout"),
@@ -58,6 +62,17 @@ class ResumableBlueprintDestroyTest(TestCase):
         ):
             rc = run_destroy(_namespace())
         return rc, inputs_file, command
+
+    def test_retained_dependency_is_not_destroyed(self):
+        rc, inputs_file, command = self._run(
+            {"network": "ok", "vm": "destroyed", "health": "destroyed"},
+            [],
+            retained=("network",),
+        )
+
+        self.assertEqual(rc, 0)
+        inputs_file.assert_not_called()
+        command.assert_not_called()
 
     def test_second_destroy_skips_terminal_state_before_inputs(self):
         rc, inputs_file, command = self._run(

--- a/hyops/blueprint/tests/test_rebuild.py
+++ b/hyops/blueprint/tests/test_rebuild.py
@@ -17,7 +17,11 @@ def _payload() -> dict:
         "mode": "hybrid",
         "path": "/tmp/blueprint.yml",
         "order": ["network", "vm", "config"],
-        "steps": [{"id": item} for item in ("network", "vm", "config")],
+        "steps": [
+            {"id": "network", "retain_on_destroy": True},
+            {"id": "vm"},
+            {"id": "config"},
+        ],
         "policy": {},
     }
 
@@ -41,6 +45,13 @@ def _namespace(root: str, *, execute: bool) -> argparse.Namespace:
 
 
 class BlueprintRebuildTests(unittest.TestCase):
+    def test_plan_marks_retained_destroy_steps(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.blueprint.command._resolve_and_validate", return_value=_payload()
+        ), patch("builtins.print") as output:
+            self.assertEqual(run_rebuild(_namespace(tmp, execute=False)), 0)
+            output.assert_any_call("  - network (retained)")
+
     def test_plan_only_does_not_execute(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, patch(
             "hyops.blueprint.command._resolve_and_validate", return_value=_payload()


### PR DESCRIPTION
Closes #63

Supersedes #72, which GitHub closed when its merged base branch was deleted.

## What changed
- add a `retain_on_destroy` blueprint step policy
- show retained steps in destroy and rebuild previews
- skip retained modules during ordinary teardown
- retain the reusable Proxmox Jammy template
- avoid forwarding apply-only dependency flags during destroy

## Validation
- `python3 -m unittest hyops.blueprint.tests.test_destroy hyops.blueprint.tests.test_rebuild`
- `bash tools/ci/check-python.sh`