### PR TITLE
Expose collection setup as setup galaxy

### DIFF
--- a/hyops/drivers/config/ansible/runtime_env.py
+++ b/hyops/drivers/config/ansible/runtime_env.py
@@ -320,7 +320,7 @@ def ensure_hybridops_collections_available(env: dict[str, str]) -> str:
     collections_path = str(env.get("ANSIBLE_COLLECTIONS_PATH") or env.get("ANSIBLE_COLLECTIONS_PATHS") or "").strip()
     if _has_hybridops_collection(collections_path):
         return ""
-    return "missing HybridOps Ansible collections; run: hyops setup ansible"
+    return "missing HybridOps Ansible collections; run: hyops setup galaxy"
 
 
 def merge_vault_env(env: dict[str, str], runtime_root: Path) -> tuple[dict[str, str], str]:

--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -21,7 +21,7 @@ from hyops.runtime.paths import resolve_runtime_paths
 def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
     # Common args must be present on both the setup parser and subcommands so operators can run:
     #   hyops setup base --sudo
-    #   hyops setup ansible
+    #   hyops setup galaxy
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument(
         "--root",
@@ -57,14 +57,14 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
         "--force",
         action="store_true",
         default=argparse.SUPPRESS,
-        help="Force reinstall where supported (currently: ansible, all).",
+        help="Force reinstall where supported (currently: galaxy, all).",
     )
     common.add_argument(
         "--hybridops-source",
         choices=("release", "git"),
         default=argparse.SUPPRESS,
         help=(
-            "How to source HybridOps collections for setup ansible/all. "
+            "How to source HybridOps collections for setup galaxy/all. "
             "release installs the pinned published collection artifacts; git installs pinned "
             "collections from Git repositories into runtime state."
         ),
@@ -82,15 +82,16 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
     ssp = p.add_subparsers(dest="setup_cmd", required=True)
 
     _add(ssp, "base", "Install base system prerequisites.", parents=[common])
-    _add(ssp, "ansible", "Install Ansible Galaxy dependencies into the runtime state directory.", parents=[common])
+    _add(ssp, "galaxy", "Install Ansible Galaxy dependencies into the runtime state directory.", parents=[common])
     _add(ssp, "cloud-azure", "Install Azure CLI prerequisites.", parents=[common])
     _add(ssp, "cloud-gcp", "Install GCP SDK prerequisites.", parents=[common])
     _add(ssp, "all", "Run base + ansible + cloud installers.", parents=[common])
     _add(ssp, "check", "Check presence of common tools (no installs).", parents=[common])
 
     # Aliases (operator-friendly)
-    _add(ssp, "config-mgmt", "Alias for: ansible.", parents=[common])
-    _add(ssp, "config-management", "Alias for: ansible.", parents=[common])
+    _add(ssp, "ansible", "Compatibility alias for: galaxy.", parents=[common])
+    _add(ssp, "config-mgmt", "Alias for: galaxy.", parents=[common])
+    _add(ssp, "config-management", "Alias for: galaxy.", parents=[common])
     _add(ssp, "azure", "Alias for: cloud-azure.", parents=[common])
     _add(ssp, "gcp", "Alias for: cloud-gcp.", parents=[common])
 
@@ -143,8 +144,8 @@ def _find_core_root(ns_root: str | None) -> Path | None:
 
 
 def _script_for(action: str) -> str | None:
-    if action in ("config-mgmt", "config-management"):
-        action = "ansible"
+    if action in ("ansible", "config-mgmt", "config-management"):
+        action = "galaxy"
     elif action == "azure":
         action = "cloud-azure"
     elif action == "gcp":
@@ -152,7 +153,7 @@ def _script_for(action: str) -> str | None:
 
     mapping = {
         "base": "setup-base.sh",
-        "ansible": "setup-ansible.sh",
+        "galaxy": "setup-ansible.sh",
         "cloud-azure": "setup-cloud-azure.sh",
         "cloud-gcp": "setup-cloud-gcp.sh",
         "all": "setup-all.sh",
@@ -176,7 +177,7 @@ def _run_check() -> int:
         ("gpg", ["gpg"]),
         ("pass", ["pass"]),
         # Different distros provide different pinentry flavors.
-        ("pinentry", ["pinentry", "pinentry-curses", "pinentry-tty", "pinentry-gtk-2"]),
+        ("pinentry", ["pinentry", "pinentry-mac", "pinentry-curses", "pinentry-tty", "pinentry-gtk-2"]),
     ]
     ok = True
     for label, candidates in checks:
@@ -198,8 +199,9 @@ def _run_check() -> int:
 def run(ns) -> int:
     action = ns._setup_action
     aliases = {
-        "config-mgmt": "ansible",
-        "config-management": "ansible",
+        "ansible": "galaxy",
+        "config-mgmt": "galaxy",
+        "config-management": "galaxy",
         "azure": "cloud-azure",
         "gcp": "cloud-gcp",
     }
@@ -226,7 +228,7 @@ def run(ns) -> int:
             evidence.exit_code = _run_check()
             return evidence.exit_code
 
-    if canonical_action in ("ansible", "all"):
+    if canonical_action in ("galaxy", "all"):
         if runtime_root_arg and env_arg:
             print("ERR: --runtime-root and --env are mutually exclusive")
             return OPERATOR_ERROR
@@ -237,8 +239,8 @@ def run(ns) -> int:
             print(f"ERR: {exc}")
             return OPERATOR_ERROR
 
-    if canonical_action == "ansible" and sudo:
-        print("ERR: hyops setup ansible must not be run with --sudo (it installs into user runtime state)")
+    if canonical_action == "galaxy" and sudo:
+        print("ERR: hyops setup galaxy must not be run with --sudo (it installs into user runtime state)")
         return OPERATOR_ERROR
 
     script_name = _script_for(canonical_action)
@@ -269,13 +271,13 @@ def run(ns) -> int:
             env["HYOPS_ENV"] = str(env_arg).strip()
 
     argv: list[str] = ["bash", str(script)]
-    if canonical_action == "ansible" and runtime_root is not None:
+    if canonical_action == "galaxy" and runtime_root is not None:
         argv += ["--root", str(runtime_root)]
-    if force and canonical_action in ("ansible", "all"):
+    if force and canonical_action in ("galaxy", "all"):
         argv += ["--force"]
-    if hybridops_source and canonical_action in ("ansible", "all"):
+    if hybridops_source and canonical_action in ("galaxy", "all"):
         argv += ["--hybridops-source", hybridops_source]
-    if hybridops_git_manifest and canonical_action in ("ansible", "all"):
+    if hybridops_git_manifest and canonical_action in ("galaxy", "all"):
         argv += ["--hybridops-git-manifest", hybridops_git_manifest]
     if sudo:
         argv = ["sudo", "-E"] + argv

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -16,7 +16,7 @@ Python wheel because operators need the runtime payload as shipped:
 
 HybridOps Ansible collection source is not part of the public bundle contract.
 Operators install the pinned released `hybridops.*` collection artifacts through
-`hyops setup ansible`.
+`hyops setup galaxy`.
 
 ## Public Product Boundary
 
@@ -75,7 +75,7 @@ TMPDIR=/dev/shm ./pkg/verify_release.sh dist/releases/hybridops-core-<label>.tar
 - `install.sh` can install the bundle into an isolated runtime root
 - installed `hyops` runs without relying on the source checkout
 - the bundle and installed payload do not include vendored HybridOps collection source
-- installed `hyops` still exposes the `setup ansible` operator path
+- installed `hyops` exposes `setup galaxy` and the compatible `setup ansible` path
 - the installed payload matches the shipped checksum manifest
 - the temporary filesystem has enough free space before extraction begins
 

--- a/pkg/verify_release.sh
+++ b/pkg/verify_release.sh
@@ -119,8 +119,9 @@ fi
   env -u PYTHONPATH HOME="${HOME_DIR}" "${INSTALLED_HYOPS}" --help >/dev/null
   env -u PYTHONPATH HOME="${HOME_DIR}" "${INSTALLED_HYOPS}" preflight --help >/dev/null
   env -u PYTHONPATH HOME="${HOME_DIR}" "${INSTALLED_HYOPS}" init --help >/dev/null
+  env -u PYTHONPATH HOME="${HOME_DIR}" "${INSTALLED_HYOPS}" setup galaxy --help >/dev/null
+  env -u PYTHONPATH HOME="${HOME_DIR}" "${INSTALLED_HYOPS}" setup galaxy --runtime-root "${HOME_DIR}/.hybridops" --dry-run >/dev/null
   env -u PYTHONPATH HOME="${HOME_DIR}" "${INSTALLED_HYOPS}" setup ansible --help >/dev/null
-  env -u PYTHONPATH HOME="${HOME_DIR}" "${INSTALLED_HYOPS}" setup ansible --runtime-root "${HOME_DIR}/.hybridops" --dry-run >/dev/null
 )
 
 env "${install_env[@]}" \
