### PR TITLE
Make forced installation transactional

### DIFF
--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -173,6 +173,21 @@ if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
 fi
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" show --help >/dev/null
 
+# A failed replacement must leave the previous CLI usable and remove staging
+# directories. Make the vault helper read-only to force a post-activation error.
+cp "${USER_HOME}/.hybridops/core/app/install.sh" "${WORK_DIR}/installed-app.sh"
+chmod 0555 "${USER_HOME}/.hybridops/tools" "${USER_HOME}/.hybridops/tools/vault-pass.sh"
+if env HOME="${USER_HOME}" "${common_env[@]}" \
+  bash "${HYOPS_REPO_ROOT}/install.sh" --force --no-system-link --no-setup-all >/dev/null 2>&1; then
+  echo "ERR: installer rollback smoke did not trigger the expected failure" >&2
+  exit 1
+fi
+chmod 0755 "${USER_HOME}/.hybridops/tools" "${USER_HOME}/.hybridops/tools/vault-pass.sh"
+cmp "${WORK_DIR}/installed-app.sh" "${USER_HOME}/.hybridops/core/app/install.sh"
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" --help >/dev/null
+test -z "$(find "${USER_HOME}/.hybridops" -maxdepth 1 \
+  \( -name 'core.install.*' -o -name 'core.previous.*' \) -print -quit)"
+
 if sudo -n true >/dev/null 2>&1; then
   sudo install -d -m 0755 "${ROOT_CACHE_DIR}"
   sudo env HOME="${ROOT_HOME}" "${common_env[@]}" \

--- a/tools/install/lib/installer.sh
+++ b/tools/install/lib/installer.sh
@@ -17,7 +17,11 @@ source "${_hyops_install_lib_dir}/wrapper.sh"
 # shellcheck source=/dev/null
 source "${_hyops_install_lib_dir}/setup.sh"
 
