### PR TITLE
Strengthen blueprint dependency preflight

### DIFF
--- a/hyops/blueprint/planner.py
+++ b/hyops/blueprint/planner.py
@@ -7,9 +7,9 @@ import os
 from pathlib import Path
 from typing import Any
 
+from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.drivers.config.ansible.config import resolve_required_env
 from hyops.drivers.config.ansible.runtime_env import merge_vault_env, missing_env
-from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.module_resolve import resolve_module
 from hyops.runtime.source_roots import resolve_module_root
 from hyops.preflight.command import run_module_driver_preflight
@@ -21,31 +21,6 @@ from .contracts import (
     resolved_step_inputs_file,
     step_state_ref,
 )
-
-
-def _required_env_error(
-    *, inputs: dict[str, Any], action: str, env_name: str, runtime_root: Path
-) -> str:
-    key = "required_env_destroy" if action == "destroy" else "required_env"
-    required, config_error = resolve_required_env(inputs, key=key)
-    if config_error:
-        return config_error
-    if not required:
-        return ""
-
-    env = {str(k): str(v) for k, v in os.environ.items()}
-    _, vault_error = merge_vault_env(env, runtime_root)
-    missing = sorted(missing_env(env, required))
-    if not missing:
-        return ""
-
-    names = ", ".join(missing)
-    hint = f"missing required env vars: {names}. "
-    if vault_error:
-        hint += f"{vault_error}. "
-    hint += "Generate them before deployment: "
-    hint += f"hyops secrets ensure --env {env_name or '<env>'} " + " ".join(missing)
-    return hint
 
 
 def run_step_module_command(step: dict[str, Any], payload: dict[str, Any], ns, paths) -> int:
@@ -70,6 +45,29 @@ def run_step_module_command(step: dict[str, Any], payload: dict[str, Any], ns, p
         allow_state_drift_recreate=bool(step.get("verify_state_on_skip", False)),
     )
     return int(module_command.run(step_ns))
