### PR TITLE
Complete the GCP EVE-NG teaching blueprint

### DIFF
--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -2,7 +2,7 @@
 
 Build a private EVE-NG host on Google Cloud using a nested-virtualization-capable Compute Engine VM.
 
-This blueprint provisions the VM, connects to it over GCP IAP, configures EVE-NG, and runs a health check so the host proves it is reachable. It is the cloud-friendly EVE-NG path for users who want a reproducible training or network-simulation host but do not have a Proxmox environment.
+This blueprint provisions the VM, connects to it over GCP IAP, configures EVE-NG, loads a small starter image set, and runs a health check so the host proves it is reachable. It is the cloud-friendly EVE-NG path for users who want a reproducible training or network-simulation host but do not have a Proxmox environment.
 
 Use this when you want the EVE-NG host lifecycle to be rebuildable from infrastructure code instead of manually creating and patching a long-lived server.
 
@@ -15,6 +15,8 @@ Use this when you want the EVE-NG host lifecycle to be rebuildable from infrastr
 - SSH access through GCP IAP
 - VM provisioning through `platform/gcp/platform-vm`
 - EVE-NG installation and configuration through `platform/linux/eve-ng`
+- a starter image set through `platform/linux/eve-ng-images`
+- a guest NAT network with DHCP for lab nodes that need outbound internet access
 - a basic EVE-NG health check through `platform/linux/eve-ng-healthcheck`
 - structured run records for each module step
 
@@ -24,6 +26,7 @@ Use this when you want the EVE-NG host lifecycle to be rebuildable from infrastr
 platform/gcp/lab-network
   -> platform/gcp/platform-vm
   -> platform/linux/eve-ng
+  -> platform/linux/eve-ng-images
   -> platform/linux/eve-ng-healthcheck
 ```
 
@@ -47,7 +50,9 @@ target environment are ready:
 - The operator can create Compute Engine networks, firewall rules, routers,
   NAT configuration, and instances.
 - EVE-NG secrets are seeded for the target environment.
-- The placeholder `CHANGE_ME_GCP_ZONE` in [blueprint.yml](blueprint.yml) has been copied or overridden with a real zone that supports the selected machine family.
+- The VM zone is derived from the initialized GCP region. An environment
+  overlay may select another zone in the same region when quota or capacity
+  requires it; a zone from a different region is rejected before apply.
 
 Seed the EVE-NG secrets before deployment:
 
@@ -74,6 +79,17 @@ hyops blueprint preflight \
   --blueprints-root blueprints
 ```
 
+Open the private EVE-NG UI after deployment:
+
+```bash
+hyops blueprint access --env dev --ref gcp/eve-ng@v1
+```
+
+HybridOps resolves the VM, project, and zone from module state, forwards HTTP
+through the existing IAP SSH path with the declared HybridOps key, opens the
+browser, and keeps access active until `Ctrl-C`. Port 80 remains closed at the
+GCP firewall. Use `--no-browser` when only the printed local URL is required.
+
 Deploy:
 
 ```bash
@@ -83,6 +99,18 @@ hyops blueprint deploy \
   --blueprints-root blueprints \
   --execute
 ```
+
+Rebuild the blueprint-managed resources:
+
+```bash
+hyops blueprint rebuild \
+  --env dev \
+  --ref gcp/eve-ng@v1 \
+  --execute
+```
+
+The command shows the destroy and deploy order and requests confirmation before
+the first destroy step.
 
 ## Default Shape
 
@@ -101,6 +129,26 @@ The shipped blueprint provisions one VM:
 The VM is placed on the private subnet created by the blueprint's lab-network
 step.
 
+The starter image set contains Alpine Linux, NETem, Tiny Core Linux, and Ubuntu
+Server. Additional public image entries are retained as commented choices in
+the blueprint. They are not downloaded unless an operator enables them. This
+keeps the first deployment relatively small and avoids filling the VM disk with
+desktop, security, and legacy images that a lab does not need.
+
+The blueprint downloads enabled images from their upstream links at deployment
+time. HybridOps does not include the image archives in its release package.
+
+## Guest Internet Access
+
+The EVE-NG host provides a guest NAT network labelled `Cloud9`. Connect a lab
+node interface to `Cloud9` and configure that interface for DHCP. The node
+receives an address from `172.29.129.50-172.29.129.200`, uses
+`172.29.129.1` as its gateway, and reaches the internet through the EVE-NG
+host's private GCP connection.
+
+DHCP is supplied by the EVE-NG host, not by GCP. GCP provides the upstream
+network path. No additional public IP is assigned to the lab node.
+
 ## Why This Exists
 
 Not every networking learner or platform operator has a Proxmox cluster available. A cloud-hosted EVE-NG path makes the host lifecycle easier to reproduce from a clean state while still keeping access private and controlled.
