### PR TITLE
Support Windows 11 through Ubuntu WSL2

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -13,13 +13,13 @@ import socket
 import subprocess
 import sys
 import time
-import webbrowser
 from pathlib import Path
 from typing import Any
 
 from hyops.drivers.iac.terragrunt.contracts import get_contract
-from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
+from hyops.runtime.browser import open_operator_url
 from hyops.runtime.evidence import new_run_id
+from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import read_module_state, split_module_state_ref
 from hyops.runtime.paths import resolve_runtime_paths
@@ -731,7 +731,7 @@ def run_access(ns) -> int:
                 print(f"URL: {url}")
                 _print_guest_network_guidance(access)
                 if not bool(getattr(ns, "no_browser", False)):
-                    webbrowser.open(url)
+                    open_operator_url(url)
                 return 0
 
             ssh = shutil.which("ssh")
@@ -809,7 +809,7 @@ def run_access(ns) -> int:
             if proc.poll() is not None:
                 return OPERATOR_ERROR
             if not bool(getattr(ns, "no_browser", False)):
-                webbrowser.open(url)
+                open_operator_url(url)
             try:
                 return int(proc.wait())
             except KeyboardInterrupt:
@@ -905,7 +905,7 @@ def run_access(ns) -> int:
             _stop_process(iap_proc)
             return OPERATOR_ERROR
         if not bool(getattr(ns, "no_browser", False)):
-            webbrowser.open(url)
+            open_operator_url(url)
         try:
             rc = int(proc.wait())
             _stop_process(iap_proc)

--- a/hyops/init/targets/hashicorp_vault.py
+++ b/hyops/init/targets/hashicorp_vault.py
@@ -9,10 +9,10 @@ import argparse
 import getpass
 import os
 from pathlib import Path
-import webbrowser
 
 from hyops.init.helpers import init_evidence_path, init_run_id, read_kv_file
 from hyops.init.shared_args import add_init_shared_args
