### PR TITLE
Add private GNS3 desktop-client access

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - added private desktop-client TCP access for the Proxmox GNS3 blueprint
   - added a standalone Proxmox GNS3 blueprint with a private authenticated API
   - added a provider-neutral GNS3 server module backed by hybridops.app 0.1.8
   - linked README scenario entries directly to their reference scenario pages

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -4,9 +4,9 @@ Build a dedicated GNS3 server on Proxmox from a verified Ubuntu 22.04
 template. The blueprint provisions the VM and configures the authenticated
 GNS3 API through the provider-neutral Linux module.
 
-The API listens on the VM loopback interface. A desktop-client access command
-will provide the private tunnel in a separate change; the server is not exposed
-to the local network by this blueprint.
+The API listens on the VM loopback interface. The access command opens a private
+SSH tunnel for the GNS3 desktop client; the server is not exposed to the local
+network by this blueprint.
 
 ## Execution chain
 
@@ -42,6 +42,24 @@ hyops blueprint deploy \
   --ref onprem/gns3@v1 \
   --execute
 ```
+
+## Connect a desktop client
+
+```bash
+hyops blueprint access \
+  --env gns3-lab \
+  --ref onprem/gns3@v1
+```
+
+Keep the command running and configure the GNS3 desktop client to use host
+`127.0.0.1`, port `3080` and protocol `HTTP`. Retrieve the generated password
+from the environment vault when configuring the client:
+
+```bash
+hyops secrets show --env gns3-lab GNS3_SERVER_PASSWORD
+```
+
+Press Ctrl-C in the access terminal to close the tunnel.
 
 ## Default VM
 

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -14,6 +14,14 @@ policy:
   evidence_required: true
   ipam_authority: "none"
 
+access:
+  type: "ssh-tcp-forward"
+  state_ref: "platform/onprem/platform-vm#gns3_vm"
+  remote_port: 3080
+  local_port: 3080
+  ssh_user: "opsadmin"
+  ssh_key_file: "~/.ssh/id_ed25519"
+
 steps:
   - id: template_image_jammy
     module_ref: "core/onprem/template-image"

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -586,7 +586,7 @@ def _require_local_ports_available(ports: list[int]) -> None:
             sockets.append(sock)
     except OSError as exc:
         raise ValueError(
-            f"native console port {port} is unavailable on localhost: {exc}"
+            f"local port {port} is unavailable on localhost: {exc}"
         ) from exc
     finally:
         for sock in sockets:
@@ -721,7 +721,7 @@ def run_access(ns) -> int:
         remote_port = int(access.get("remote_port") or 80)
         path = str(access.get("path") or "/")
 
-        if access_type in {"direct-http", "ssh-forward"}:
+        if access_type in {"direct-http", "ssh-forward", "ssh-tcp-forward"}:
             host = _extract_access_host(outputs)
             if not host:
                 raise ValueError(f"VM state does not contain a usable IPv4 address: {state_ref}")
@@ -786,7 +786,12 @@ def run_access(ns) -> int:
                 if console_ports:
                     _require_local_ports_available(console_ports)
 
-            port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
+            requested_port = int(getattr(ns, "local_port", 0) or 0) or int(
+                access.get("local_port") or 0
+            )
+            port = _available_local_port(requested_port)
+            if requested_port:
+                _require_local_ports_available([port])
             url = f"http://127.0.0.1:{port}{path}"
             argv = [*ssh_base, "-N", "-o", "ExitOnForwardFailure=yes"]
             argv.extend(["-L", f"127.0.0.1:{port}:127.0.0.1:{remote_port}"])
@@ -796,8 +801,12 @@ def run_access(ns) -> int:
                 )
             argv.append(ssh_target)
 
-            print("opening private Proxmox EVE-NG access")
-            print(f"local URL: {url}")
+            if access_type == "ssh-tcp-forward":
+                print("opening private TCP access")
+                print(f"local endpoint: 127.0.0.1:{port}")
+            else:
+                print("opening private Proxmox EVE-NG access")
+                print(f"local URL: {url}")
             _print_guest_network_guidance(access)
             if bool(getattr(ns, "native_consoles", False)):
                 print(_native_console_status(console_ports))
@@ -808,7 +817,9 @@ def run_access(ns) -> int:
             time.sleep(2)
             if proc.poll() is not None:
                 return OPERATOR_ERROR
-            if not bool(getattr(ns, "no_browser", False)):
+            if access_type != "ssh-tcp-forward" and not bool(
+                getattr(ns, "no_browser", False)
+            ):
                 open_operator_url(url)
             try:
                 return int(proc.wait())

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -173,12 +173,13 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         if access_type not in {
             "direct-http",
             "ssh-forward",
+            "ssh-tcp-forward",
             "gcp-iap-http",
             "gcp-iap-ssh-forward",
         }:
             raise ValueError(
-                "access.type must be direct-http, ssh-forward, gcp-iap-http, "
-                "or gcp-iap-ssh-forward"
+                "access.type must be direct-http, ssh-forward, ssh-tcp-forward, "
+                "gcp-iap-http, or gcp-iap-ssh-forward"
             )
         access = {
             "type": access_type,
@@ -186,6 +187,7 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 raw_access.get("state_ref"), "access.state_ref"
             ),
             "remote_port": int(raw_access.get("remote_port") or 80),
+            "local_port": int(raw_access.get("local_port") or 0),
             "path": str(raw_access.get("path") or "/").strip() or "/",
             "ssh_user": str(raw_access.get("ssh_user") or "").strip(),
             "ssh_key_file": str(raw_access.get("ssh_key_file") or "").strip(),
@@ -202,7 +204,13 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         }
         if not 1 <= access["remote_port"] <= 65535:
             raise ValueError("access.remote_port must be between 1 and 65535")
-        if access_type in {"ssh-forward", "gcp-iap-ssh-forward"}:
+        if access["local_port"] and not 1 <= access["local_port"] <= 65535:
+            raise ValueError("access.local_port must be between 1 and 65535")
+        if access_type in {
+            "ssh-forward",
+            "ssh-tcp-forward",
+            "gcp-iap-ssh-forward",
+        }:
             if not access["ssh_user"]:
                 raise ValueError(
                     "access.ssh_user is required for SSH-forward access"

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -37,6 +37,13 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(server_step["inputs"]["gns3_server_port"], 3080)
         self.assertTrue(server_step["inputs"]["gns3_server_require_kvm"])
 
+    def test_desktop_client_access_uses_private_tcp_forward(self) -> None:
+        access = self.blueprint["access"]
+        self.assertEqual(access["type"], "ssh-tcp-forward")
+        self.assertEqual(access["state_ref"], "platform/onprem/platform-vm#gns3_vm")
+        self.assertEqual(access["remote_port"], 3080)
+        self.assertEqual(access["local_port"], 3080)
+
     def test_template_is_retained_during_blueprint_destroy(self) -> None:
         template_step = self.blueprint["steps"][0]
         self.assertTrue(template_step["retain_on_destroy"])


### PR DESCRIPTION
Closes #108

## Summary

- add a reusable SSH TCP-forward blueprint access type
- support a blueprint-preferred local port with command-line override
- fail clearly when the requested local port is occupied
- add private desktop-client access to `onprem/gns3@v1`

## Validation

- default port 3080 collision detected against a local GNS3 service
- tunnel opened successfully with `--local-port 13080`
- authenticated GNS3 2.2.55 API reached through the tunnel
- Ctrl-C closed the tunnel cleanly
- no browser was launched for TCP access
- `python3 -m unittest discover -s hyops -p "test_*.py"` (96 tests)

## Dependency

Stacked on #107. Rebase after that blueprint reaches `main`.