@@ -111,7 +159,8 @@ This blueprint turns the EVE-NG host into a normal platform outcome:
 - nested virtualization is explicitly enabled
 - access goes through IAP instead of exposing SSH publicly
 - EVE-NG configuration is a module step, not a manual shell session
-- the final health check produces evidence that the EVE-NG host is reachable
+- the declared starter images are installed before validation
+- the final health check records whether the EVE-NG host is reachable
 
 That makes the EVE-NG host disposable enough to rebuild and predictable enough to share as part of a training or network-emulation workflow.
 
@@ -120,6 +169,7 @@ That makes the EVE-NG host disposable enough to rebuild and predictable enough t
 - [platform/gcp/lab-network](../../../modules/platform/gcp/lab-network)
 - [platform/gcp/platform-vm](../../../modules/platform/gcp/platform-vm)
 - [platform/linux/eve-ng](../../../modules/platform/linux/eve-ng)
+- [platform/linux/eve-ng-images](../../../modules/platform/linux/eve-ng-images)
 - [platform/linux/eve-ng-healthcheck](../../../modules/platform/linux/eve-ng-healthcheck)
 
 ## On-Prem Alternative

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -22,10 +22,14 @@ access:
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
   native_console_mode: "eve-ng-qemu"
+  guest_network_label: "Cloud9"
+  guest_gateway: "172.29.129.1"
+  guest_dhcp_range: "172.29.129.50-172.29.129.200"
 
 steps:
   - id: gcp_eve_ng_network
     module_ref: "platform/gcp/lab-network"
+    execution_profile: "gcp-local@v1.0"
     state_instance: "gcp_eve_ng_network"
     action: "deploy"
     phase: "bootstrap"
@@ -41,6 +45,7 @@ steps:
 
   - id: gcp_eve_ng_vm
     module_ref: "platform/gcp/platform-vm"
+    execution_profile: "gcp-local@v1.0"
     state_instance: "gcp_eve_ng_vm"
     action: "deploy"
     phase: "bootstrap"
@@ -56,7 +61,8 @@ steps:
       context_id: "labs"
       network_state_ref: "platform/gcp/lab-network#gcp_eve_ng_network"
       subnetwork_output_key: "subnetwork_name"
-      zone: "CHANGE_ME_GCP_ZONE"
+      zone: ""
+      zone_from_init_region: true
       machine_type: "n2-standard-8"
       boot_disk_size_gb: 256
       boot_disk_type: "pd-standard"
@@ -106,6 +112,73 @@ steps:
       ssh_access_mode: "gcp-iap"
       connectivity_wait_s: 90
       eveng_resource_profile: "standard"