@@ -163,7 +164,7 @@ if sudo -n true >/dev/null 2>&1; then
       --no-setup-all >/dev/null
 
   env -u PYTHONPATH HOME="${ROOT_HOME_DIR}" "${ROOT_LINK_HYOPS}" --help >/dev/null
-  env -u PYTHONPATH HOME="${ROOT_HOME_DIR}" "${ROOT_LINK_HYOPS}" setup ansible --help >/dev/null
+  env -u PYTHONPATH HOME="${ROOT_HOME_DIR}" "${ROOT_LINK_HYOPS}" setup galaxy --help >/dev/null
   sudo env HOME="${ROOT_HOME_DIR}" PATH="/usr/bin:/bin:${PATH}" \
     HYOPS_INSTALL_SYSTEM_LINK_PATH="${ROOT_LINK_HYOPS}" \
     HYOPS_INSTALL_USE_SYSTEM_DEPS=true \
@@ -175,7 +176,7 @@ if sudo -n true >/dev/null 2>&1; then
       --no-wrapper \
       --no-setup-all >/dev/null
   env -u PYTHONPATH HOME="${ROOT_HOME_DIR}" "${ROOT_LINK_HYOPS}" show --help >/dev/null
-  env -u PYTHONPATH HOME="${ROOT_HOME_DIR}" "${ROOT_LINK_HYOPS}" setup ansible --runtime-root "${ROOT_HOME_DIR}/.hybridops" --dry-run >/dev/null
+  env -u PYTHONPATH HOME="${ROOT_HOME_DIR}" "${ROOT_LINK_HYOPS}" setup galaxy --runtime-root "${ROOT_HOME_DIR}/.hybridops" --dry-run >/dev/null
 
   cat > "${ROOT_FAKE_APP_DIR}/tools/setup/setup-all.sh" <<'EOF'
 #!/usr/bin/env bash

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -59,8 +59,10 @@ if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
 fi
 
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" --help >/dev/null
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup galaxy --help >/dev/null
+env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup galaxy --runtime-root "${USER_HOME}/.hybridops" --dry-run >/dev/null
+# Compatibility alias remains available for existing runbooks.
 env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup ansible --help >/dev/null
