### PR TITLE
Keep backend tools out of primary CLI help

### DIFF
--- a/hyops/cli.py
+++ b/hyops/cli.py
@@ -40,6 +40,15 @@ _DRIVERS_REGISTERED = False
 _VALIDATORS_REGISTERED = False
 
 
+class _OperatorHelpFormatter(argparse.HelpFormatter):
+    """Omit compatibility-only commands from the primary operator view."""
+
+    def _format_action(self, action: argparse.Action) -> str:
+        if action.help == argparse.SUPPRESS:
+            return ""
+        return super()._format_action(action)
+
+
 def _register_drivers() -> None:
     global _DRIVERS_REGISTERED
     if _DRIVERS_REGISTERED:
@@ -77,7 +86,11 @@ def _register_validators() -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="hyops", add_help=True)
+    p = argparse.ArgumentParser(
+        prog="hyops",
+        add_help=True,
+        formatter_class=_OperatorHelpFormatter,
+    )
     p.add_argument("--version", action="store_true", help="Print version and exit.")
     p.add_argument(
         "-v",
@@ -85,7 +98,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Stream tool output to terminal while also writing run records.",
     )
-    sp = p.add_subparsers(dest="cmd", required=False)
+    sp = p.add_subparsers(dest="cmd", required=False, metavar="COMMAND")
 
     add_init_subparser(sp)
     add_module_subparser(sp)

--- a/hyops/stacks/command.py
+++ b/hyops/stacks/command.py
@@ -13,7 +13,7 @@ from hyops.runtime.exitcodes import INTERNAL_ERROR
 
 
 def add_stacks_subparser(sp: argparse._SubParsersAction) -> None:
-    p = sp.add_parser("stacks", help="Terragrunt stack alias utilities.")
+    p = sp.add_parser("stacks", help=argparse.SUPPRESS)
     ssp = p.add_subparsers(dest="stacks_cmd", required=True)
 
     q = ssp.add_parser("aliases", help="Generate stacks aliases from a Terragrunt live root.")

--- a/hyops/terragrunt/command.py
+++ b/hyops/terragrunt/command.py
@@ -31,7 +31,7 @@ def _exit_code_from_system_exit(exc: SystemExit) -> int:
 
 
 def add_terragrunt_subparser(sp: argparse._SubParsersAction) -> None:
-    p = sp.add_parser("terragrunt", help="Terragrunt helper tools.")
+    p = sp.add_parser("terragrunt", help=argparse.SUPPRESS)
     ssp = p.add_subparsers(dest="terragrunt_cmd", required=True)
 
     q = ssp.add_parser(
@@ -63,4 +63,3 @@ def run_validate_proxmox_sdn_vnets(ns) -> int:
 
 
 __all__ = ["add_terragrunt_subparser", "run_validate_proxmox_sdn_vnets"]
-

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -37,6 +37,19 @@ class CliRoutingTests(unittest.TestCase):
         for command in ("apply", "blueprint", "module", "state"):
             self.assertIn(command, result.stdout)
 
+    def test_top_level_help_omits_backend_maintenance_commands(self) -> None:
+        result = run_cli("--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for command in ("terragrunt", "tfc", "stacks"):
+            self.assertNotIn(command, result.stdout)
+
+    def test_backend_maintenance_command_help_remains_available(self) -> None:
+        for command in ("terragrunt", "tfc", "stacks"):
+            with self.subTest(command=command):
+                result = run_cli(command, "--help")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(f"hyops {command}", result.stdout)
+
     def test_no_command_prints_help_and_returns_usage_error(self) -> None:
         result = run_cli()
         self.assertEqual(result.returncode, 2)

--- a/hyops/tfc/command.py
+++ b/hyops/tfc/command.py
@@ -47,7 +47,7 @@ def _exit_code_from_system_exit(exc: SystemExit) -> int:
 
 
 def add_tfc_subparser(sp: argparse._SubParsersAction) -> None:
-    p = sp.add_parser("tfc", help="Terraform Cloud helper commands.")
+    p = sp.add_parser("tfc", help=argparse.SUPPRESS)
     ssp = p.add_subparsers(dest="tfc_cmd", required=True)
 
     q = ssp.add_parser(


### PR DESCRIPTION
Closes #101.

Keeps backend-maintenance command paths available while removing them from the primary operator help and usage display. Regression tests cover both the public view and direct compatibility-command help.