### PR TITLE
Add a reusable GNS3 server module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - added a provider-neutral GNS3 server module backed by hybridops.app 0.1.8
   - linked README scenario entries directly to their reference scenario pages
   - added README coverage for every shipped blueprint directory
   - refreshed the blueprint catalogue so all 26 shipped blueprints are visible from the index

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <table align="center">
   <tr>
-    <td align="center"><strong>74</strong><br><sub>runtime modules</sub></td>
+    <td align="center"><strong>75</strong><br><sub>runtime modules</sub></td>
     <td align="center"><strong>26</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported surfaces</sub></td>

--- a/hyops/tests/test_gns3_server_module.py
+++ b/hyops/tests/test_gns3_server_module.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class GNS3ServerModuleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        spec_path = REPO_ROOT / "modules/platform/linux/gns3-server/spec.yml"
+        self.spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+
+    def test_module_uses_provider_neutral_ansible_pack(self) -> None:
+        self.assertEqual(self.spec["module_ref"], "platform/linux/gns3-server")
+        self.assertEqual(self.spec["execution"]["driver"], "config/ansible")
+        self.assertEqual(
+            self.spec["execution"]["pack_ref"]["id"],
+            "linux/common/platform/44-gns3-server@v1.0",
+        )
+
+    def test_module_requires_server_password(self) -> None:
+        defaults = self.spec["inputs"]["defaults"]
+        self.assertEqual(defaults["required_env"], ["GNS3_SERVER_PASSWORD"])
+        self.assertTrue(defaults["load_vault_env"])
+        self.assertEqual(defaults["required_env_destroy"], [])
+
+    def test_module_publishes_access_contract(self) -> None:
+        self.assertEqual(
+            self.spec["outputs"]["publish"],
+            ["gns3_url", "gns3_api_port", "cap.lab.gns3"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/platform/linux/gns3-server/README.md
+++ b/modules/platform/linux/gns3-server/README.md
@@ -1,0 +1,24 @@
+# platform/linux/gns3-server
+
+Installs and configures an authenticated GNS3 server on an existing Ubuntu
+22.04 or 24.04 x86_64 host. The module is provider-neutral and can use direct
+SSH, a jump host or GCP IAP.
+
+It installs the server and open-source emulator runtime. It does not provision
+the host, install a desktop client or supply proprietary network images.
+
+## Usage
+
+```bash
+hyops secrets ensure --env lab GNS3_SERVER_PASSWORD
+
+hyops apply --env lab \
+  --module platform/linux/gns3-server \
+  --inputs modules/platform/linux/gns3-server/examples/inputs.min.yml
+```
+
+## Outputs
+
+- `gns3_url`
+- `gns3_api_port`
+- `cap.lab.gns3 = ready`

--- a/modules/platform/linux/gns3-server/examples/inputs.min.yml
+++ b/modules/platform/linux/gns3-server/examples/inputs.min.yml
@@ -1,0 +1,4 @@
+# Minimal GNS3 server example for an existing Ubuntu host.
+# GNS3_SERVER_PASSWORD is supplied through the environment vault.
+
+target_host: "10.10.0.42"

--- a/modules/platform/linux/gns3-server/spec.yml
+++ b/modules/platform/linux/gns3-server/spec.yml
@@ -1,0 +1,69 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/gns3-server"
+
+metadata:
+  title: "Linux GNS3 Server"
+  description: "Install and configure an authenticated GNS3 server on an existing Ubuntu host."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+
+    required_env:
+      - "GNS3_SERVER_PASSWORD"
+    required_env_destroy: []
+    load_vault_env: true
+
+    gns3_server_role_fqcn: "hybridops.app.gns3_server"
+    gns3_server_bind_address: "0.0.0.0"
+    gns3_server_port: 3080
+    gns3_server_username: "gns3"
+    gns3_server_password_env: "GNS3_SERVER_PASSWORD"
+    gns3_server_allowed_interfaces:
+      - "virbr0"
+    gns3_server_enable_kvm: true
+    gns3_server_require_kvm: false
+    gns3_server_install_emulators: true
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/44-gns3-server@v1.0"
+
+outputs:
+  publish:
+    - gns3_url
+    - gns3_api_port
+    - cap.lab.gns3
+
+probes: []
+constraints: []

--- a/packs/config/ansible/linux/common/platform/44-gns3-server@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/44-gns3-server@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,47 @@
+---
+- name: Destroy platform/linux/gns3-server
+  hosts: targets
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Stop GNS3 server
+      ansible.builtin.systemd:
+        name: gns3server
+        state: stopped
+        enabled: false
+      failed_when: false
+
+    - name: Remove GNS3 server packages
+      ansible.builtin.apt:
+        name:
+          - gns3-server
+        state: absent
+        purge: true
+      failed_when: false
+      when: ansible_os_family == "Debian"
+
+    - name: Remove GNS3 service and configuration
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/systemd/system/gns3server.service
+        - /etc/gns3
+      failed_when: false
+
+    - name: Reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3': 'absent'
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/44-gns3-server@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/44-gns3-server@v1.0/stack/playbook.yml
@@ -1,0 +1,51 @@
+---
+- name: platform/linux/gns3-server (configure)
+  hosts: targets
+  become: true
+  gather_facts: true
+
+  vars:
+    gns3_server_role_fqcn: >-
+      {{ gns3_server_role_fqcn | default('hybridops.app.gns3_server') }}
+    _hyops_gns3_bind_address: "{{ gns3_server_bind_address | default('0.0.0.0') }}"
+    _hyops_gns3_port: "{{ gns3_server_port | default(3080) | int }}"
+    _hyops_gns3_username: "{{ gns3_server_username | default('gns3') }}"
+    _hyops_gns3_password: >-
+      {{ lookup('env', gns3_server_password_env | default('GNS3_SERVER_PASSWORD')) }}
+    _hyops_gns3_allowed_interfaces: >-
+      {{ gns3_server_allowed_interfaces | default(['virbr0']) }}
+    _hyops_gns3_enable_kvm: "{{ gns3_server_enable_kvm | default(true) | bool }}"
+    _hyops_gns3_require_kvm: "{{ gns3_server_require_kvm | default(false) | bool }}"
+    _hyops_gns3_install_emulators: >-
+      {{ gns3_server_install_emulators | default(true) | bool }}
+
+  tasks:
+    - name: Install and configure GNS3 server
+      ansible.builtin.include_role:
+        name: "{{ gns3_server_role_fqcn }}"
+      vars:
+        gns3_server_bind_address: "{{ _hyops_gns3_bind_address }}"
+        gns3_server_port: "{{ _hyops_gns3_port }}"
+        gns3_server_username: "{{ _hyops_gns3_username }}"
+        gns3_server_password: "{{ _hyops_gns3_password }}"
+        gns3_server_allowed_interfaces: "{{ _hyops_gns3_allowed_interfaces }}"
+        gns3_server_enable_kvm: "{{ _hyops_gns3_enable_kvm }}"
+        gns3_server_require_kvm: "{{ _hyops_gns3_require_kvm }}"
+        gns3_server_install_emulators: "{{ _hyops_gns3_install_emulators }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'gns3_url': ('http://' ~ (
+              hostvars[inventory_hostname].hyops_resolved_host
+              | default(hostvars[inventory_hostname].hyops_private_host | default(hostvars[inventory_hostname].ansible_host | default('')))
+            ) ~ ':' ~ (_hyops_gns3_port | string) ~ '/'),
+            'gns3_api_port': _hyops_gns3_port,
+            'cap.lab.gns3': 'ready'
+          } | to_json }}

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -6,7 +6,7 @@ collections:
     version: "0.1.6"
 
   - name: hybridops.app
-    version: "0.1.7"
+    version: "0.1.8"
 
   - name: ansible.posix
     version: "1.6.2"


### PR DESCRIPTION
Closes #96.

Adds the provider-neutral `platform/linux/gns3-server` contract, Ansible execution pack, destroy path and focused contract tests. Authentication is loaded from the runtime vault through `GNS3_SERVER_PASSWORD`.

This change depends on `hybridops.app` 0.1.8 from hybridops-tech/ansible-collection-app#6. Provider blueprints, appliance handling and client integration remain separate follow-ups.

Checks:
- module catalog check
- 91 Core tests
- focused module contract tests
- apply and destroy playbook syntax
- rendered module validation