-env -u PYTHONPATH HOME="${USER_HOME}" "${USER_HOME}/.local/bin/hyops" setup ansible --runtime-root "${USER_HOME}/.hybridops" --dry-run >/dev/null
 
 INSTALL_EVIDENCE="$(latest_evidence_dir "${USER_HOME}/.hybridops/logs/install")"
 python3 - "${INSTALL_EVIDENCE}" <<'PY'
@@ -201,7 +203,7 @@ if sudo -n true >/dev/null 2>&1; then
       --no-setup-all >/dev/null
 
   env -u PYTHONPATH HOME="${ROOT_HOME}" "${ROOT_BIN_DIR}/hyops" --help >/dev/null
-  env -u PYTHONPATH HOME="${ROOT_HOME}" "${ROOT_BIN_DIR}/hyops" setup ansible --help >/dev/null
+  env -u PYTHONPATH HOME="${ROOT_HOME}" "${ROOT_BIN_DIR}/hyops" setup galaxy --help >/dev/null
   sudo env HOME="${ROOT_HOME}" "${common_env[@]}" \
     PIP_CACHE_DIR="${ROOT_CACHE_DIR}" \
     HYOPS_INSTALL_SYSTEM_LINK_PATH="${ROOT_BIN_DIR}/hyops" \
@@ -212,7 +214,7 @@ if sudo -n true >/dev/null 2>&1; then
       --no-wrapper \
       --no-setup-all >/dev/null
   env -u PYTHONPATH HOME="${ROOT_HOME}" "${ROOT_BIN_DIR}/hyops" show --help >/dev/null
-  env -u PYTHONPATH HOME="${ROOT_HOME}" "${ROOT_BIN_DIR}/hyops" setup ansible --runtime-root "${ROOT_HOME}/.hybridops" --dry-run >/dev/null
+  env -u PYTHONPATH HOME="${ROOT_HOME}" "${ROOT_BIN_DIR}/hyops" setup galaxy --runtime-root "${ROOT_HOME}/.hybridops" --dry-run >/dev/null
 
   cat > "${ROOT_FAKE_APP}/tools/setup/setup-all.sh" <<'EOF'
 #!/usr/bin/env bash

