### PR TITLE
Provide target-oriented prerequisite setup

### DIFF
--- a/hyops/runtime/command_evidence.py
+++ b/hyops/runtime/command_evidence.py
@@ -60,6 +60,8 @@ def run_streamed(
     env: Mapping[str, str],
     evidence_dir: Path,
     command: str,
+    stream_output: bool = True,
+    announce: bool = True,
 ) -> int:
     started_at = _utc_now()
     output_path = evidence_dir / "output.log"
@@ -78,8 +80,9 @@ def run_streamed(
         assert process.stdout is not None
         for raw_line in process.stdout:
             safe_line = redact_text(raw_line)
-            sys.stdout.write(safe_line)
-            sys.stdout.flush()
+            if stream_output:
+                sys.stdout.write(safe_line)
+                sys.stdout.flush()
             output.write(safe_line)
             output.flush()
         exit_code = int(process.wait())
@@ -90,7 +93,8 @@ def run_streamed(
         started_at=started_at,
         exit_code=exit_code,
     )
-    print(f"run record: {evidence_dir}")
+    if announce:
+        print(f"run record: {evidence_dir}")
     return exit_code
 
 

--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -16,6 +16,24 @@ from hyops.runtime.exitcodes import OK, INTERNAL_ERROR, OPERATOR_ERROR
 from hyops.runtime.command_evidence import PythonCommandEvidence, command_evidence_dir, run_streamed
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
+from hyops.runtime.progress import ProgressDisplay, verbose_enabled
+
+
+TARGET_STEPS = {
+    "gcp": ("base", "cloud-gcp", "galaxy"),
+    "azure": ("base", "cloud-azure", "galaxy"),
+    "proxmox": ("base", "galaxy"),
+}
+
+SETUP_LABELS = {
+    "base": "Base tools",
+    "cloud-gcp": "GCP tools",
+    "cloud-azure": "Azure tools",
+    "galaxy": "Galaxy dependencies",
+    "all": "All setup components",
+}
+
+TARGET_LABELS = {"gcp": "GCP", "azure": "Azure", "proxmox": "Proxmox"}
 
 
 def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
@@ -23,6 +41,13 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
     #   hyops setup base --sudo
     #   hyops setup galaxy
     common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Stream setup output while retaining the run record.",
+    )
     common.add_argument(
         "--root",
         "--core-root",
@@ -33,18 +58,27 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
     common.add_argument(
         "--env",
         default=argparse.SUPPRESS,
-        help="Target runtime environment for installers that write into runtime state (e.g. ansible).",
+        help=(
+            "Target runtime environment for installers that write into runtime state "
+            "(for example, Galaxy)."
+        ),
     )
     common.add_argument(
         "--runtime-root",
         default=argparse.SUPPRESS,
-        help="Override runtime root for installers that write into runtime state (mutually exclusive with --env).",
+        help=(
+            "Override runtime root for installers that write into runtime state "
+            "(mutually exclusive with --env)."
+        ),
     )
     common.add_argument(
         "--sudo",
         action="store_true",
         default=argparse.SUPPRESS,
-        help="Run setup script via sudo (recommended for system installers).",
+        help=(
+            "Run an individual setup script via sudo; target setup elevates "
+            "system stages automatically."
+        ),
     )
     common.add_argument(
         "--dry-run",
@@ -57,14 +91,14 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
         "--force",
         action="store_true",
         default=argparse.SUPPRESS,
-        help="Force reinstall where supported (currently: galaxy, all).",
+        help="Force Galaxy dependency installation where supported.",
     )
     common.add_argument(
         "--hybridops-source",
         choices=("release", "git"),
         default=argparse.SUPPRESS,
         help=(
-            "How to source HybridOps collections for setup galaxy/all. "
+            "How to source HybridOps collections for setup galaxy/all or target setup. "
             "release installs the pinned published collection artifacts; git installs pinned "
             "collections from Git repositories into runtime state."
         ),
@@ -78,22 +112,32 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
         ),
     )
 
