### PR TITLE
Add module catalog consistency check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,17 @@ state, and verification explicit in the blueprint contract.
 
 ## Validate your change
 
-Run the checks that cover the files you changed:
+Use a focused check while working on the relevant area:
+
+```bash
+python3 -m unittest hyops.tests.test_cli
+python3 tools/ci/check-module-catalog.py
+```
+
+Before opening a pull request, run the applicable full checks:
 
 ```bash
 bash tools/ci/check-python.sh
-python3 -m unittest hyops.tests.test_cli
 bash tools/ci/check-ruff.sh
 bash tools/ci/check-yaml.sh
 bash tools/ci/check-shell.sh

--- a/modules/platform/gcp/vm-firewall-rules/examples/inputs.example.yml
+++ b/modules/platform/gcp/vm-firewall-rules/examples/inputs.example.yml
@@ -1,0 +1,15 @@
+name_prefix: platform
+context_id: dev
+network: default
+rules:
+  - name_suffix: allow-ssh
+    description: SSH from the operator network
+    direction: INGRESS
+    source_ranges:
+      - 203.0.113.10/32
+    target_tags:
+      - allow-ssh
+    allow:
+      - protocol: tcp
+        ports:
+          - "22"

--- a/modules/platform/k8s/gcp-secret-store/examples/inputs.example.yml
+++ b/modules/platform/k8s/gcp-secret-store/examples/inputs.example.yml
@@ -1,0 +1,7 @@
+kubeconfig_state_ref: platform/gcp/gke-kubeconfig#gke_burst_kubeconfig
+cluster_state_ref: platform/gcp/gke-cluster#gke_burst_cluster
+secret_project_id: example-secrets-project
+eso_namespace: external-secrets
+service_account_namespace: external-secrets
+service_account_name: eso-gcp-secret-manager
+secret_store_name: gcp-secret-manager

--- a/tools/ci/check-module-catalog.py
+++ b/tools/ci/check-module-catalog.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Check that module contracts include their reviewable companion files."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def check_catalog(repo_root: Path) -> tuple[list[str], int]:
+    modules_root = repo_root / "modules"
+    failures: list[str] = []
+    spec_paths = sorted(modules_root.rglob("spec.yml"))
+
+    if not spec_paths:
+        return ["modules: no spec.yml files found"], 0
+
+    for spec_path in spec_paths:
+        module_dir = spec_path.parent
+        module_path = module_dir.relative_to(repo_root)
+
+        if not (module_dir / "README.md").is_file():
+            failures.append(f"{module_path}: missing README.md")
+
+        examples_dir = module_dir / "examples"
+        if not examples_dir.is_dir():
+            failures.append(f"{module_path}: missing examples/")
+        elif not any(path.is_file() for path in examples_dir.rglob("*")):
+            failures.append(f"{module_path}: examples/ contains no files")
+
+    return failures, len(spec_paths)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    failures, module_count = check_catalog(repo_root)
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}", file=sys.stderr)
+        return 1
+
+    print(f"module catalog: ok ({module_count} modules)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/check-python.sh
+++ b/tools/ci/check-python.sh
@@ -11,6 +11,8 @@ source "${SCRIPT_DIR}/lib/common.sh"
 
 hyops_ci::require_cmd python3
 
+python3 "${HYOPS_REPO_ROOT}/tools/ci/check-module-catalog.py"
+
 python3 -m compileall "${HYOPS_REPO_ROOT}/hyops"
 
 python3 -m unittest discover \


### PR DESCRIPTION
Closes #23

## What changed
- add a local checker for module README and example companions
- report the affected module path and missing catalog item
- add examples for the two modules that previously lacked them
- run the stable catalog check in the Python CI gate
- document the focused contributor command

## Validation
- `python3 tools/ci/check-module-catalog.py`
- `bash tools/ci/check-python.sh`