+
+
+def _required_env_error(*, inputs: dict[str, Any], action: str, env_name: str, runtime_root: Path) -> str:
+    key = "required_env_destroy" if action == "destroy" else "required_env"
+    required, config_error = resolve_required_env(inputs, key=key)
+    if config_error:
+        return config_error
+    if not required:
+        return ""
+
+    env = {str(k): str(v) for k, v in os.environ.items()}
+    _, vault_error = merge_vault_env(env, runtime_root)
+    missing = sorted(missing_env(env, required))
+    if not missing:
+        return ""
+
+    names = ", ".join(missing)
+    hint = f"missing required env vars: {names}. "
+    if vault_error:
+        hint += f"{vault_error}. "
+    hint += "Generate them before deployment: "
+    hint += f"hyops secrets ensure --env {env_name or '<env>'} " + " ".join(missing)
+    return hint
 
 
 def preflight_step(
@@ -226,9 +224,7 @@ def preflight_step(
             {"name": "required_env", "ok": False, "detail": required_env_error}
         )
         return result
-    result["checks"].append(
-        {"name": "required_env", "ok": True, "detail": "ok"}
-    )
+    result["checks"].append({"name": "required_env", "ok": True, "detail": "ok"})
 
     if deferred_driver_preflight_refs:
         refs = ", ".join(sorted(deferred_driver_preflight_refs))
@@ -236,10 +232,7 @@ def preflight_step(
             {
                 "name": "module_preflight",
                 "ok": True,
-                "detail": (
-                    "driver checks deferred until upstream blueprint state exists: "
-                    f"{refs}"
-                ),
+                "detail": f"driver checks deferred until upstream blueprint state exists: {refs}",
             }
         )
         result["driver_preflight"] = {
@@ -294,12 +287,97 @@ def compute_preflight(
     assumed_state_ok: set[str] = set()
     step_status_by_id: dict[str, str] = {}
 
+    if any(str(step.get("module_ref") or "").startswith("platform/linux/") for step in payload["steps"]):
+        from hyops.drivers.config.ansible.runtime_env import ensure_hybridops_collections_available
+
+        ansible_env = os.environ.copy()
+        if not str(ansible_env.get("ANSIBLE_COLLECTIONS_PATH") or "").strip():
+            runtime_root = Path(getattr(paths, "root", Path.home() / ".hybridops"))
+            candidates = [
+                runtime_root / "state" / "ansible" / "galaxy_collections",
+                runtime_root / "state" / "ansible" / "collections",
+                Path.home() / ".hybridops" / "state" / "ansible" / "galaxy_collections",
+                Path.home() / ".hybridops" / "state" / "ansible" / "collections",
+                Path.home() / ".ansible" / "collections",
+                Path("/usr/share/ansible/collections"),
+            ]
+            ansible_env["ANSIBLE_COLLECTIONS_PATH"] = os.pathsep.join(
+                str(path) for path in candidates if path.is_dir()
+            )
+        collections_error = ensure_hybridops_collections_available(ansible_env)
+        if collections_error:
+            return (
+                [
+                    {
+                        "id": "ansible_controller",
+                        "module_ref": "config/ansible",
+                        "action": "preflight",
+                        "phase": "bootstrap",
+                        "optional": False,
+                        "status": "blocked",
+                        "checks": [{"name": "collections", "ok": False, "detail": collections_error}],
+                    }
+                ],
+                ["ansible_controller"],
+                [],
+            )
+
     for step_id in payload["order"]:
         step = by_id[step_id]
         deferred_driver_preflight_refs: set[str] = set()
         raw_deps = step.get("requires")
         if raw_deps is None:
             raw_deps = step.get("depends_on", [])
+        blocked_dependencies = [
+            str(dep_id)
+            for dep_id in (raw_deps or [])
+            if step_status_by_id.get(str(dep_id)) in {"blocked", "deferred"}
+        ]
+        if blocked_dependencies:
+            step_results.append(
+                {
+                    "id": step["id"],
+                    "module_ref": step["module_ref"],
+                    "module_state_ref": step_state_ref(step),
+                    "action": step["action"],
+                    "phase": step["phase"],
+                    "optional": bool(step.get("optional", False)),
+                    "checks": [
+                        {
+                            "name": "dependencies",
+                            "ok": True,
+                            "detail": "deferred because upstream preflight failed: "
+                            + ", ".join(blocked_dependencies),
+                        }
+                    ],
+                    "status": "deferred",
+                }
+            )
+            step_status_by_id[step_id] = "deferred"
+            continue
+        pending_configuration = [
+            str(dep_id)
+            for dep_id in (raw_deps or [])
+            if step_status_by_id.get(str(dep_id)) == "ready"
+            and str((by_id.get(str(dep_id)) or {}).get("module_ref") or "").startswith("platform/linux/")
+            and not bool((by_id.get(str(dep_id)) or {}).get("skip_if_state_ok", False))
+        ]
+        if pending_configuration:
+            step_results.append(
+                {
+                    "id": step["id"],
+                    "module_ref": step["module_ref"],
+                    "module_state_ref": step_state_ref(step),
+                    "action": step["action"],
+                    "phase": step["phase"],
+                    "optional": bool(step.get("optional", False)),
+                    "checks": [{"name": "dependencies", "ok": True, "detail": "remote checks deferred until configuration runs: " + ", ".join(pending_configuration)}],
+                    "status": "ready",
+                }
+            )
+            step_status_by_id[step_id] = "ready"
+            assumed_state_ok.add(step_state_ref(step))
+            continue
         for dep_id in raw_deps or []:
             dep_step = by_id.get(str(dep_id))
             if not isinstance(dep_step, dict):

--- a/hyops/blueprint/tests/test_planner.py
+++ b/hyops/blueprint/tests/test_planner.py
@@ -7,7 +7,7 @@ from hyops.blueprint.planner import _required_env_error, compute_preflight
 
 
 class RequiredEnvironmentPreflightTest(TestCase):
-    def test_missing_secrets_include_recovery_command(self):
+    def test_missing_secrets_are_reported_before_deferred_driver_checks(self):
         with patch.dict("hyops.blueprint.planner.os.environ", {}, clear=True):
             error = _required_env_error(
                 inputs={
@@ -21,8 +21,7 @@ class RequiredEnvironmentPreflightTest(TestCase):
 
         self.assertIn("EVENG_ADMIN_PASSWORD, EVENG_ROOT_PASSWORD", error)
         self.assertIn(
-            "hyops secrets ensure --env student-lab "
-            "EVENG_ADMIN_PASSWORD EVENG_ROOT_PASSWORD",
+            "hyops secrets ensure --env student-lab EVENG_ADMIN_PASSWORD EVENG_ROOT_PASSWORD",
             error,
         )
 
@@ -38,26 +37,83 @@ class RequiredEnvironmentPreflightTest(TestCase):
         )
         self.assertEqual(error, "")
 
-    def test_vault_backed_values_satisfy_requirement(self):
-        def load_vault(env, _runtime_root):
-            env["EVENG_ROOT_PASSWORD"] = "stored"
-            return {"EVENG_ROOT_PASSWORD": "stored"}, ""
-
-        with patch.dict(
-            "hyops.blueprint.planner.os.environ", {}, clear=True
-        ), patch(
-            "hyops.blueprint.planner.merge_vault_env", side_effect=load_vault
-        ):
-            error = _required_env_error(
-                inputs={"required_env": ["EVENG_ROOT_PASSWORD"]},
-                action="deploy",
-                env_name="student-lab",
-                runtime_root=Path("/tmp/hyops-required-env-test"),
-            )
-        self.assertEqual(error, "")
-
 
 class PlannedDependencyPreflightTest(TestCase):
+    @patch(
+        "hyops.drivers.config.ansible.runtime_env.ensure_hybridops_collections_available",
+        return_value="missing HybridOps Ansible collections; run: hyops setup galaxy",
+    )
+    def test_missing_collections_block_linux_steps(self, _collections):
+        payload = {
+            "order": ["config"],
+            "steps": [
+                {
+                    "id": "config",
+                    "module_ref": "platform/linux/eve-ng",
+                    "action": "deploy",
+                    "phase": "operations",
+                    "optional": False,
+                }
+            ],
+        }
+
+        results, required_failures, optional_failures = compute_preflight(
+            payload,
+            SimpleNamespace(),
+            SimpleNamespace(state_dir="/tmp/state", root=Path("/tmp/runtime")),
+        )
+
+        self.assertEqual(results[0]["status"], "blocked")
+        self.assertIn("hyops setup galaxy", results[0]["checks"][0]["detail"])
+        self.assertEqual(required_failures, ["ansible_controller"])
+        self.assertEqual(optional_failures, [])
+
+    @patch(
+        "hyops.drivers.config.ansible.runtime_env.ensure_hybridops_collections_available",
+        return_value="",
+    )
+    @patch("hyops.blueprint.planner.preflight_step")
+    def test_remote_check_waits_for_configuration(self, preflight_step, _collections):
+        payload = {
+            "order": ["config", "health"],
+            "steps": [
+                {
+                    "id": "config",
+                    "module_ref": "platform/linux/eve-ng",
+                    "state_instance": "student_config",
+                    "action": "deploy",
+                    "phase": "operations",
+                    "optional": False,
+                },
+                {
+                    "id": "health",
+                    "module_ref": "platform/linux/eve-ng-healthcheck",
+                    "state_instance": "student_health",
+                    "action": "deploy",
+                    "phase": "operations",
+                    "optional": False,
+                    "requires": ["config"],
+                },
+            ],
+        }
+        preflight_step.return_value = {
+            "id": "config",
+            "status": "ready",
+            "optional": False,
+        }
+
+        results, required_failures, optional_failures = compute_preflight(
+            payload,
+            SimpleNamespace(),
+            SimpleNamespace(state_dir="/tmp/state", root=Path("/tmp/runtime")),
+        )
+
+        self.assertEqual([item["status"] for item in results], ["ready", "ready"])
+        self.assertIn("configuration runs", results[1]["checks"][0]["detail"])
+        self.assertEqual(required_failures, [])
+        self.assertEqual(optional_failures, [])
+        preflight_step.assert_called_once()
+
     @patch("hyops.blueprint.planner.module_state_ok", return_value=True)
     @patch("hyops.blueprint.planner.preflight_step")
     def test_changed_upstream_state_defers_downstream_checks(
@@ -106,3 +162,59 @@ class PlannedDependencyPreflightTest(TestCase):
             vm_call.kwargs["deferred_driver_preflight_refs"],
             {"platform/gcp/lab-network#student_network"},
         )
+
+    @patch(
+        "hyops.drivers.config.ansible.runtime_env.ensure_hybridops_collections_available",
+        return_value="",
+    )
+    @patch("hyops.blueprint.planner.preflight_step")
+    def test_upstream_failure_defers_dependency_chain(
+        self, preflight_step, _collections
+    ):
+        payload = {
+            "order": ["network", "vm", "config"],
+            "steps": [
+                {
+                    "id": "network",
+                    "module_ref": "platform/gcp/lab-network",
+                    "state_instance": "student_network",
+                    "action": "deploy",
+                    "phase": "bootstrap",
+                    "optional": False,
+                },
+                {
+                    "id": "vm",
+                    "module_ref": "platform/gcp/platform-vm",
+                    "state_instance": "student_vm",
+                    "action": "deploy",
+                    "phase": "bootstrap",
+                    "optional": False,
+                    "requires": ["network"],
+                },
+                {
+                    "id": "config",
+                    "module_ref": "platform/linux/eve-ng",
+                    "state_instance": "student_config",
+                    "action": "deploy",
+                    "phase": "operations",
+                    "optional": False,
+                    "requires": ["vm"],
+                },
+            ],
+        }
+        preflight_step.return_value = {
+            "id": "network",
+            "status": "blocked",
+            "optional": False,
+        }
+
+        results, required_failures, optional_failures = compute_preflight(
+            payload,
+            SimpleNamespace(),
+            SimpleNamespace(state_dir="/tmp/state"),
+        )
+
+        self.assertEqual([item["status"] for item in results], ["blocked", "deferred", "deferred"])
+        self.assertEqual(required_failures, ["network"])
+        self.assertEqual(optional_failures, [])
+        preflight_step.assert_called_once()


### PR DESCRIPTION
Closes #77

## What changed
- check HybridOps Galaxy collections before Linux blueprint steps
- propagate blocked upstream status through dependent steps
- defer remote checks until their configuration dependency has run

## Validation
- `python3 -m unittest hyops.blueprint.tests.test_planner`
- `bash tools/ci/check-python.sh`