### PR TITLE
Align the published module count

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <table align="center">
   <tr>
-    <td align="center"><strong>73</strong><br><sub>runtime modules</sub></td>
+    <td align="center"><strong>74</strong><br><sub>runtime modules</sub></td>
     <td align="center"><strong>26</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported surfaces</sub></td>


### PR DESCRIPTION
Closes #94.

The module catalog contains 74 specifications while the README still reported 73. This updates the public count so the cross-repository metadata audit reflects the current catalog.

Validation:
- counted module spec files
- public metadata audit reports the expected value as 74