+      eveng_guest_nat_enabled: true
+
+  - id: gcp_eve_ng_images
+    module_ref: "platform/linux/eve-ng-images"
+    state_instance: "gcp_eve_ng_images"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_eve_ng_config
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_eve_ng_vm"
+      inventory_vm_groups:
+        targets:
+          - "eve-ng-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      eveng_images_source: "url"
+      eveng_images_logging_enabled: true
+      eveng_images_generate_report: true
+      eveng_images_list:
+        # Small, broadly useful starter set for a first lab deployment.
+        - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/LhBG1ZQI"
+          name: "linux-alpine-3.21.3.tar.gz"
+          type: "qemu"
+        - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/GopE0RJR"
+          name: "linux-netem.tar.gz"
+          type: "qemu"
+        - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/nkJjgBQL"
+          name: "linux-tinycore-6.4.tar.gz"
+          type: "qemu"
+        - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/uoIABDjA"
+          name: "linux-ubuntu-24.04.01-server.tar.gz"
+          type: "qemu"
+
+        # Optional public images. Enable only what a lab needs; desktop,
+        # security and legacy images can add substantial download and disk use.
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/2kIywDKR", name: "android-8.1-x86.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/u1ByjDLC", name: "android-9.1-x64.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/z1gwRLrb", name: "freebsd-13.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/6sQxhK7J", name: "freenas-11.3-U5.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/rkpgWJRR", name: "linux-alpine-3.18.4.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/utwBFI7C", name: "linux-centos-8.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/K44jUbIY", name: "linux-centos-9-stream.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/GswzBCzD", name: "linux-daloRadius-0.9.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/i4wBnSjb", name: "linux-debian-10.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/jkwEQKBI", name: "linux-freepbx-2302-1.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/mtwx2IpZ", name: "linux-kali-large-2019.3.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/OlIVQIKQ", name: "linux-metasploitable-2.0.0.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/2k52kILT", name: "linux-mint-21.1.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/q95EETIK", name: "linux-rhel-8.1.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/KkJxVQbT", name: "linux-rhel-8.4.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/DhxDWAYB", name: "linux-slax-9.11.0.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/qo5DFL6C", name: "linux-ubuntu-18.04-server.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/atJRjIoK", name: "linux-ubuntu-18.04.06-desktop.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/n0I21RAS", name: "linux-ubuntu-21.04-desktop.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/jwZ1VKoJ", name: "linux-ubuntu-21.10-desktop.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/6xIH0QTA", name: "linux-ubuntu-22.04-desktop.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/31JlSQjQ", name: "linux-ubuntu-22.04-server.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/2xpSBb4Y", name: "linux-ubuntu-22.04.02-server.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/mppnzTQT", name: "linux-ubuntu-mate-20.04.tar.gz", type: "qemu"}
+        # - {url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/u0QFzIpL", name: "linux-ubuntu-srv-16.04.4-webmin.tar.gz", type: "qemu"}
 
   - id: gcp_eve_ng_healthcheck
     module_ref: "platform/linux/eve-ng-healthcheck"
@@ -113,7 +186,7 @@ steps:
     action: "deploy"
     phase: "operations"
     requires:
-      - gcp_eve_ng_config
+      - gcp_eve_ng_images
     with_deps: false
     skip_if_state_ok: false
     contracts:

--- a/hyops/blueprint/planner.py
+++ b/hyops/blueprint/planner.py
@@ -43,6 +43,7 @@ def run_step_module_command(step: dict[str, Any], payload: dict[str, Any], ns, p
         out_dir=getattr(ns, "out_dir", None),
         state_instance=str(step.get("state_instance") or "").strip() or None,
         allow_state_drift_recreate=bool(step.get("verify_state_on_skip", False)),
+        profile_override=str(step.get("execution_profile") or "").strip() or None,
     )
     return int(module_command.run(step_ns))
 
@@ -255,6 +256,7 @@ def preflight_step(
                 bool(step.get("verify_state_on_skip", False))
                 and any(check.get("name") == "state_skip" for check in result["checks"])
             ),
+            profile_override=str(step.get("execution_profile") or "").strip() or None,
         )
         result["driver_preflight"] = driver_preflight
         driver_status = str(driver_preflight.get("status") or "").strip().lower()

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from typing import Any
 import yaml
 
@@ -242,6 +243,11 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         step_ids.add(step_id)
 
         module_ref = module_ref_field(step.get("module_ref"), f"steps[{idx}].module_ref")
+        execution_profile = str(step.get("execution_profile") or "").strip()
+        if execution_profile and not re.fullmatch(
+            r"[a-z0-9][a-z0-9@._-]*", execution_profile
+        ):
+            raise ValueError(f"steps[{idx}].execution_profile has invalid format")
 
         action = str(step.get("action") or "deploy").strip().lower()
         if action not in ACTION_SET:
