### PR TITLE
Apply execution profile overrides during preflight

### DIFF
--- a/hyops/preflight/command.py
+++ b/hyops/preflight/command.py
@@ -93,6 +93,7 @@ def run_module_driver_preflight(
     state_instance: str | None = None,
     assumed_state_ok: set[str] | None = None,
     allow_state_drift_recreate: bool = False,
+    profile_override: str | None = None,
 ) -> dict[str, Any]:
     module_ref = normalize_module_ref(str(module_ref or "").strip())
     if not module_ref:
@@ -109,6 +110,8 @@ def run_module_driver_preflight(
         invocation_command="preflight",
         assumed_state_ok=assumed_state_ok,
     )
+    if str(profile_override or "").strip():
+        resolved.execution["profile"] = str(profile_override).strip()
 
     driver_ref = str(resolved.execution.get("driver") or "").strip()
     driver_fn = REGISTRY.resolve(driver_ref)

--- a/hyops/preflight/tests/__init__.py
+++ b/hyops/preflight/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Preflight command tests."""

--- a/hyops/preflight/tests/test_profile_override.py
+++ b/hyops/preflight/tests/test_profile_override.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from types import SimpleNamespace
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.preflight.command import run_module_driver_preflight
+
+
+class ModulePreflightProfileOverrideTest(TestCase):
+    def test_profile_override_is_passed_to_driver(self) -> None:
+        captured = {}
+
+        def driver(request):
+            captured.update(request)
+            return {"status": "ok"}
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = SimpleNamespace(
+                root=root,
+                state_dir=root / "state",
+                logs_dir=root / "logs",
+                meta_dir=root / "meta",
+                credentials_dir=root / "credentials",
+                work_dir=root / "work",
+            )
+            resolved = SimpleNamespace(
+                execution={"driver": "test/driver", "profile": "default@v1"},
+                module_dir=root / "module",
+                inputs={},
+                required_credentials=[],
+                outputs_publish=[],
+            )
+
+            with (
+                patch("hyops.preflight.command.ensure_layout"),
+                patch("hyops.preflight.command.resolve_module", return_value=resolved),
+                patch("hyops.preflight.command.REGISTRY.resolve", return_value=driver),
+                patch("hyops.preflight.command.new_run_id", return_value="preflight-test"),
+                patch(
+                    "hyops.preflight.command.init_evidence_dir",
+                    return_value=root / "logs" / "preflight-test",
+                ),
+            ):
+                result = run_module_driver_preflight(
+                    paths=paths,
+                    env_name="test",
+                    module_ref="platform/test/module",
+                    module_root=root / "modules",
+                    inputs_file=None,
+                    profile_override="override@v2",
+                )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(captured["execution"]["profile"], "override@v2")


### PR DESCRIPTION
Closes #105.

Accepts the blueprint execution-profile override in module driver preflight and applies it to the resolved execution request, matching the deploy path. Adds a focused regression test that verifies the driver receives the selected profile.

Checks:
- focused preflight and planner tests
- 89 Core tests
- diff validation