### PR TITLE
Document and test strict plugin mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,3 +93,10 @@ Small, reviewable pull requests are easier to test, understand, and merge.
 
 Do not report vulnerabilities in a public issue or pull request. Follow
 [SECURITY.md](.github/SECURITY.md) instead.
+
+## Plugin development
+
+Plugin discovery is tolerant by default: a registration error is written as a
+warning so the built-in command surface remains available. During plugin
+development or CI, set `HYOPS_STRICT_PLUGINS=1` to make driver or validator
+registration errors fail the command immediately.

--- a/hyops/tests/__init__.py
+++ b/hyops/tests/__init__.py
@@ -1,1 +1,1 @@
-"""HybridOps CLI tests."""
+"""HybridOps unit tests."""

--- a/hyops/tests/test_plugins.py
+++ b/hyops/tests/test_plugins.py
@@ -1,0 +1,73 @@
+"""Tests for optional and strict plugin registration."""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from contextlib import redirect_stderr
+from unittest.mock import patch
+
+from hyops import cli
+
+
+class PluginRegistrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        cli._DRIVERS_REGISTERED = False
+        cli._VALIDATORS_REGISTERED = False
+
+    def tearDown(self) -> None:
+        cli._DRIVERS_REGISTERED = False
+        cli._VALIDATORS_REGISTERED = False
+
+    def test_default_mode_warns_for_driver_plugin_failure(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.dict(os.environ, {"HYOPS_STRICT_PLUGINS": ""}),
+            patch.object(cli, "register_builtin_drivers"),
+            patch.object(cli, "register_driver_plugins", side_effect=RuntimeError("broken driver")),
+            redirect_stderr(stderr),
+        ):
+            cli._register_drivers()
+
+        self.assertIn("WARN: driver plugin registration failed: broken driver", stderr.getvalue())
+        self.assertTrue(cli._DRIVERS_REGISTERED)
+
+    def test_default_mode_warns_for_validator_plugin_failure(self) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.dict(os.environ, {"HYOPS_STRICT_PLUGINS": ""}),
+            patch.object(cli, "register_builtin_validators"),
+            patch.object(cli, "register_validator_plugins", side_effect=RuntimeError("broken validator")),
+            redirect_stderr(stderr),
+        ):
+            cli._register_validators()
+
+        self.assertIn("WARN: validator plugin registration failed: broken validator", stderr.getvalue())
+        self.assertTrue(cli._VALIDATORS_REGISTERED)
+
+    def test_strict_mode_raises_driver_plugin_failure(self) -> None:
+        with (
+            patch.dict(os.environ, {"HYOPS_STRICT_PLUGINS": "1"}),
+            patch.object(cli, "register_builtin_drivers"),
+            patch.object(cli, "register_driver_plugins", side_effect=RuntimeError("broken driver")),
+            self.assertRaisesRegex(RuntimeError, "broken driver"),
+        ):
+            cli._register_drivers()
+
+        self.assertFalse(cli._DRIVERS_REGISTERED)
+
+    def test_strict_mode_raises_validator_plugin_failure(self) -> None:
+        with (
+            patch.dict(os.environ, {"HYOPS_STRICT_PLUGINS": "1"}),
+            patch.object(cli, "register_builtin_validators"),
+            patch.object(cli, "register_validator_plugins", side_effect=RuntimeError("broken validator")),
+            self.assertRaisesRegex(RuntimeError, "broken validator"),
+        ):
+            cli._register_validators()
+
+        self.assertFalse(cli._VALIDATORS_REGISTERED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #18

## What changed
- verify that driver and validator registration failures warn in default mode
- verify that strict mode raises the original registration failure
- document when to set `HYOPS_STRICT_PLUGINS=1`

## Validation
- `python3 -m unittest hyops.tests.test_plugins`
- `bash tools/ci/check-python.sh`