-hyops_install_run() {
+hyops_install_run() (
+  _hyops_install_run_transaction
+)
+
+_hyops_install_run_transaction() {
   hyops_install_need_cmd python3
   hyops_install_need_cmd cp
   hyops_install_need_cmd mkdir
@@ -26,8 +30,31 @@ hyops_install_run() {
   PREFIX="$(hyops_install_abs_path "${PREFIX}")"
   BIN_DIR="$(hyops_install_abs_path "${BIN_DIR}")"
 
-  APP_DIR="${PREFIX}/app"
-  VENV_DIR="${PREFIX}/venv"
+  HYOPS_INSTALL_TX_FINAL_PREFIX="${PREFIX}"
+  HYOPS_INSTALL_TX_STAGE_PREFIX="${PREFIX}.install.$$"
+  HYOPS_INSTALL_TX_PREVIOUS_PREFIX="${PREFIX}.previous.$$"
+  HYOPS_INSTALL_TX_HAD_PREVIOUS="false"
+  HYOPS_INSTALL_TX_ACTIVATED="false"
+  HYOPS_INSTALL_TX_COMPLETED="false"
+
+  hyops_install_transaction_cleanup() {
+    local exit_code=$?
+    trap - EXIT HUP INT TERM
+    set +e
+    if [[ "${HYOPS_INSTALL_TX_COMPLETED}" != "true" && "${HYOPS_INSTALL_TX_ACTIVATED}" == "true" ]]; then
+      echo "[install] installation failed; restoring previous installation" >&2
+      rm -rf "${HYOPS_INSTALL_TX_FINAL_PREFIX}"
+      if [[ "${HYOPS_INSTALL_TX_HAD_PREVIOUS}" == "true" && -d "${HYOPS_INSTALL_TX_PREVIOUS_PREFIX}" ]]; then
+        mv "${HYOPS_INSTALL_TX_PREVIOUS_PREFIX}" "${HYOPS_INSTALL_TX_FINAL_PREFIX}"
+      fi
+    fi
+    rm -rf "${HYOPS_INSTALL_TX_STAGE_PREFIX}" "${HYOPS_INSTALL_TX_PREVIOUS_PREFIX}"
+    return "${exit_code}"
+  }
+  trap hyops_install_transaction_cleanup EXIT HUP INT TERM
+
+  APP_DIR="${HYOPS_INSTALL_TX_STAGE_PREFIX}/app"
+  VENV_DIR="${HYOPS_INSTALL_TX_STAGE_PREFIX}/venv"
   SYSTEM_LINK_PATH="${HYOPS_INSTALL_SYSTEM_LINK_PATH:-/usr/local/bin/hyops}"
   SYSTEM_LINK_DIR="$(dirname -- "${SYSTEM_LINK_PATH}")"
 
@@ -40,15 +67,15 @@ hyops_install_run() {
   USE_SYSTEM_DEPS="${HYOPS_INSTALL_USE_SYSTEM_DEPS:-false}"
   INSTALL_NO_DEPS="${HYOPS_INSTALL_NO_DEPS:-false}"
 
-  mkdir -p "${PREFIX}" "${RUNTIME_ROOT}" "${TOOLS_DIR}"
+  mkdir -p "$(dirname -- "${PREFIX}")" "${RUNTIME_ROOT}" "${TOOLS_DIR}"
 
   echo "[install] prefix=${PREFIX}"
   echo "[install] bin_dir=${BIN_DIR}"
 
   if [[ "${SETUP_ALL}" == "auto" ]]; then
     if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
-      # Homebrew refuses to run as root. Keep the CLI install smooth and leave
-      # prerequisite installation as an explicit, user-owned setup step.
+      # Homebrew refuses to run as root. Leave prerequisite installation as an
+      # explicit setup step owned by the macOS user.
       SETUP_ALL="false"
       echo "[install] macOS detected; automatic setup-all is disabled"
     elif [[ "${SYSTEM_LINK}" == "true" ]]; then
@@ -72,11 +99,29 @@ hyops_install_run() {
     fi
   fi
 
-  hyops_install_remove_or_fail_dir "${APP_DIR}" "app dir"
-  hyops_install_copy_payload
+  if [[ -e "${HYOPS_INSTALL_TX_FINAL_PREFIX}" && "${FORCE}" != "true" ]]; then
+    echo "ERR: install prefix already exists: ${HYOPS_INSTALL_TX_FINAL_PREFIX} (use --force)" >&2
+    exit 2
+  fi
+  rm -rf "${HYOPS_INSTALL_TX_STAGE_PREFIX}" "${HYOPS_INSTALL_TX_PREVIOUS_PREFIX}"
 
-  hyops_install_remove_or_fail_dir "${VENV_DIR}" "venv dir"
+  hyops_install_copy_payload
   hyops_install_create_venv_and_payload
+
+  echo "[install] verifying candidate"
+  "${VENV_DIR}/bin/hyops" --help >/dev/null
+
+  echo "[install] activating installation"
+  hyops_install_relocate_venv "${HYOPS_INSTALL_TX_STAGE_PREFIX}" "${HYOPS_INSTALL_TX_FINAL_PREFIX}"
+  if [[ -e "${HYOPS_INSTALL_TX_FINAL_PREFIX}" ]]; then
+    mv "${HYOPS_INSTALL_TX_FINAL_PREFIX}" "${HYOPS_INSTALL_TX_PREVIOUS_PREFIX}"
+    HYOPS_INSTALL_TX_HAD_PREVIOUS="true"
+  fi
+  mv "${HYOPS_INSTALL_TX_STAGE_PREFIX}" "${HYOPS_INSTALL_TX_FINAL_PREFIX}"
+  HYOPS_INSTALL_TX_ACTIVATED="true"
+  PREFIX="${HYOPS_INSTALL_TX_FINAL_PREFIX}"
+  APP_DIR="${PREFIX}/app"
+  VENV_DIR="${PREFIX}/venv"
 
   hyops_install_normalize_payload_permissions
   hyops_install_install_vault_helper
@@ -87,23 +132,20 @@ hyops_install_run() {
   hyops_install_verify_command
   hyops_install_run_setup_all
 
+  HYOPS_INSTALL_TX_COMPLETED="true"
+  rm -rf "${HYOPS_INSTALL_TX_PREVIOUS_PREFIX}"
+  trap - EXIT HUP INT TERM
   echo "[install] OK"
-  local resolved_hyops=""
-  resolved_hyops="$(command -v hyops 2>/dev/null || true)"
-  if [[ "${resolved_hyops}" == "${SYSTEM_LINK_PATH}" || ( -n "${WRAPPER:-}" && "${resolved_hyops}" == "${WRAPPER}" ) ]]; then
-    echo "Next:"
-    echo "  hyops --help"
-    if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
-      echo "  hyops setup base"
-    else
-      echo "  hyops preflight"
-    fi
-  elif [[ -n "${PATH_PROFILE:-}" ]]; then
-    echo "Open a new terminal, then run:"
-    echo "  hyops --help"
+  echo "Next:"
+  echo "  hyops --help"
+  if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
     echo "  hyops setup base"
+    echo "  hyops setup gcp"
+    echo "  hyops setup galaxy"
   else
-    echo "Run:"
+    echo "  hyops preflight"
+  fi
+  if [[ -n "${WRAPPER:-}" ]]; then
     echo "  ${WRAPPER} --help"
   fi
 }

--- a/tools/install/lib/python_env.sh
+++ b/tools/install/lib/python_env.sh
@@ -62,3 +62,24 @@ EOS
     "${VENV_DIR}/bin/python3" -m pip install "${APP_DIR}" >/dev/null
   fi
 }
+
+hyops_install_relocate_venv() {
+  local source_prefix="$1"
+  local target_prefix="$2"
+
+  python3 - "${VENV_DIR}/bin" "${source_prefix}" "${target_prefix}" <<'PY'
+import pathlib
+import sys
+
+bin_dir = pathlib.Path(sys.argv[1])
+source = sys.argv[2].encode()
+target = sys.argv[3].encode()
+
+for path in bin_dir.iterdir():
+    if path.is_symlink() or not path.is_file():
+        continue
+    content = path.read_bytes()
+    if source in content:
+        path.write_bytes(content.replace(source, target))
+PY
+}


### PR DESCRIPTION
Closes #78

## What changed
- build forced replacements in a staging prefix
- verify the candidate CLI before activation
- restore the previous prefix after a post-activation failure
- remove transaction directories on every exit path
- keep installer run-record traps isolated from transaction cleanup

## Validation
- `bash tools/ci/check-install.sh`