@@ -345,6 +351,7 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             {
                 "id": step_id,
                 "module_ref": module_ref,
+                "execution_profile": execution_profile,
                 "action": action,
                 "phase": phase,
                 "requires": requires,

--- a/hyops/blueprint/tests/test_gcp_eve_ng.py
+++ b/hyops/blueprint/tests/test_gcp_eve_ng.py
@@ -1,0 +1,44 @@
+"""Tests for the complete GCP EVE-NG teaching blueprint."""
+
+from pathlib import Path
+from unittest import TestCase
+
+from hyops.blueprint.schema import load_blueprint, validate_blueprint
+
+
+class GcpEveNgBlueprintTest(TestCase):
+    def test_declares_complete_local_state_lab(self):
+        root = Path(__file__).resolve().parents[3]
+        path = root / "blueprints" / "gcp" / "eve-ng@v1" / "blueprint.yml"
+        validated = validate_blueprint(load_blueprint(path), path)
+
+        self.assertEqual(
+            validated["order"],
+            [
+                "gcp_eve_ng_network",
+                "gcp_eve_ng_vm",
+                "gcp_eve_ng_config",
+                "gcp_eve_ng_images",
+                "gcp_eve_ng_healthcheck",
+            ],
+        )
+        by_id = {step["id"]: step for step in validated["steps"]}
+        self.assertEqual(
+            by_id["gcp_eve_ng_network"]["execution_profile"],
+            "gcp-local@v1.0",
+        )
+        self.assertEqual(
+            by_id["gcp_eve_ng_vm"]["execution_profile"],
+            "gcp-local@v1.0",
+        )
+        self.assertTrue(by_id["gcp_eve_ng_vm"]["inputs"]["zone_from_init_region"])
+        self.assertTrue(
+            by_id["gcp_eve_ng_config"]["inputs"]["eveng_guest_nat_enabled"]
+        )
+        self.assertEqual(
+            len(by_id["gcp_eve_ng_images"]["inputs"]["eveng_images_list"]), 4
+        )
+        self.assertEqual(
+            by_id["gcp_eve_ng_healthcheck"]["requires"], ["gcp_eve_ng_images"]
+        )
+

--- a/hyops/commands/_apply_execute.py
+++ b/hyops/commands/_apply_execute.py
@@ -45,6 +45,7 @@ def run_single(
     allow_state_drift_recreate: bool = False,
     import_resource_address: str | None = None,
     import_resource_id: str | None = None,
+    profile_override: str | None = None,
 ) -> int:
     command_name = str(command_name or "apply").strip().lower()
     if command_name not in ("apply", "deploy", "plan", "validate", "destroy", "import"):
@@ -63,6 +64,8 @@ def run_single(
             lifecycle_command=command_name,
             invocation_command=command_name,
         )
+        if profile_override:
+            resolved.execution["profile"] = str(profile_override).strip()
     except Exception as exc:
         print(f"ERR: {exc}", file=sys.stderr)
         return 1

--- a/hyops/commands/apply.py
+++ b/hyops/commands/apply.py
@@ -47,7 +47,7 @@ def _configure_parser(p: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Apply dependencies even when their latest module state is already ok.",
     )
-    p.add_argument("--out-dir", default=None, help="Override evidence root.")
+    p.add_argument("--out-dir", default=None, help="Override run-record root.")
     p.add_argument(
         "--state-instance",
         default=None,
@@ -157,6 +157,7 @@ def run(ns) -> int:
                 skip_preflight=skip_preflight,
                 state_instance=None,
                 allow_state_drift_recreate=allow_state_drift_recreate,
+                profile_override=getattr(ns, "profile_override", None),
             )
             if rc != 0:
                 if rc == CANCELLED:
@@ -186,6 +187,7 @@ def run(ns) -> int:
         skip_preflight=skip_preflight,
         state_instance=state_instance,
         allow_state_drift_recreate=allow_state_drift_recreate,
+        profile_override=getattr(ns, "profile_override", None),
         import_resource_address=str(getattr(ns, "resource_address", "") or "").strip(),
         import_resource_id=str(getattr(ns, "resource_id", "") or "").strip(),
     )