--- a/tools/install/lib/installer.sh
+++ b/tools/install/lib/installer.sh
@@ -136,16 +136,30 @@ _hyops_install_run_transaction() {
   rm -rf "${HYOPS_INSTALL_TX_PREVIOUS_PREFIX}"
   trap - EXIT HUP INT TERM
   echo "[install] OK"
-  echo "Next:"
-  echo "  hyops --help"
-  if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
-    echo "  hyops setup base"
-    echo "  hyops setup gcp"
-    echo "  hyops setup galaxy"
+  local resolved_hyops=""
+  resolved_hyops="$(command -v hyops 2>/dev/null || true)"
+  if [[ "${resolved_hyops}" == "${SYSTEM_LINK_PATH}" || ( -n "${WRAPPER:-}" && "${resolved_hyops}" == "${WRAPPER}" ) ]]; then
+    echo "Next:"
+    echo "  hyops --help"
+    if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+      echo "  hyops setup base"
+      echo "  hyops setup gcp"
+      echo "  hyops setup galaxy"
+    else
+      echo "  hyops preflight"
+    fi
+  elif [[ -n "${PATH_PROFILE:-}" ]]; then
+    echo "Open a new terminal, then run:"
+    echo "  hyops --help"
+    if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
+      echo "  hyops setup base"
+      echo "  hyops setup gcp"
+      echo "  hyops setup galaxy"
+    else
+      echo "  hyops preflight"
+    fi
   else
-    echo "  hyops preflight"
-  fi
-  if [[ -n "${WRAPPER:-}" ]]; then
+    echo "Run:"
     echo "  ${WRAPPER} --help"
   fi
 }

--- a/tools/setup/README.md
+++ b/tools/setup/README.md
@@ -11,9 +11,9 @@ hyops setup check
 hyops setup base --sudo
 hyops setup cloud-azure --sudo
 hyops setup cloud-gcp --sudo
-hyops setup ansible
-hyops setup ansible --hybridops-source git
-hyops setup ansible --root /path/to/hybridops-core --hybridops-source git
+hyops setup galaxy
+hyops setup galaxy --hybridops-source git
+hyops setup galaxy --root /path/to/hybridops-core --hybridops-source git
 hyops setup all --sudo
 ```
 
@@ -21,7 +21,7 @@ hyops setup all --sudo
 
 - On macOS, install [Homebrew](https://brew.sh/) first, then run setup commands
   without `--sudo` (`hyops setup base`, `hyops setup gcp`, and
-  `hyops setup ansible`). Linux setup commands retain their existing `--sudo`
+  `hyops setup galaxy`). Linux setup commands retain their existing `--sudo`
   behavior.
 - `hyops setup gcp` and `hyops setup azure` are operator-friendly aliases for
   `cloud-gcp` and `cloud-azure`.
@@ -35,13 +35,13 @@ hyops setup all --sudo
   `hybridops.helper`, and `hybridops.app` collections from
   [tools/setup/requirements/ansible.galaxy.yml](./requirements/ansible.galaxy.yml).
 - Git-based install path (for iteration or a pinned Git-based flow):
-  - `hyops setup ansible --hybridops-source git`
-  - `hyops setup ansible --hybridops-source git --hybridops-git-manifest /path/to/manifest.json`
+  - `hyops setup galaxy --hybridops-source git`
+  - `hyops setup galaxy --hybridops-source git --hybridops-git-manifest /path/to/manifest.json`
   - builds and installs pinned `hybridops.common`, `hybridops.helper`, and `hybridops.app` from Git into runtime state
   - requires access to the private collection release workspaces named in the manifest
   - the primary public install contract remains the released collection set
 - For local source-tree iteration, point `hyops setup` at the checkout you want to use:
-  - `hyops setup ansible --root /path/to/hybridops-core --hybridops-source git`
+  - `hyops setup galaxy --root /path/to/hybridops-core --hybridops-source git`
 - Drivers and modules do not install dependencies automatically; they fail fast and instruct which `hyops setup` command to run.
 
 ## Documentation


### PR DESCRIPTION
Closes #79

## What changed
- make `hyops setup galaxy` the canonical collection command
- retain `hyops setup ansible` as a compatibility alias
- preserve the GCP and Azure setup aliases and setup run records
- update installer, package verification, and setup guidance
- recognize Homebrew pinentry on macOS

## Validation
- CLI help smoke for `setup galaxy` and `setup ansible`
- `bash tools/ci/check-install.sh`