-    p = sp.add_parser("setup", help="Install prerequisites (explicit operator action).", parents=[common])
+    p = sp.add_parser(
+        "setup",
+        help="Install prerequisites (explicit operator action).",
+        parents=[common],
+    )
     ssp = p.add_subparsers(dest="setup_cmd", required=True)
 
     _add(ssp, "base", "Install base system prerequisites.", parents=[common])
-    _add(ssp, "galaxy", "Install Ansible Galaxy dependencies into the runtime state directory.", parents=[common])
+    _add(
+        ssp,
+        "galaxy",
+        "Install Ansible Galaxy dependencies into runtime state.",
+        parents=[common],
+    )
     _add(ssp, "cloud-azure", "Install Azure CLI prerequisites.", parents=[common])
     _add(ssp, "cloud-gcp", "Install GCP SDK prerequisites.", parents=[common])
     _add(ssp, "all", "Run base + ansible + cloud installers.", parents=[common])
     _add(ssp, "check", "Check presence of common tools (no installs).", parents=[common])
 
-    # Aliases (operator-friendly)
+    # Compatibility aliases and complete target setup commands.
     _add(ssp, "ansible", "Compatibility alias for: galaxy.", parents=[common])
     _add(ssp, "config-mgmt", "Alias for: galaxy.", parents=[common])
     _add(ssp, "config-management", "Alias for: galaxy.", parents=[common])
-    _add(ssp, "azure", "Alias for: cloud-azure.", parents=[common])
-    _add(ssp, "gcp", "Alias for: cloud-gcp.", parents=[common])
+    _add(ssp, "azure", "Install Azure workstation prerequisites.", parents=[common])
+    _add(ssp, "gcp", "Install GCP workstation prerequisites.", parents=[common])
+    _add(ssp, "proxmox", "Install Proxmox workstation prerequisites.", parents=[common])
 
     p.set_defaults(_handler=run)
 
@@ -161,6 +205,30 @@ def _script_for(action: str) -> str | None:
     return mapping.get(action)
 
 
+def _setup_argv(
+    action: str,
+    script: Path,
+    *,
+    runtime_root: Path | None,
+    force: bool,
+    hybridops_source: str | None,
+    hybridops_git_manifest: str | None,
+    elevate: bool,
+) -> list[str]:
+    argv = ["bash", str(script)]
+    if action == "galaxy" and runtime_root is not None:
+        argv += ["--root", str(runtime_root)]
+    if force and action in ("galaxy", "all"):
+        argv += ["--force"]
+    if hybridops_source and action in ("galaxy", "all"):
+        argv += ["--hybridops-source", hybridops_source]
+    if hybridops_git_manifest and action in ("galaxy", "all"):
+        argv += ["--hybridops-git-manifest", hybridops_git_manifest]
+    if elevate:
+        argv = ["sudo", "-H", "-E"] + argv
+    return argv
+
+
 def _run_check() -> int:
     checks: list[tuple[str, list[str]]] = [
         ("python3", ["python3"]),
@@ -177,13 +245,24 @@ def _run_check() -> int:
         ("gpg", ["gpg"]),
         ("pass", ["pass"]),
         # Different distros provide different pinentry flavors.
-        ("pinentry", ["pinentry", "pinentry-mac", "pinentry-curses", "pinentry-tty", "pinentry-gtk-2"]),
+        (
+            "pinentry",
+            [
+                "pinentry",
+                "pinentry-mac",
+                "pinentry-curses",
+                "pinentry-tty",
+                "pinentry-gtk-2",
+            ],
+        ),
     ]
     ok = True
     for label, candidates in checks:
         found = ""
         for cand in candidates:
-            rc = subprocess.call(["/usr/bin/env", "bash", "-lc", f"command -v {cand} >/dev/null 2>&1"])
+            rc = subprocess.call(
+                ["/usr/bin/env", "bash", "-lc", f"command -v {cand} >/dev/null 2>&1"]
+            )
             if rc == 0:
                 found = cand
                 break
@@ -202,8 +281,6 @@ def run(ns) -> int:
         "ansible": "galaxy",
         "config-mgmt": "galaxy",
         "config-management": "galaxy",
