### PR TITLE
Add CLI routing smoke tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ Run the checks that cover the files you changed:
 
 ```bash
 bash tools/ci/check-python.sh
+python3 -m unittest hyops.tests.test_cli
 bash tools/ci/check-ruff.sh
 bash tools/ci/check-yaml.sh
 bash tools/ci/check-shell.sh

--- a/hyops/tests/__init__.py
+++ b/hyops/tests/__init__.py
@@ -1,0 +1,1 @@
+"""HybridOps CLI tests."""

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -1,0 +1,59 @@
+"""Smoke tests for the public HybridOps command table."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "hyops.cli", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class CliRoutingTests(unittest.TestCase):
+    def test_version(self) -> None:
+        result = run_cli("--version")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertRegex(result.stdout.strip(), r"^\d+\.\d+\.\d+(?:[-+].*)?$")
+
+    def test_top_level_help_lists_public_commands(self) -> None:
+        result = run_cli("--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for command in ("apply", "blueprint", "module", "state"):
+            self.assertIn(command, result.stdout)
+
+    def test_no_command_prints_help_and_returns_usage_error(self) -> None:
+        result = run_cli()
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("usage: hyops", result.stdout)
+
+    def test_selected_command_help(self) -> None:
+        for command in ("apply", "blueprint", "module", "state"):
+            with self.subTest(command=command):
+                result = run_cli(command, "--help")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(f"hyops {command}", result.stdout)
+
+    def test_unknown_command_returns_parser_error(self) -> None:
+        result = run_cli("not-a-command")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("invalid choice", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #17

## What changed
- cover version, top-level help, and the no-command path
- verify help routing for apply, blueprint, module, and state
- assert parser failure for an unknown command
- document the focused contributor test command

## Validation
- `python3 -m unittest hyops.tests.test_cli`
- `bash tools/ci/check-python.sh`
- Ruff was not available locally; CI runs the repository lint job.
