### PR TITLE
Show live progress for long-running commands

### DIFF
--- a/hyops/commands/_apply_execute.py
+++ b/hyops/commands/_apply_execute.py
@@ -112,14 +112,14 @@ def run_single(
         )
     )
     if not child_progress:
+        print(f"run record: {evidence_dir}")
+        if not progress.enabled:
+            print(f"progress: logs={progress_log_hint(driver_ref, evidence_dir)}")
         progress.start(
             module_ref,
             f"{command_name} {module_ref}",
             plain=f"module={module_ref} status=running run_id={run_id}",
         )
-        print(f"run record: {evidence_dir}")
-        if not progress.enabled:
-            print(f"progress: logs={progress_log_hint(driver_ref, evidence_dir)}")
 
     def persist_status_error_state(error_message: str) -> None:
         if command_name not in ("apply", "deploy"):

--- a/hyops/runtime/proc.py
+++ b/hyops/runtime/proc.py
@@ -17,6 +17,7 @@ import threading
 import time
 
 from hyops.runtime.redact import redact_text
+from hyops.runtime.progress import ProgressDisplay, concise_enabled
 from hyops.runtime.state import write_json_atomic
 
 
@@ -90,7 +91,13 @@ def run_capture(
     timeout_s: int | None = None,
     redact: bool = True,
 ) -> ProcResult:
-    r = run(argv, cwd=cwd, env=env, timeout_s=timeout_s)
+    r = _run_with_delayed_progress(
+        argv,
+        label=label,
+        cwd=cwd,
+        env=env,
+        timeout_s=timeout_s,
+    )
 
     out = r.stdout
     err = r.stderr