-        "azure": "cloud-azure",
-        "gcp": "cloud-gcp",
     }
     canonical_action = aliases.get(action, action)
 
@@ -228,7 +305,7 @@ def run(ns) -> int:
             evidence.exit_code = _run_check()
             return evidence.exit_code
 
-    if canonical_action in ("galaxy", "all"):
+    if canonical_action in ("galaxy", "all", *TARGET_STEPS):
         if runtime_root_arg and env_arg:
             print("ERR: --runtime-root and --env are mutually exclusive")
             return OPERATOR_ERROR
@@ -240,18 +317,108 @@ def run(ns) -> int:
             return OPERATOR_ERROR
 
     if canonical_action == "galaxy" and sudo:
-        print("ERR: hyops setup galaxy must not be run with --sudo (it installs into user runtime state)")
+        print(
+            "ERR: hyops setup galaxy must not use --sudo "
+            "(it writes to user runtime state)"
+        )
         return OPERATOR_ERROR
 
     script_name = _script_for(canonical_action)
-    if not script_name:
+    if not script_name and canonical_action not in TARGET_STEPS:
         print(f"ERR: unsupported setup action: {canonical_action}")
         return INTERNAL_ERROR
 
     core_root = _find_core_root(getattr(ns, "root", None))
     if not core_root:
-        print("ERR: tools/setup not found. Set HYOPS_CORE_ROOT or pass: hyops setup --root <path> ...")
+        print(
+            "ERR: tools/setup not found. Set HYOPS_CORE_ROOT or pass: "
+            "hyops setup --root <path> ..."
+        )
         return INTERNAL_ERROR
+
+    if canonical_action in TARGET_STEPS:
+        steps = TARGET_STEPS[canonical_action]
+        if dry_run:
+            print(f"setup={canonical_action}")
+            for step in steps:
+                path = (core_root / "tools" / "setup" / str(_script_for(step))).resolve()
+                print(f"- {step}: {path}")
+            if runtime_root is not None:
+                print(f"runtime_root={runtime_root}")
+            return OK
+
+        env = os.environ.copy()
+        if runtime_root is not None:
+            env["HYOPS_RUNTIME_ROOT"] = str(runtime_root)
+            if (env_arg or "").strip():
+                env["HYOPS_ENV"] = str(env_arg).strip()
+
+        evidence_paths = resolve_runtime_paths(root=runtime_root_arg, env=env_arg)
+        ensure_layout(evidence_paths)
+        progress = ProgressDisplay()
+        print(f"Setup target: {TARGET_LABELS[canonical_action]}")
+        requires_sudo = os.uname().sysname != "Darwin" and any(
+            step != "galaxy" for step in steps
+        )
+        if requires_sudo and sys.stdin.isatty() and sys.stdout.isatty():
+            print("Administrator access is required for system setup.")
+            if subprocess.call(["sudo", "-v"]) != 0:
+                print("ERR: administrator authentication failed")
+                return OPERATOR_ERROR
+        for step in steps:
+            step_script = (
+                core_root / "tools" / "setup" / str(_script_for(step))
+            ).resolve()
+            if not step_script.exists():
+                print(f"ERR: setup script not found: {step_script}")
+                return INTERNAL_ERROR
+            argv = _setup_argv(
+                step,
+                step_script,
+                runtime_root=runtime_root,
+                force=force,
+                hybridops_source=hybridops_source,
+                hybridops_git_manifest=hybridops_git_manifest,
+                elevate=step != "galaxy" and os.uname().sysname != "Darwin",
+            )
+            label = SETUP_LABELS[step]
+            evidence_dir = command_evidence_dir(
+                evidence_paths.logs_dir,
+                "setup",
+                f"{canonical_action}/{step}",
+            )
+            progress.start(
+                step,
+                label,
+                plain=f"setup={canonical_action} stage={step} status=running",
+            )
+            rc = run_streamed(
+                argv,
+                env=env,
+                evidence_dir=evidence_dir,
+                command=f"setup {canonical_action} {step}",
+                stream_output=verbose_enabled(),
+                announce=False,
+            )
+            if rc != 0:
+                progress.finish(
+                    step,
+                    label,
+                    "failed",
+                    plain=f"setup={canonical_action} stage={step} status=failed",
+                )
+                print(f"run record: {evidence_dir}")
+                print(f"rerun: hyops setup {canonical_action} --verbose")
+                return rc
+            progress.finish(
+                step,
+                label,
+                "ok",
+                plain=f"setup={canonical_action} stage={step} status=ok",
+            )
+        print(f"setup={canonical_action} status=ok")
+        print(f"run records: {evidence_paths.logs_dir / 'setup' / canonical_action}")
+        return OK
 
     script = (core_root / "tools" / "setup" / script_name).resolve()
     if not script.exists():