--- a/hyops/drivers/iac/terragrunt/profiles/gcp-local@v1.0.profile.yml
+++ b/hyops/drivers/iac/terragrunt/profiles/gcp-local@v1.0.profile.yml
@@ -1,0 +1,64 @@
+api_version: hybridops/v1
+kind: DriverProfile
+
+profile_ref: "gcp-local@v1.0"
+driver: "iac/terragrunt"
+description: "Terragrunt profile for GCP stacks using local state and runtime-injected credentials."
+
+policy:
+  workspace:
+    backend_mode: local
+  constraints:
+    credential_contracts:
+      gcp:
+        required_tfvars:
+          - project_id
+          - region
+
+terragrunt:
+  bin: terragrunt
+  terraform_bin: terraform
+  init_args: ["init", "-no-color"]
+  apply_args: ["apply", "-auto-approve", "-input=false", "-no-color"]
+  output_args: ["output", "-json", "-no-color"]
+
+templates:
+  - src: gcp/root.hcl.tmpl
+    dst: root.hcl
+  - src: gcp/gcp.locals.hcl.tmpl
+    dst: gcp.locals.hcl
+
+env:
+  TG_LOG: ""
+
+workspace_policy:
+  enabled: false
+  provider: gcp
+  mode: local
+  strict: false
+
+hooks:
+  export_infra:
+    command:
+      - hyops
+      - inventory
+      - export-infra
+      - --target
+      - "{target}"
+      - --terragrunt-root
+      - "{hook_root}"
+      - --only-module
+      - .
+      - --changed-only
+    netbox_sync_command:
+      - hyops
+      - inventory
+      - sync-netbox
+      - --dataset
+      - "{netbox_dataset_json}"
+    hook_root_env: HYOPS_EXPORT_HOOK_ROOT
+    hook_root_default: "."
+    strict: false
+    redact: true
+    timeout_s: 120
+    netbox_sync_timeout_s: 120

--- a/hyops/runtime/module_resolve.py
+++ b/hyops/runtime/module_resolve.py
@@ -40,6 +40,7 @@ from hyops.runtime.module_state_contracts import (
     resolve_reverse_ssh_contract_from_state as _resolve_reverse_ssh_contract_from_state,
     resolve_router_contract_from_state as _resolve_router_contract_from_state,
     resolve_ssh_keys_from_init as _resolve_ssh_keys_from_init,
+    resolve_gcp_vm_zone_from_init as _resolve_gcp_vm_zone_from_init,
     resolve_target_host_from_state as _resolve_target_host_from_state,
     resolve_vyos_artifact_contract_from_state as _resolve_vyos_artifact_contract_from_state,
 )
@@ -185,6 +186,8 @@ def resolve_module(
                 inputs,
                 runtime_root=Path(runtime_root).expanduser().resolve() if runtime_root else None,
             )
+        if module_ref == "platform/gcp/platform-vm":
+            _resolve_gcp_vm_zone_from_init(inputs, state_root=state_root)
         _resolve_target_host_from_state(inputs, state_root=state_root, assumed_state_ok=assumed_state_ok)
         _resolve_inventory_groups_from_state(inputs, state_root=state_root, assumed_state_ok=assumed_state_ok)
         _resolve_kubeconfig_contract_from_state(inputs, state_root=state_root, assumed_state_ok=assumed_state_ok)