@@ -103,6 +110,66 @@ def run_capture(
     (evidence_dir / f"{label}.stderr.txt").write_text(err, encoding="utf-8")
     _write_result_envelope(evidence_dir, label, r, redact=redact)
     return r
+
+
+def _progress_label(label: str) -> str:
+    return " ".join(label.replace("_", " ").replace("-", " ").split())
+
+
+def _run_with_delayed_progress(
+    argv: Sequence[str],
+    *,
+    label: str,
+    cwd: str | None,
+    env: Mapping[str, str] | None,
+    timeout_s: int | None,
+) -> ProcResult:
+    """Show progress for a captured command only when it outlasts a quick probe."""
+
+    enabled = concise_enabled() and str(os.getenv("HYOPS_PROGRESS_CHILD") or "").strip() != "1"
+    if not enabled:
+        return run(argv, cwd=cwd, env=env, timeout_s=timeout_s)
+
+    display = ProgressDisplay(enabled=True)
+    key = f"proc:{label}"
+    display_label = _progress_label(label)
+    state_lock = threading.Lock()
+    state = {"complete": False, "started": False}
+
+    def begin() -> None:
+        with state_lock:
+            if state["complete"]:
+                return
+            display.start(key, display_label, plain=f"operation={label} status=running")
+            state["started"] = True
+
+    timer = threading.Timer(1.0, begin)
+    timer.daemon = True
+    timer.start()
+    result: ProcResult | None = None
+    error: BaseException | None = None
+    try:
+        result = run(argv, cwd=cwd, env=env, timeout_s=timeout_s)
+    except BaseException as exc:
+        error = exc
+    finally:
+        with state_lock:
+            state["complete"] = True
+            started = state["started"]
+        timer.cancel()
+
+    if started:
+        succeeded = error is None and result is not None and result.rc == 0
+        display.finish(
+            key,
+            display_label,
+            "ok" if succeeded else "failed",
+            plain=f"operation={label} status={'ok' if succeeded else 'failed'}",
+        )
+    if error is not None:
+        raise error
+    assert result is not None
+    return result
 
 
 def run_interactive(
@@ -182,6 +249,12 @@ def run_capture_stream(
     terminal_lock = threading.Lock()
     heartbeat_stop = threading.Event()
     verbose_terminal = str(os.getenv("HYOPS_VERBOSE") or "").strip().lower() in {"1", "true", "yes", "on"}
+    stream_progress = ProgressDisplay(
+        enabled=(
+            concise_enabled()
+            and str(os.getenv("HYOPS_PROGRESS_CHILD") or "").strip() != "1"
+        )
+    )
     if tee_path is not None:
         try:
             tee_path.parent.mkdir(parents=True, exist_ok=True)
@@ -227,6 +300,12 @@ def run_capture_stream(
         stderr=subprocess.PIPE,
         bufsize=1,
     )
+    if stream_progress.enabled:
+        stream_progress.start(
+            label,
+            _progress_label(label),
+            plain=f"operation={label} status=running",
+        )
     assert p.stdout is not None
     assert p.stderr is not None
 
@@ -274,6 +353,8 @@ def run_capture_stream(
         if interval <= 0:
             return
         if verbose_terminal:
+            return
+        if stream_progress.enabled:
             return
         if str(os.getenv("HYOPS_PROGRESS_CHILD") or "").strip() == "1":
             return
@@ -350,6 +431,13 @@ def run_capture_stream(
         stderr="",
     )
     _write_result_envelope(evidence_dir, label, r, redact=redact)
+    if stream_progress.enabled:
+        stream_progress.finish(
+            label,
+            _progress_label(label),
+            "cancelled" if interrupted else ("ok" if rc == 0 else "failed"),
+            plain=f"operation={label} status={'cancelled' if interrupted else ('ok' if rc == 0 else 'failed')}",
+        )
     if interrupted:
         raise KeyboardInterrupt
     return r
@@ -367,7 +455,13 @@ def run_capture_sensitive(
 
     For commands that may emit secrets, do not persist stdout/stderr to disk.
     """
-    r = run(argv, cwd=cwd, env=env, timeout_s=timeout_s)
+    r = _run_with_delayed_progress(
+        argv,
+        label=label,
+        cwd=cwd,
+        env=env,
+        timeout_s=timeout_s,
+    )
     evidence_dir.mkdir(parents=True, exist_ok=True)
     _write_result_envelope(evidence_dir, label, r)
     return r

--- a/hyops/runtime/progress.py
+++ b/hyops/runtime/progress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 
@@ -33,11 +34,34 @@ class ProgressDisplay:
 
     enabled: bool = field(default_factory=concise_enabled)
     _started: dict[str, float] = field(default_factory=dict)
+    _stops: dict[str, threading.Event] = field(default_factory=dict)
+    _threads: dict[str, threading.Thread] = field(default_factory=dict)
+
+    def _animate(self, key: str, label: str, stopped: threading.Event) -> None:
+        frames = ("|", "/", "-", "\\")
+        frame = 0
+        while not stopped.wait(0.2):
+            started = self._started.get(key, time.monotonic())
+            print(
+                f"\r\033[2K{frames[frame]} {label}  {_elapsed(started)}",
+                end="",
+                flush=True,
+            )
+            frame = (frame + 1) % len(frames)
 
     def start(self, key: str, label: str, *, plain: str) -> None:
         self._started[key] = time.monotonic()
         if self.enabled:
-            print(f"… {label}", flush=True)
+            print(f"| {label}  0s", end="", flush=True)
+            stopped = threading.Event()
+            thread = threading.Thread(
+                target=self._animate,
+                args=(key, label, stopped),
+                daemon=True,
+            )
+            self._stops[key] = stopped
+            self._threads[key] = thread
+            thread.start()
         else:
             print(plain, flush=True)
 
@@ -56,6 +80,12 @@ class ProgressDisplay:
         if not self.enabled:
             print(plain, flush=True)
             return
+        stopped = self._stops.pop(key, None)
+        if stopped is not None:
+            stopped.set()
+        thread = self._threads.pop(key, None)
+        if thread is not None:
+            thread.join(timeout=1)
         symbol = {
             "ok": "✓",
             "skipped": "○",
@@ -66,4 +96,4 @@ class ProgressDisplay:
         suffix = f"  {_elapsed(started)}"
         if detail:
             suffix += f"  {detail}"
-        print(f"{symbol} {label}{suffix}", flush=True)
+        print(f"\r\033[2K{symbol} {label}{suffix}", flush=True)

--- a/hyops/runtime/tests/test_proc_progress.py
+++ b/hyops/runtime/tests/test_proc_progress.py
@@ -1,0 +1,59 @@
+"""Progress behaviour for captured subprocesses."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hyops.runtime import proc
+
+
+class _ImmediateTimer:
+    def __init__(self, _interval, callback):
+        self.callback = callback
+        self.daemon = False
+
+    def start(self) -> None:
+        self.callback()
+
+    def cancel(self) -> None:
+        return None
+
+
+class CapturedProcessProgressTests(unittest.TestCase):
+    def test_quick_capture_does_not_start_progress_outside_tty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch.object(
+            proc, "concise_enabled", return_value=False
+        ), patch.object(proc, "ProgressDisplay") as display:
+            result = proc.run_capture(
+                ["bash", "-lc", "printf ok"],
+                evidence_dir=Path(tmp),
+                label="quick_probe",
+            )
+
+        self.assertEqual(result.rc, 0)
+        display.assert_not_called()
+
+    def test_long_capture_finishes_delayed_progress(self) -> None:
+        display = MagicMock()
+        display.enabled = True
+        with patch.object(proc, "concise_enabled", return_value=True), patch.object(
+            proc.threading, "Timer", _ImmediateTimer
+        ), patch.object(proc, "ProgressDisplay", return_value=display):
+            result = proc._run_with_delayed_progress(
+                ["bash", "-lc", "exit 0"],
+                label="project_lookup",
+                cwd=None,
+                env=None,
+                timeout_s=None,
+            )
+
+        self.assertEqual(result.rc, 0)
+        display.start.assert_called_once()
+        display.finish.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hyops/runtime/tests/test_progress.py
+++ b/hyops/runtime/tests/test_progress.py
@@ -37,10 +37,13 @@ class ProgressDisplayTests(unittest.TestCase):
         display = ProgressDisplay(enabled=True)
         with redirect_stdout(output), patch(
             "hyops.runtime.progress.time.monotonic", side_effect=[10.0, 15.0]
-        ):
+        ), patch.object(display, "_animate"):
             display.start("network", "Network", plain="ignored")
             display.finish("network", "Network", "ok", plain="ignored")
-        self.assertEqual(output.getvalue().splitlines(), ["… Network", "✓ Network  5s"])
+        self.assertEqual(
+            output.getvalue(),
+            "| Network  0s\r\x1b[2K✓ Network  5s\n",
+        )
 
     def test_verbose_disables_concise_output(self) -> None:
         output = _Stream(True)


### PR DESCRIPTION
Closes #90.

Depends on the target setup branch.

## What changed

- animates long-running interactive stages with elapsed time
- covers setup, module, blueprint, provider-init and runner operations
- delays progress for quick captured probes
- authenticates sudo before animated setup stages
- preserves plain redirected output, verbose streaming and run records

## Why

Quiet execution should not leave operators unsure whether a command is still active.

## Validation

- 86 Python tests
- installer quality checks
- focused progress and captured-process tests