@@ -270,23 +437,39 @@ def run(ns) -> int:
         if (env_arg or "").strip():
             env["HYOPS_ENV"] = str(env_arg).strip()
 
-    argv: list[str] = ["bash", str(script)]
-    if canonical_action == "galaxy" and runtime_root is not None:
-        argv += ["--root", str(runtime_root)]
-    if force and canonical_action in ("galaxy", "all"):
-        argv += ["--force"]
-    if hybridops_source and canonical_action in ("galaxy", "all"):
-        argv += ["--hybridops-source", hybridops_source]
-    if hybridops_git_manifest and canonical_action in ("galaxy", "all"):
-        argv += ["--hybridops-git-manifest", hybridops_git_manifest]
-    if sudo:
-        argv = ["sudo", "-E"] + argv
+    argv = _setup_argv(
+        canonical_action,
+        script,
+        runtime_root=runtime_root,
+        force=force,
+        hybridops_source=hybridops_source,
+        hybridops_git_manifest=hybridops_git_manifest,
+        elevate=sudo,
+    )
     evidence_paths = resolve_runtime_paths(root=runtime_root_arg, env=env_arg)
     ensure_layout(evidence_paths)
     evidence_dir = command_evidence_dir(evidence_paths.logs_dir, "setup", canonical_action)