--- a/hyops/runtime/module_state_contracts.py
+++ b/hyops/runtime/module_state_contracts.py
@@ -1358,6 +1358,23 @@ def resolve_ssh_keys_from_init(
     inputs["ssh_keys"] = deduped
 
 
+def resolve_gcp_vm_zone_from_init(inputs: dict[str, Any], *, state_root: Path | None) -> None:
+    if not as_bool(inputs.get("zone_from_init_region"), default=False):
+        return
+    if state_root is None:
+        return
+    marker = read_marker(state_root.parent / "meta", "gcp")
+    context = marker.get("context") if isinstance(marker.get("context"), dict) else {}
+    region = str(context.get("region") or "").strip()
+    if not region:
+        return
+    zone = str(inputs.get("zone") or "").strip()
+    if not zone:
+        inputs["zone"] = f"{region}-a"
+    elif not zone.startswith(f"{region}-"):
+        raise ValueError(f"inputs.zone={zone!r} does not belong to initialized GCP region {region!r}")
+
+
 def normalize_repo_backend(raw: Any) -> str:
     backend = str(raw or "").strip().lower()
     if backend in ("gcp",):

--- a/hyops/runtime/tests/test_gcp.py
+++ b/hyops/runtime/tests/test_gcp.py
@@ -1,7 +1,11 @@
 from unittest import TestCase
 from unittest.mock import patch
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from hyops.runtime.gcp import diagnose_project_billing
+from hyops.runtime.module_state_contracts import resolve_gcp_vm_zone_from_init
+from hyops.runtime.readiness import write_marker
 
 
 class ProjectBillingTest(TestCase):
@@ -30,3 +34,28 @@ class ProjectBillingTest(TestCase):
         self.assertFalse(validated)
         self.assertFalse(enabled)
         self.assertIn("unexpected billingEnabled value", detail)
+
+
+class GcpVmZoneResolutionTest(TestCase):
+    def test_derives_zone_from_initialized_region(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_root = root / "state"
+            write_marker(root / "meta", "gcp", {"status": "ready", "context": {"region": "europe-west2"}})
+            inputs = {"zone": "", "zone_from_init_region": True}
+
+            resolve_gcp_vm_zone_from_init(inputs, state_root=state_root)
+
+        self.assertEqual(inputs["zone"], "europe-west2-a")
+
+    def test_rejects_zone_outside_initialized_region(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_root = root / "state"
+            write_marker(root / "meta", "gcp", {"status": "ready", "context": {"region": "europe-west2"}})
+
+            with self.assertRaisesRegex(ValueError, "does not belong"):
+                resolve_gcp_vm_zone_from_init(
+                    {"zone": "us-central1-a", "zone_from_init_region": True},
+                    state_root=state_root,
+                )

--- a/hyops/validators/platform/gcp/platform_vm.py
+++ b/hyops/validators/platform/gcp/platform_vm.py
@@ -118,8 +118,14 @@ def validate(inputs: dict[str, Any]) -> None:
         network_state_ref_value = _require_non_empty_str(network_state_ref, "inputs.network_state_ref")
         _reject_placeholder(network_state_ref_value, "inputs.network_state_ref")
 
-    zone = _require_non_empty_str(data.get("zone"), "inputs.zone")
-    _reject_placeholder(zone, "inputs.zone")
+    zone_from_init_region = data.get("zone_from_init_region")
+    if zone_from_init_region is not None:
+        _require_bool(zone_from_init_region, "inputs.zone_from_init_region")
+    zone = str(data.get("zone") or "").strip()
+    if not zone and not bool(zone_from_init_region):
+        _require_non_empty_str(zone, "inputs.zone")
+    if zone:
+        _reject_placeholder(zone, "inputs.zone")
     if not has_network_state_ref:
         network = _require_non_empty_str(data.get("network"), "inputs.network")
         _reject_placeholder(network, "inputs.network")

--- a/modules/platform/gcp/platform-vm/README.md
+++ b/modules/platform/gcp/platform-vm/README.md
@@ -24,6 +24,10 @@ It can also enable nested virtualization for workloads that need KVM in the gues
 - `network_state_ref`: resolves `inputs.network`
 - `subnetwork_output_key`: resolves `inputs.subnetwork` from a named output published by the network state
 - `ssh_keys_from_init`: resolves `inputs.ssh_keys` from `<root>/meta/gcp.ready.json` so blueprints do not need to embed a public key
+- `zone_from_init_region`: when explicitly enabled with an empty `zone`, derives
+  the `-a` zone from GCP init readiness and rejects an explicit zone from a
+  different region. Keep it disabled for governed modules that require an
+  explicit placement decision.
 
 SSH key source of truth is intentionally strict:
 

--- a/modules/platform/gcp/platform-vm/spec.yml
+++ b/modules/platform/gcp/platform-vm/spec.yml
@@ -20,6 +20,7 @@ inputs:
 
     # Location / network
     zone: "" # required
+    zone_from_init_region: false
     network_state_ref: ""
     network: "default"
     subnetwork: "" # optional (empty => let GCP pick default subnet for the zone)


### PR DESCRIPTION
Closes #76

## What changed
- add the declared local-state GCP execution profile
- derive VM placement from the initialized region
- add the starter image stage before health validation
- enable the Cloud9 guest NAT path and access guidance
- document the five-stage teaching-lab outcome

## Validation
- `python3 -m unittest hyops.blueprint.tests.test_gcp_eve_ng hyops.runtime.tests.test_gcp`
- `bash tools/ci/check-python.sh`