+from hyops.runtime.browser import open_operator_url
 from hyops.runtime.config import write_template_if_missing
 from hyops.runtime.exitcodes import (
     CONFIG_TEMPLATE_WRITTEN,
@@ -322,7 +322,7 @@ def run(ns) -> int:
             ui_url = _vault_ui_url(vault_addr)
             opened = False
             try:
-                opened = bool(webbrowser.open(ui_url, new=2))
+                opened = open_operator_url(ui_url, new=2)
             except Exception:
                 opened = False
             if opened:

--- a/hyops/runtime/browser.py
+++ b/hyops/runtime/browser.py
@@ -1,0 +1,50 @@
+"""Open operator URLs on the host desktop.
+
+purpose: Bridge browser launch behaviour across Linux, macOS, and Windows WSL.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import webbrowser
+from collections.abc import Mapping
+
+
+def is_windows_wsl(
+    *,
+    environ: Mapping[str, str] | None = None,
+    kernel_release: str | None = None,
+) -> bool:
+    env = os.environ if environ is None else environ
+    if platform.system() != "Linux":
+        return False
+    if env.get("WSL_DISTRO_NAME") or env.get("WSL_INTEROP"):
+        return True
+    release = platform.release() if kernel_release is None else kernel_release
+    return "microsoft" in release.lower()
+
+
+def open_operator_url(url: str, *, new: int = 0) -> bool:
+    """Open a URL in the desktop browser, including the Windows host from WSL."""
+
+    if is_windows_wsl():
+        for command in ("wslview", "explorer.exe"):
+            executable = shutil.which(command)
+            if not executable:
+                continue
+            try:
+                subprocess.Popen(
+                    [executable, url],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                return True
+            except OSError:
+                continue
+    return bool(webbrowser.open(url, new=new))

--- a/hyops/runtime/tests/test_browser.py
+++ b/hyops/runtime/tests/test_browser.py
@@ -1,0 +1,56 @@
+"""Tests for operator browser integration."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock, patch
+
+from hyops.runtime.browser import is_windows_wsl, open_operator_url
+
+
+class BrowserTests(unittest.TestCase):
+    @patch("hyops.runtime.browser.platform.system", return_value="Linux")
+    def test_detects_wsl_from_environment(self, _system: Mock) -> None:
+        self.assertTrue(
+            is_windows_wsl(environ={"WSL_DISTRO_NAME": "Ubuntu"}, kernel_release="6.6.0")
+        )
+
+    @patch("hyops.runtime.browser.platform.system", return_value="Linux")
+    def test_detects_wsl_from_kernel_release(self, _system: Mock) -> None:
+        self.assertTrue(
+            is_windows_wsl(
+                environ={}, kernel_release="5.15.167.4-microsoft-standard-WSL2"
+            )
+        )
+
+    @patch("hyops.runtime.browser.platform.system", return_value="Linux")
+    def test_plain_linux_is_not_wsl(self, _system: Mock) -> None:
+        self.assertFalse(is_windows_wsl(environ={}, kernel_release="6.8.0-generic"))
+
+    @patch("hyops.runtime.browser.subprocess.Popen")
+    @patch("hyops.runtime.browser.shutil.which")
+    @patch("hyops.runtime.browser.is_windows_wsl", return_value=True)
+    def test_wsl_opens_url_with_host_bridge(
+        self, _is_wsl: Mock, which: Mock, popen: Mock
+    ) -> None:
+        which.side_effect = (
+            lambda command: f"/usr/bin/{command}" if command == "wslview" else None
+        )
+
+        self.assertTrue(open_operator_url("http://127.0.0.1:8080/"))
+
+        popen.assert_called_once()
+        self.assertEqual(
+            popen.call_args.args[0],
+            ["/usr/bin/wslview", "http://127.0.0.1:8080/"],
+        )
+
+    @patch("hyops.runtime.browser.webbrowser.open", return_value=True)
+    @patch("hyops.runtime.browser.is_windows_wsl", return_value=False)
+    def test_non_wsl_uses_python_browser(self, _is_wsl: Mock, browser_open: Mock) -> None:
+        self.assertTrue(open_operator_url("https://example.invalid/", new=2))
+        browser_open.assert_called_once_with("https://example.invalid/", new=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/install-windows.cmd
+++ b/install-windows.cmd
@@ -1,0 +1,291 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+rem purpose: Install HybridOps.Core into Ubuntu 24.04 on Windows WSL2.
+rem maintainer: HybridOps.Tech
+
+set "DISTRO=Ubuntu-24.04"
+set "FORCE=false"
+if /I "%~1"=="--force" set "FORCE=true"
+if /I "%~1"=="/force" set "FORCE=true"
+
+echo.
+echo HybridOps.Core for Windows
+echo --------------------------
+echo HybridOps runs inside Ubuntu 24.04 on Windows Subsystem for Linux 2.
+echo This bootstrap prepares that environment, verifies the release package,
+echo and starts the HybridOps.Core installer.
+echo No Windows component will be changed without your confirmation.
+echo.
+echo [1/4] Checking Windows prerequisites...
+
+where wsl.exe >nul 2>&1
+if errorlevel 1 (
+  echo WSL is not available.
+  echo Open Terminal as Administrator and run: wsl --install -d %DISTRO%
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+wsl.exe --status >nul 2>&1
+if errorlevel 1 (
+  echo.
+  echo Windows Subsystem for Linux needs to be installed.
+  echo This is a one-time Windows setup for WSL2 and Ubuntu 24.04.
+  echo Windows may require a restart before HybridOps installation can continue.
+  echo.
+  set "CONFIRM="
+  set /p "CONFIRM=Install WSL2 and %DISTRO% now? [y/N]: "
+  if /I not "!CONFIRM!"=="y" (
+    echo Installation cancelled. No Windows components were changed.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b 0
+  )
+  fltmc >nul 2>&1
+  if not errorlevel 1 (
+    echo Installing WSL in this administrator window...
+    wsl.exe --install -d %DISTRO% --no-launch
+  ) else (
+    echo Windows will request administrator approval once.
+    powershell.exe -NoProfile -Command "$process = Start-Process -FilePath 'wsl.exe' -Verb RunAs -Wait -PassThru -ArgumentList '--install','-d','%DISTRO%','--no-launch'; exit $process.ExitCode"
+  )
+  if errorlevel 1 (
+    echo WSL installation was cancelled or failed.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b 2
+  )
+  echo WSL setup finished.
+  set "RESTART_NOW="
+  set /p "RESTART_NOW=Restart Windows now to complete WSL setup? [y/N]: "
+  if /I "!RESTART_NOW!"=="y" (
+    echo Windows will restart in 15 seconds. Save any open work.
+    shutdown.exe /r /t 15 /c "Complete Windows Subsystem for Linux setup"
+    if errorlevel 1 (
+      echo Windows could not schedule the restart. Restart manually before continuing.
+      echo Press any key to close this window.
+      pause >nul
+      exit /b 2
+    )
+    exit /b 10
+  )
+  echo Restart Windows later, then run install-windows.cmd again.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 10
+)
+
+set "ARCHIVE="
+set "ARCHIVE_COUNT=0"
+for %%F in ("%~dp0hybridops-core-*.tar.gz") do (
+  if exist "%%~fF" (
+    set /a ARCHIVE_COUNT+=1
+    set "ARCHIVE=%%~fF"
+  )
+)
+if not "%ARCHIVE_COUNT%"=="1" (
+  echo Place this installer beside exactly one HybridOps.Core .tar.gz archive.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+set "HELPER=%~dp0install-windows-wsl.sh"
+if not exist "%HELPER%" (
+  echo Missing Windows WSL helper: %HELPER%
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+echo.
+echo [2/4] Checking Ubuntu 24.04...
+powershell.exe -NoProfile -Command "$names = @(wsl.exe --list --quiet) | ForEach-Object { ($_ -replace [char]0, '').Trim() }; if ($names -contains '%DISTRO%') { exit 0 } else { exit 1 }"
+if errorlevel 1 (
+  echo.
+  echo %DISTRO% is not installed.
+  echo HybridOps uses this Linux environment on Windows.
+  echo.
+  echo Ubuntu will ask you to create a Linux username and password.
+  echo Setup returns to this installer after the account is created.
+  echo.
+  set "CONFIRM="
+  set /p "CONFIRM=Install %DISTRO% on WSL2 now? [y/N]: "
+  if /I not "!CONFIRM!"=="y" (
+    echo Installation cancelled. No distribution was installed.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b 0
+  )
+  fltmc >nul 2>&1
+  if not errorlevel 1 (
+    echo Installing %DISTRO% in this administrator window...
+    wsl.exe --install -d %DISTRO% --no-launch
+  ) else (
+    powershell.exe -NoProfile -Command "$process = Start-Process -FilePath 'wsl.exe' -Verb RunAs -Wait -PassThru -ArgumentList '--install','-d','%DISTRO%','--no-launch'; exit $process.ExitCode"
+  )
+  if errorlevel 1 (
+    echo %DISTRO% installation was cancelled or failed.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b 2
+  )
+  powershell.exe -NoProfile -Command "$names = @(wsl.exe --list --quiet) | ForEach-Object { ($_ -replace [char]0, '').Trim() }; if ($names -contains '%DISTRO%') { exit 0 } else { exit 1 }"
+  if errorlevel 1 (
+    echo %DISTRO% did not register successfully.
+    echo Restart Windows, then run install-windows.cmd again.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b 2
+  )
+  echo %DISTRO% is installed.
+)
+
+echo Provisioning %DISTRO%...
+echo Create the Ubuntu username and password when prompted.
+start "Ubuntu 24.04 account setup" wsl.exe -d %DISTRO%
+if errorlevel 1 (
+  echo %DISTRO% is installed but could not be started.
+  echo Open %DISTRO% from the Start menu and complete its username prompt.
+  echo Then run install-windows.cmd again.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+set "WSL_USER="
+set /a "ACCOUNT_WAIT=0"
+timeout /t 1 /nobreak >nul
+:wait_for_ubuntu_user
+for /f "tokens=1 delims=:" %%U in ('wsl.exe -d %DISTRO% -u root -- getent passwd 1000 2^>nul') do set "WSL_USER=%%U"
+if defined WSL_USER goto ubuntu_user_ready
+set /a "ACCOUNT_WAIT+=1"
+if !ACCOUNT_WAIT! GEQ 600 goto ubuntu_user_timeout
+timeout /t 1 /nobreak >nul
+goto wait_for_ubuntu_user
+
+:ubuntu_user_timeout
+echo Ubuntu account setup did not complete within 10 minutes.
+echo Complete the username prompt, then run this installer again.
+echo Press any key to close this window.
+pause >nul
+exit /b 2
+
+:ubuntu_user_ready
+if not defined WSL_USER (
+  echo Unable to identify the Ubuntu user account.
+  echo Open %DISTRO% once, complete its username prompt, then run this installer again.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+if /I "!WSL_USER!"=="root" (
+  echo Ubuntu returned an invalid default user.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+echo Ubuntu account created. Finalizing WSL setup...
+wsl.exe --terminate %DISTRO% >nul 2>&1
+echo Starting Ubuntu as !WSL_USER!...
+set "WSL_UID="
+for /f "delims=" %%U in ('wsl.exe -d %DISTRO% -u !WSL_USER! -- id -u') do set "WSL_UID=%%U"
+if not "!WSL_UID!"=="1000" (
+  echo Ubuntu user validation failed for !WSL_USER! ^(uid=!WSL_UID!^).
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+echo Ubuntu user: !WSL_USER!
+
+echo.
+echo Checking that Ubuntu is using WSL2...
+wsl.exe -d %DISTRO% -- bash -lc "grep -qi microsoft-standard-wsl2 /proc/sys/kernel/osrelease"
+if errorlevel 1 (
+  set "CONFIRM="
+  set /p "CONFIRM=Convert %DISTRO% to WSL2 now? [y/N]: "
+  if /I not "!CONFIRM!"=="y" (
+    echo Installation cancelled. The distribution was not converted.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b 0
+  )
+  echo Converting %DISTRO% to WSL2...
+  wsl.exe --set-version %DISTRO% 2
+  if errorlevel 1 (
+    echo WSL2 conversion failed.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b 2
+  )
+)
+
+echo.
+echo [3/4] Verifying and preparing the release package...
+for /f "usebackq delims=" %%P in (`wsl.exe -d %DISTRO% -u !WSL_USER! -- wslpath -u "%ARCHIVE%"`) do set "WSL_ARCHIVE=%%P"
+if not defined WSL_ARCHIVE (
+  echo Unable to map the release archive into %DISTRO%.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+if not "!WSL_ARCHIVE:~0,1!"=="/" (
+  echo Invalid WSL archive path: !WSL_ARCHIVE!
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+for /f "usebackq delims=" %%P in (`wsl.exe -d %DISTRO% -u !WSL_USER! -- wslpath -u "%HELPER%"`) do set "WSL_HELPER=%%P"
+if not defined WSL_HELPER (
+  echo Unable to map the WSL installer helper into %DISTRO%.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+if not "!WSL_HELPER:~0,1!"=="/" (
+  echo Invalid WSL helper path: !WSL_HELPER!
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+echo.
+echo [4/4] Installing HybridOps.Core in %DISTRO%...
+wsl.exe -d %DISTRO% -u !WSL_USER! -- bash "%WSL_HELPER%" "%WSL_ARCHIVE%" "%FORCE%"
+if errorlevel 1 (
+  echo HybridOps.Core installation failed.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+wsl.exe -d %DISTRO% -u !WSL_USER! -- bash -lc "command -v hyops >/dev/null 2>&1 && hyops --help >/dev/null 2>&1"
+if errorlevel 1 (
+  echo HybridOps.Core did not pass its final command check.
+  echo Press any key to close this window.
+  pause >nul
+  exit /b 2
+)
+
+echo.
+set "CREATE_SHORTCUT="
+set /p "CREATE_SHORTCUT=Create a HybridOps.Core desktop shortcut? [y/N]: "
+if /I "!CREATE_SHORTCUT!"=="y" (
+  powershell.exe -NoProfile -Command "$shell = New-Object -ComObject WScript.Shell; $shortcut = $shell.CreateShortcut([Environment]::GetFolderPath('Desktop') + '\HybridOps.Core.lnk'); $shortcut.TargetPath = $env:SystemRoot + '\System32\wsl.exe'; $shortcut.Arguments = '-d %DISTRO% --cd ~'; $shortcut.WorkingDirectory = $env:USERPROFILE; $shortcut.IconLocation = $env:SystemRoot + '\System32\wsl.exe,0'; $shortcut.Description = 'Open HybridOps.Core in Ubuntu'; $shortcut.Save()"
+  if errorlevel 1 (
+    echo WARN: unable to create the HybridOps.Core desktop shortcut.
+  ) else (
+    echo Desktop shortcut created: HybridOps.Core
+  )
+)
+
+echo.
+echo HybridOps.Core installation completed.
+echo Run open-hybridops.cmd from this folder, then enter: hyops --help
+echo Press any key to close this window.
+pause >nul
+exit /b 0

--- a/open-hybridops.cmd
+++ b/open-hybridops.cmd
@@ -1,0 +1,10 @@
+@echo off
+rem purpose: Open HybridOps.Core in its Ubuntu WSL2 environment.
+rem maintainer: HybridOps.Tech
+
+wsl.exe -d Ubuntu-24.04 --cd ~
+if errorlevel 1 (
+  echo Unable to open Ubuntu-24.04.
+  echo Confirm its state with: wsl --list --verbose
+  pause
+)

--- a/pkg/build_release.sh
+++ b/pkg/build_release.sh
@@ -28,6 +28,9 @@ OUT_DIR="${OUT_DIR:-${REPO_ROOT}/dist/releases}"
 PACKAGE_ROOT="hybridops-core-${RELEASE_LABEL}"
 TARBALL_PATH="${OUT_DIR}/${PACKAGE_ROOT}.tar.gz"
 SHA256_PATH="${TARBALL_PATH}.sha256"
+WINDOWS_INSTALLER_PATH="${OUT_DIR}/install-windows.cmd"
+WINDOWS_HELPER_PATH="${REPO_ROOT}/tools/install/windows/install-windows-wsl.sh"
+WINDOWS_BUNDLE_PATH="${OUT_DIR}/${PACKAGE_ROOT}-windows.zip"
 BUILD_WHEELHOUSE="${HYOPS_RELEASE_BUILD_WHEELHOUSE:-true}"
 
 WORK_DIR="$(mktemp -d)"
@@ -39,6 +42,7 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "${OUT_DIR}" "${STAGE_ROOT}"
+rm -f "${OUT_DIR}/install-windows.ps1"
 
 estimate_manifest_bytes() {
   local relpath=""
@@ -157,8 +161,55 @@ tar -C "${WORK_DIR}" -czf "${TARBALL_PATH}" "${PACKAGE_ROOT}"
   cd "${OUT_DIR}"
   sha256sum "$(basename "${TARBALL_PATH}")" >"$(basename "${SHA256_PATH}")"
 )
+cp "${REPO_ROOT}/install-windows.cmd" "${WINDOWS_INSTALLER_PATH}"
+
+WINDOWS_STAGE="${WORK_DIR}/${PACKAGE_ROOT}-windows"
+mkdir -p "${WINDOWS_STAGE}"
+cp "${TARBALL_PATH}" "${SHA256_PATH}" "${WINDOWS_INSTALLER_PATH}" "${WINDOWS_HELPER_PATH}" \
+  "${REPO_ROOT}/open-hybridops.cmd" "${WINDOWS_STAGE}/"
+cat >"${WINDOWS_STAGE}/README-WINDOWS.txt" <<EOF
+HybridOps.Core for Windows 11 (WSL2)
+
+1. Extract every file from this ZIP archive.
+2. Run install-windows.cmd.
+
+After installation, run open-hybridops.cmd to open HybridOps.Core. The
+installer can also create an optional desktop shortcut.
+
+The first Ubuntu launch may ask you to create a Linux username and password.
+Complete that prompt. Control returns to the installer automatically.
+
+If Windows features require a reboot, the bootstrap asks before scheduling it.
+The default answer is No.
+
+For replacement of an existing installation, run install-windows.cmd --force.
+
+The bootstrap verifies the included release archive, prepares Ubuntu 24.04 on
+WSL2, and starts the HybridOps.Core installer.
+
+The initial installation provides the HybridOps CLI. Install prerequisites for
+one target afterward:
+  hyops setup gcp
+  hyops setup azure
+  hyops setup proxmox
+EOF
+python3 - "${WINDOWS_STAGE}" "${WINDOWS_BUNDLE_PATH}" <<'PY'
+from pathlib import Path
+import sys
+import zipfile
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+with zipfile.ZipFile(target, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+    for path in sorted(source.iterdir()):
+        archive.write(path, arcname=path.name)
+PY
 
 echo "Built bundle:"
 echo "  ${TARBALL_PATH}"
 echo "Checksum:"
 echo "  ${SHA256_PATH}"
+echo "Windows bootstrap:"
+echo "  ${WINDOWS_INSTALLER_PATH}"
+echo "Windows bundle:"
+echo "  ${WINDOWS_BUNDLE_PATH}"

--- a/pkg/manifest.yml
+++ b/pkg/manifest.yml
@@ -4,6 +4,7 @@
 
 include:
   - install.sh
+  - install-windows.cmd
   - LICENSE
   - README
   - CHANGELOG

--- a/tools/install/lib/common.sh
+++ b/tools/install/lib/common.sh
@@ -11,6 +11,19 @@ hyops_install_need_cmd() {
   }
 }
 
+hyops_install_is_windows_wsl() {
+  [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]] || return 1
+  if [[ -n "${WSL_DISTRO_NAME:-}" || -n "${WSL_INTEROP:-}" ]]; then
+    return 0
+  fi
+
+  local kernel_release="${HYOPS_TEST_KERNEL_RELEASE:-}"
+  if [[ -z "${kernel_release}" ]]; then
+    kernel_release="$(uname -r 2>/dev/null || true)"
+  fi
+  [[ "${kernel_release,,}" == *microsoft* ]]
+}
+
 hyops_install_set_blueprint_payload_read_only() {
   local root="$1"
   local bp_root="${root}/blueprints"

--- a/tools/install/windows/install-windows-wsl.sh
+++ b/tools/install/windows/install-windows-wsl.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# purpose: Complete the Windows bootstrap inside Ubuntu on WSL2.
+# maintainer: HybridOps.Tech
+
+archive="${1:-}"
+force_install="${2:-false}"
+
+[[ -f "${archive}" ]] || {
+  echo "ERR: release archive not found: ${archive}" >&2
+  exit 2
+}
+
+if ! python3 -c 'import ensurepip' >/dev/null 2>&1; then
+  echo "[windows] installing the Ubuntu Python virtual-environment prerequisite"
+  sudo apt-get update
+  sudo apt-get install -y python3-venv
+fi
+
+checksum="${archive}.sha256"
+if [[ -f "${checksum}" ]]; then
+  (
+    cd "$(dirname -- "${archive}")"
+    sha256sum -c "$(basename -- "${checksum}")"
+  )
+else
+  echo "WARN: matching .sha256 file not found; release checksum was not verified" >&2
+fi
+
+install_root="${HOME}/hybridops/windows-install"
+archive_list="$(mktemp)"
+cleanup() {
+  rm -f "${archive_list}"
+}
+trap cleanup EXIT
+
+tar -tzf "${archive}" >"${archive_list}"
+package_dir="$(awk -F/ 'NF {print $1; exit}' "${archive_list}")"
+[[ -n "${package_dir}" ]] || {
+  echo "ERR: release archive is empty" >&2
+  exit 2
+}
+
+mkdir -p "${install_root}"
+rm -rf "${install_root:?}/${package_dir}"
+tar -xzf "${archive}" -C "${install_root}"
+cd "${install_root}/${package_dir}"
+
+args=()
+if [[ "${force_install}" == "true" ]]; then
+  args+=(--force)
+fi
+exec ./install.sh "${args[@]}"


### PR DESCRIPTION
Closes #88.

## What changed

- adds the Windows WSL2 bootstrap and packaged launcher
- installs Core under the Ubuntu user and validates the result
- keeps desktop shortcut creation optional
- opens browser-assisted commands on the Windows host
- packages the Windows ZIP alongside the standard release archive

## Why

Windows operators need a supported path that retains the existing Linux runtime and command contracts without requiring a separate Windows implementation.

## Validation

- Python test suite
- installer quality checks
- Windows 11 installation exercised through fresh WSL2 and Ubuntu account setup