-    return run_streamed(
+    label = SETUP_LABELS.get(canonical_action, canonical_action)
+    progress = ProgressDisplay()
+    progress.start(canonical_action, label, plain=f"setup={canonical_action} status=running")
+    rc = run_streamed(
         argv,
         env=env,
         evidence_dir=evidence_dir,
         command=f"setup {canonical_action}",
+        stream_output=verbose_enabled(),
+        announce=False,
     )
+    if rc == 0:
+        progress.finish(canonical_action, label, "ok", plain=f"setup={canonical_action} status=ok")
+    else:
+        progress.finish(
+            canonical_action,
+            label,
+            "failed",
+            plain=f"setup={canonical_action} status=failed",
+        )
+    print(f"run record: {evidence_dir}")
+    if rc != 0:
+        print(f"rerun: hyops setup {action} --verbose")
+    return rc

--- a/hyops/setup/tests/__init__.py
+++ b/hyops/setup/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Setup command tests."""

--- a/hyops/setup/tests/test_command.py
+++ b/hyops/setup/tests/test_command.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from hyops.cli import main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class SetupCommandTests(unittest.TestCase):
+    def test_target_dry_run_lists_composed_steps(self) -> None:
+        cases = {
+            "gcp": ("base", "cloud-gcp", "galaxy"),
+            "azure": ("base", "cloud-azure", "galaxy"),
+            "proxmox": ("base", "galaxy"),
+        }
+        for target, expected in cases.items():
+            with self.subTest(target=target), tempfile.TemporaryDirectory() as runtime:
+                output = io.StringIO()
+                with redirect_stdout(output):
+                    rc = main(
+                        [
+                            "setup",
+                            target,
+                            "--root",
+                            str(REPO_ROOT),
+                            "--runtime-root",
+                            runtime,
+                            "--dry-run",
+                        ]
+                    )
+                self.assertEqual(rc, 0)
+                for step in expected:
+                    self.assertIn(f"- {step}:", output.getvalue())
+
+    def test_target_runs_privileged_steps_without_privileging_galaxy(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", return_value=0
+        ) as run_streamed, patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            rc = main(
+                [
+                    "setup",
+                    "proxmox",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(run_streamed.call_count, 2)
+        base_argv = run_streamed.call_args_list[0].args[0]
+        galaxy_argv = run_streamed.call_args_list[1].args[0]
+        self.assertEqual(base_argv[:3], ["sudo", "-H", "-E"])
+        self.assertEqual(galaxy_argv[0], "bash")
+        self.assertIn("--root", galaxy_argv)
+
+    def test_verbose_is_accepted_after_setup_action(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime:
+            rc = main(
+                [
+                    "setup",
+                    "gcp",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                    "--verbose",
+                    "--dry-run",
+                ]
+            )
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ Defaults:
   --prefix           ~/.hybridops/core
   --bin-dir          ~/.local/bin
   --system-link      enabled (installs /usr/local/bin/hyops; requires sudo)
-  --setup-all        auto (Linux: runs when --system-link is enabled; macOS: skipped)
+  --setup-all        Run every prerequisite installer after Core installation (default: disabled)
 USAGE
 }
 

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -38,14 +38,16 @@ common_env=(
   PATH="${PATH}:/usr/bin:/bin"
 )
 
-env WSL_DISTRO_NAME=Ubuntu bash -c \
+env HYOPS_TEST_SYSTEM_NAME=Linux WSL_DISTRO_NAME=Ubuntu bash -c \
   'source "$1"; hyops_install_is_windows_wsl' _ \
   "${HYOPS_REPO_ROOT}/tools/install/lib/common.sh"
 env -u WSL_DISTRO_NAME -u WSL_INTEROP \
+  HYOPS_TEST_SYSTEM_NAME=Linux \
   HYOPS_TEST_KERNEL_RELEASE=5.15.167.4-microsoft-standard-WSL2 \
   bash -c 'source "$1"; hyops_install_is_windows_wsl' _ \
   "${HYOPS_REPO_ROOT}/tools/install/lib/common.sh"
 if env -u WSL_DISTRO_NAME -u WSL_INTEROP \
+  HYOPS_TEST_SYSTEM_NAME=Linux \
   HYOPS_TEST_KERNEL_RELEASE=6.8.0-generic \
   bash -c 'source "$1"; hyops_install_is_windows_wsl' _ \
   "${HYOPS_REPO_ROOT}/tools/install/lib/common.sh"; then

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -38,6 +38,30 @@ common_env=(
   PATH="${PATH}:/usr/bin:/bin"
 )
 
+env WSL_DISTRO_NAME=Ubuntu bash -c \
+  'source "$1"; hyops_install_is_windows_wsl' _ \
+  "${HYOPS_REPO_ROOT}/tools/install/lib/common.sh"
+env -u WSL_DISTRO_NAME -u WSL_INTEROP \
+  HYOPS_TEST_KERNEL_RELEASE=5.15.167.4-microsoft-standard-WSL2 \
+  bash -c 'source "$1"; hyops_install_is_windows_wsl' _ \
+  "${HYOPS_REPO_ROOT}/tools/install/lib/common.sh"
+if env -u WSL_DISTRO_NAME -u WSL_INTEROP \
+  HYOPS_TEST_KERNEL_RELEASE=6.8.0-generic \
+  bash -c 'source "$1"; hyops_install_is_windows_wsl' _ \
+  "${HYOPS_REPO_ROOT}/tools/install/lib/common.sh"; then
+  echo "ERR: plain Linux was detected as Windows WSL" >&2
+  exit 1
+fi
+
+grep -Fq 'start "Ubuntu 24.04 account setup" wsl.exe -d %DISTRO%' "${HYOPS_REPO_ROOT}/install-windows.cmd"
+grep -Fq ':wait_for_ubuntu_user' "${HYOPS_REPO_ROOT}/install-windows.cmd"
+grep -Fq "CreateShortcut([Environment]::GetFolderPath('Desktop')" "${HYOPS_REPO_ROOT}/install-windows.cmd"
+grep -Fq -- "-d %DISTRO% --cd ~" "${HYOPS_REPO_ROOT}/install-windows.cmd"
+grep -Fq 'Create a HybridOps.Core desktop shortcut? [y/N]:' "${HYOPS_REPO_ROOT}/install-windows.cmd"
+grep -Fq 'open-hybridops.cmd' "${HYOPS_REPO_ROOT}/pkg/build_release.sh"
+grep -Fq -- '-u !WSL_USER! -- bash "%WSL_HELPER%"' "${HYOPS_REPO_ROOT}/install-windows.cmd"
+grep -Fq -- '-u !WSL_USER! -- bash -lc "command -v hyops' "${HYOPS_REPO_ROOT}/install-windows.cmd"
+
 latest_evidence_dir() {
   python3 - "$1" <<'PY'
 import sys
@@ -155,7 +179,8 @@ SETUP_RC=$?
 set -e
 [[ "${SETUP_RC}" -eq 7 ]]
 ! grep -Fq 'evidence-test-secret' "${WORK_DIR}/setup-failure.out"
-grep -Fq 'token=***REDACTED***' "${WORK_DIR}/setup-failure.out"
+grep -Fq 'setup=base status=failed' "${WORK_DIR}/setup-failure.out"
+grep -Fq 'rerun: hyops setup base --verbose' "${WORK_DIR}/setup-failure.out"
 SETUP_EVIDENCE="$(latest_evidence_dir "${USER_HOME}/.hybridops/logs/setup/base")"
 ! grep -Fq 'evidence-test-secret' "${SETUP_EVIDENCE}/output.log"
 grep -Fq 'token=***REDACTED***' "${SETUP_EVIDENCE}/output.log"

--- a/tools/install/lib/common.sh
+++ b/tools/install/lib/common.sh
@@ -25,7 +25,8 @@ hyops_install_is_windows_wsl() {
   if [[ -z "${kernel_release}" ]]; then
     kernel_release="$(uname -r 2>/dev/null || true)"
   fi
-  [[ "${kernel_release,,}" == *microsoft* ]]
+  kernel_release="$(printf '%s' "${kernel_release}" | tr '[:upper:]' '[:lower:]')"
+  [[ "${kernel_release}" == *microsoft* ]]
 }
 
 hyops_install_set_blueprint_payload_read_only() {

--- a/tools/install/lib/common.sh
+++ b/tools/install/lib/common.sh
@@ -12,7 +12,11 @@ hyops_install_need_cmd() {
 }
 
 hyops_install_is_windows_wsl() {
-  [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]] || return 1
+  local system_name="${HYOPS_TEST_SYSTEM_NAME:-}"
+  if [[ -z "${system_name}" ]]; then
+    system_name="$(uname -s 2>/dev/null || true)"
+  fi
+  [[ "${system_name}" == "Linux" ]] || return 1
   if [[ -n "${WSL_DISTRO_NAME:-}" || -n "${WSL_INTEROP:-}" ]]; then
     return 0
   fi

--- a/tools/install/lib/installer.sh
+++ b/tools/install/lib/installer.sh
@@ -72,16 +72,23 @@ _hyops_install_run_transaction() {
   echo "[install] prefix=${PREFIX}"
   echo "[install] bin_dir=${BIN_DIR}"
 
+  local is_windows_wsl="false"
+  if hyops_install_is_windows_wsl; then
+    is_windows_wsl="true"
+    echo "[install] platform=windows-wsl"
+  fi
+
   if [[ "${SETUP_ALL}" == "auto" ]]; then
     if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
       # Homebrew refuses to run as root. Leave prerequisite installation as an
       # explicit setup step owned by the macOS user.
       SETUP_ALL="false"
       echo "[install] macOS detected; automatic setup-all is disabled"
-    elif [[ "${SYSTEM_LINK}" == "true" ]]; then
-      SETUP_ALL="true"
+    elif [[ "${is_windows_wsl}" == "true" ]]; then
+      SETUP_ALL="false"
     else
       SETUP_ALL="false"
+      echo "[install] automatic setup-all is disabled"
     fi
   fi
   echo "[install] setup_all=${SETUP_ALL}"
@@ -141,23 +148,11 @@ _hyops_install_run_transaction() {
   if [[ "${resolved_hyops}" == "${SYSTEM_LINK_PATH}" || ( -n "${WRAPPER:-}" && "${resolved_hyops}" == "${WRAPPER}" ) ]]; then
     echo "Next:"
     echo "  hyops --help"
-    if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
-      echo "  hyops setup base"
-      echo "  hyops setup gcp"
-      echo "  hyops setup galaxy"
-    else
-      echo "  hyops preflight"
-    fi
+    echo "  hyops setup gcp      # or: azure, proxmox"
   elif [[ -n "${PATH_PROFILE:-}" ]]; then
     echo "Open a new terminal, then run:"
     echo "  hyops --help"
-    if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
-      echo "  hyops setup base"
-      echo "  hyops setup gcp"
-      echo "  hyops setup galaxy"
-    else
-      echo "  hyops preflight"
-    fi
+    echo "  hyops setup gcp      # or: azure, proxmox"
   else
     echo "Run:"
     echo "  ${WRAPPER} --help"

--- a/tools/install/lib/setup.sh
+++ b/tools/install/lib/setup.sh
@@ -24,5 +24,5 @@ hyops_install_run_setup_all() {
     exit 2
   }
 
-  sudo -E bash "${setup_all_script}"
+  sudo -H -E bash "${setup_all_script}"
 }

--- a/tools/setup/setup-all.sh
+++ b/tools/setup/setup-all.sh
@@ -44,7 +44,7 @@ if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
 fi
 
 if [[ "${EUID}" -ne 0 ]]; then
-  exec sudo -E bash "$0" "$@"
+  exec sudo -H -E bash "$0" "$@"
 fi
 
 bash "${ROOT}/setup-base.sh"
@@ -52,5 +52,5 @@ bash "${ROOT}/setup-cloud-azure.sh"
 bash "${ROOT}/setup-cloud-gcp.sh"
 
 if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
-  sudo -u "${SUDO_USER}" -E bash "${ROOT}/setup-ansible.sh" "${FORCE_ARGS[@]}" "${HYBRIDOPS_ARGS[@]}"
+  sudo -H -u "${SUDO_USER}" -E bash "${ROOT}/setup-ansible.sh" "${FORCE_ARGS[@]}" "${HYBRIDOPS_ARGS[@]}"
 fi

--- a/tools/setup/setup-ansible.sh
+++ b/tools/setup/setup-ansible.sh
@@ -132,10 +132,12 @@ fi
 
 # temp/cache: keep ansible-galaxy reliable in constrained environments
 TMP_DIR="${RUNTIME_ROOT}/tmp"
-mkdir -p "${TMP_DIR}/ansible-local"
+GALAXY_CACHE_DIR="${TMP_DIR}/galaxy-cache"
+mkdir -p "${TMP_DIR}/ansible-local" "${GALAXY_CACHE_DIR}"
 export TMPDIR="${TMP_DIR}"
 export ANSIBLE_LOCAL_TEMP="${TMP_DIR}/ansible-local"
 export ANSIBLE_REMOTE_TEMP="/tmp/.ansible-tmp"
+export ANSIBLE_GALAXY_CACHE_DIR="${GALAXY_CACHE_DIR}"
 export HYOPS_SETUP_ANSIBLE_HYBRIDOPS_SOURCE="${HYBRIDOPS_SOURCE}"
 if [[ -n "${HYBRIDOPS_GIT_MANIFEST_FILE}" ]]; then
   export HYOPS_SETUP_ANSIBLE_HYBRIDOPS_GIT_MANIFEST="${HYBRIDOPS_GIT_MANIFEST_FILE}"


### PR DESCRIPTION
Closes #89.

Depends on the Windows WSL2 foundation in the preceding branch.

## What changed

- adds complete gcp, azure and proxmox setup targets
- keeps the individual setup stages available
- makes installation Core-first on supported platforms
- retains setup output in run records and provides a verbose rerun path
- keeps Galaxy dependencies in runtime-owned state

## Why

Operators should be able to prepare one target without manually composing base, provider and Galaxy setup commands.

## Validation

- Python test suite
- installer quality checks
- target setup command tests