### PR TITLE
Add structured GNS3 health checks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - added structured GNS3 health checks with an optional disposable VPCS lifecycle
   - added private desktop-client TCP access for the Proxmox GNS3 blueprint
   - added a standalone Proxmox GNS3 blueprint with a private authenticated API
   - added a provider-neutral GNS3 server module backed by hybridops.app 0.1.8

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - added private desktop-client TCP access for the Proxmox GNS3 blueprint
   - added a standalone Proxmox GNS3 blueprint with a private authenticated API
   - added a provider-neutral GNS3 server module backed by hybridops.app 0.1.8
   - linked README scenario entries directly to their reference scenario pages

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <table align="center">
   <tr>
-    <td align="center"><strong>75</strong><br><sub>runtime modules</sub></td>
+    <td align="center"><strong>76</strong><br><sub>runtime modules</sub></td>
     <td align="center"><strong>27</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported surfaces</sub></td>

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -4,9 +4,9 @@ Build a dedicated GNS3 server on Proxmox from a verified Ubuntu 22.04
 template. The blueprint provisions the VM and configures the authenticated
 GNS3 API through the provider-neutral Linux module.
 
-The API listens on the VM loopback interface. A desktop-client access command
-will provide the private tunnel in a separate change; the server is not exposed
-to the local network by this blueprint.
+The API listens on the VM loopback interface. The access command opens a private
+SSH tunnel for the GNS3 desktop client; the server is not exposed to the local
+network by this blueprint.
 
 ## Execution chain
 
@@ -42,6 +42,24 @@ hyops blueprint deploy \
   --ref onprem/gns3@v1 \
   --execute
 ```
+
+## Connect a desktop client
+
+```bash
+hyops blueprint access \
+  --env gns3-lab \
+  --ref onprem/gns3@v1
+```
+
+Keep the command running and configure the GNS3 desktop client to use host
+`127.0.0.1`, port `3080` and protocol `HTTP`. Retrieve the generated password
+from the environment vault when configuring the client:
+
+```bash
+hyops secrets show --env gns3-lab GNS3_SERVER_PASSWORD
+```
+
+Press Ctrl-C in the access terminal to close the tunnel.
 
 ## Default VM
 

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -14,6 +14,7 @@ network by this blueprint.
 core/onprem/template-image
   -> platform/onprem/platform-vm
   -> platform/linux/gns3-server
+  -> platform/linux/gns3-healthcheck
 ```
 
 ## Prerequisites

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -89,3 +89,26 @@ steps:
       gns3_server_enable_kvm: true
       gns3_server_require_kvm: true
       gns3_server_install_emulators: true
+
+  - id: gns3_healthcheck
+    module_ref: "platform/linux/gns3-healthcheck"
+    action: "deploy"
+    phase: "operations"
+    with_deps: false
+    requires:
+      - gns3_server
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+      inventory_vm_groups:
+        targets:
+          - "gns3-01"
+      target_user: "opsadmin"
+      ssh_proxy_jump_auto: true
+      ssh_proxy_jump_user: "root"
+      become: true
+      become_user: "root"
+      gns3_healthcheck_require_kvm: true
+      gns3_healthcheck_require_local_compute: true
+      gns3_healthcheck_deep: true

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -14,6 +14,14 @@ policy:
   evidence_required: true
   ipam_authority: "none"
 
+access:
+  type: "ssh-tcp-forward"
+  state_ref: "platform/onprem/platform-vm#gns3_vm"
+  remote_port: 3080
+  local_port: 3080
+  ssh_user: "opsadmin"
+  ssh_key_file: "~/.ssh/id_ed25519"
+
 steps:
   - id: template_image_jammy
     module_ref: "core/onprem/template-image"

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -586,7 +586,7 @@ def _require_local_ports_available(ports: list[int]) -> None:
             sockets.append(sock)
     except OSError as exc:
         raise ValueError(
-            f"native console port {port} is unavailable on localhost: {exc}"
+            f"local port {port} is unavailable on localhost: {exc}"
         ) from exc
     finally:
         for sock in sockets:
@@ -721,7 +721,7 @@ def run_access(ns) -> int:
         remote_port = int(access.get("remote_port") or 80)
         path = str(access.get("path") or "/")
 
-        if access_type in {"direct-http", "ssh-forward"}:
+        if access_type in {"direct-http", "ssh-forward", "ssh-tcp-forward"}:
             host = _extract_access_host(outputs)
             if not host:
                 raise ValueError(f"VM state does not contain a usable IPv4 address: {state_ref}")
@@ -786,7 +786,12 @@ def run_access(ns) -> int:
                 if console_ports:
                     _require_local_ports_available(console_ports)
 
-            port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
+            requested_port = int(getattr(ns, "local_port", 0) or 0) or int(
+                access.get("local_port") or 0
+            )
+            port = _available_local_port(requested_port)
+            if requested_port:
+                _require_local_ports_available([port])
             url = f"http://127.0.0.1:{port}{path}"
             argv = [*ssh_base, "-N", "-o", "ExitOnForwardFailure=yes"]
             argv.extend(["-L", f"127.0.0.1:{port}:127.0.0.1:{remote_port}"])
@@ -796,8 +801,12 @@ def run_access(ns) -> int:
                 )
             argv.append(ssh_target)
 
-            print("opening private Proxmox EVE-NG access")
-            print(f"local URL: {url}")
+            if access_type == "ssh-tcp-forward":
+                print("opening private TCP access")
+                print(f"local endpoint: 127.0.0.1:{port}")
+            else:
+                print("opening private Proxmox EVE-NG access")
+                print(f"local URL: {url}")
             _print_guest_network_guidance(access)
             if bool(getattr(ns, "native_consoles", False)):
                 print(_native_console_status(console_ports))
@@ -808,7 +817,9 @@ def run_access(ns) -> int:
             time.sleep(2)
             if proc.poll() is not None:
                 return OPERATOR_ERROR
-            if not bool(getattr(ns, "no_browser", False)):
+            if access_type != "ssh-tcp-forward" and not bool(
+                getattr(ns, "no_browser", False)
+            ):
                 open_operator_url(url)
             try:
                 return int(proc.wait())

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -173,12 +173,13 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         if access_type not in {
             "direct-http",
             "ssh-forward",
+            "ssh-tcp-forward",
             "gcp-iap-http",
             "gcp-iap-ssh-forward",
         }:
             raise ValueError(
-                "access.type must be direct-http, ssh-forward, gcp-iap-http, "
-                "or gcp-iap-ssh-forward"
+                "access.type must be direct-http, ssh-forward, ssh-tcp-forward, "
+                "gcp-iap-http, or gcp-iap-ssh-forward"
             )
         access = {
             "type": access_type,
@@ -186,6 +187,7 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 raw_access.get("state_ref"), "access.state_ref"
             ),
             "remote_port": int(raw_access.get("remote_port") or 80),
+            "local_port": int(raw_access.get("local_port") or 0),
             "path": str(raw_access.get("path") or "/").strip() or "/",
             "ssh_user": str(raw_access.get("ssh_user") or "").strip(),
             "ssh_key_file": str(raw_access.get("ssh_key_file") or "").strip(),
@@ -202,7 +204,13 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         }
         if not 1 <= access["remote_port"] <= 65535:
             raise ValueError("access.remote_port must be between 1 and 65535")
-        if access_type in {"ssh-forward", "gcp-iap-ssh-forward"}:
+        if access["local_port"] and not 1 <= access["local_port"] <= 65535:
+            raise ValueError("access.local_port must be between 1 and 65535")
+        if access_type in {
+            "ssh-forward",
+            "ssh-tcp-forward",
+            "gcp-iap-ssh-forward",
+        }:
             if not access["ssh_user"]:
                 raise ValueError(
                     "access.ssh_user is required for SSH-forward access"

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -37,6 +37,13 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(server_step["inputs"]["gns3_server_port"], 3080)
         self.assertTrue(server_step["inputs"]["gns3_server_require_kvm"])
 
+    def test_desktop_client_access_uses_private_tcp_forward(self) -> None:
+        access = self.blueprint["access"]
+        self.assertEqual(access["type"], "ssh-tcp-forward")
+        self.assertEqual(access["state_ref"], "platform/onprem/platform-vm#gns3_vm")
+        self.assertEqual(access["remote_port"], 3080)
+        self.assertEqual(access["local_port"], 3080)
+
     def test_template_is_retained_during_blueprint_destroy(self) -> None:
         template_step = self.blueprint["steps"][0]
         self.assertTrue(template_step["retain_on_destroy"])

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -16,7 +16,7 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(self.blueprint["policy"]["ipam_authority"], "none")
         self.assertEqual(
             [step["id"] for step in self.blueprint["steps"]],
-            ["template_image_jammy", "gns3_vm", "gns3_server"],
+            ["template_image_jammy", "gns3_vm", "gns3_server", "gns3_healthcheck"],
         )
 
         vm_step = self.blueprint["steps"][1]
@@ -51,3 +51,11 @@ class OnPremGNS3BlueprintTest(TestCase):
             template_step["inputs"]["template_key"],
             "ubuntu-22.04",
         )
+
+    def test_healthcheck_runs_disposable_vpcs_lifecycle(self) -> None:
+        health_step = self.blueprint["steps"][3]
+        self.assertEqual(health_step["requires"], ["gns3_server"])
+        self.assertEqual(
+            health_step["module_ref"], "platform/linux/gns3-healthcheck"
+        )
+        self.assertTrue(health_step["inputs"]["gns3_healthcheck_deep"])

--- a/modules/platform/linux/gns3-healthcheck/README.md
+++ b/modules/platform/linux/gns3-healthcheck/README.md
@@ -12,4 +12,3 @@ hyops apply --env lab \
   --module platform/linux/gns3-healthcheck \
   --inputs modules/platform/linux/gns3-healthcheck/examples/inputs.min.yml
 ```
-

--- a/modules/platform/linux/gns3-healthcheck/README.md
+++ b/modules/platform/linux/gns3-healthcheck/README.md
@@ -1,0 +1,15 @@
+# platform/linux/gns3-healthcheck
+
+Validate an installed GNS3 server and its local compute runtime. The module
+checks service state, API authentication, nested KVM, emulator commands and
+writable data directories.
+
+Set `gns3_healthcheck_deep: true` to run a disposable VPCS lifecycle. The
+temporary project is removed after the check.
+
+```bash
+hyops apply --env lab \
+  --module platform/linux/gns3-healthcheck \
+  --inputs modules/platform/linux/gns3-healthcheck/examples/inputs.min.yml
+```
+

--- a/modules/platform/linux/gns3-healthcheck/examples/inputs.min.yml
+++ b/modules/platform/linux/gns3-healthcheck/examples/inputs.min.yml
@@ -4,4 +4,3 @@ inventory_vm_groups:
     - "gns3-01"
 target_user: "opsadmin"
 gns3_healthcheck_deep: true
-

--- a/modules/platform/linux/gns3-healthcheck/examples/inputs.min.yml
+++ b/modules/platform/linux/gns3-healthcheck/examples/inputs.min.yml
@@ -1,0 +1,7 @@
+inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+inventory_vm_groups:
+  targets:
+    - "gns3-01"
+target_user: "opsadmin"
+gns3_healthcheck_deep: true
+

--- a/modules/platform/linux/gns3-healthcheck/spec.yml
+++ b/modules/platform/linux/gns3-healthcheck/spec.yml
@@ -1,0 +1,68 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/gns3-healthcheck"
+
+metadata:
+  title: "Linux GNS3 Health Check"
+  description: "Validate an installed GNS3 server, its local compute runtime, and optional disposable VPCS execution."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+
+    required_env:
+      - "GNS3_SERVER_PASSWORD"
+    required_env_destroy: []
+    load_vault_env: true
+
+    gns3_healthcheck_role_fqcn: "hybridops.app.gns3_healthcheck"
+    gns3_healthcheck_port: 3080
+    gns3_healthcheck_username: "gns3"
+    gns3_healthcheck_password_env: "GNS3_SERVER_PASSWORD"
+    gns3_healthcheck_require_kvm: true
+    gns3_healthcheck_require_local_compute: true
+    gns3_healthcheck_deep: false
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/45-gns3-healthcheck@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.gns3.health
+    - gns3_health_status
+    - gns3_health_version
+    - gns3_health_deep_check
+
+probes: []
+constraints: []
+

--- a/modules/platform/linux/gns3-healthcheck/spec.yml
+++ b/modules/platform/linux/gns3-healthcheck/spec.yml
@@ -65,4 +65,3 @@ outputs:
 
 probes: []
 constraints: []
-

--- a/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/destroy.playbook.yml
@@ -20,4 +20,3 @@
             'gns3_health_version': '',
             'gns3_health_deep_check': 'not-run'
           } | to_json }}
-

--- a/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,23 @@
+---
+- name: Destroy platform/linux/gns3-healthcheck
+  hosts: targets
+  become: false
+  gather_facts: false
+
+  tasks: []
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.health': 'not-run',
+            'gns3_health_status': 'not-run',
+            'gns3_health_version': '',
+            'gns3_health_deep_check': 'not-run'
+          } | to_json }}
+

--- a/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/playbook.yml
@@ -29,4 +29,3 @@
             'gns3_health_version': gns3_healthcheck_results.version,
             'gns3_health_deep_check': gns3_healthcheck_results.deep_check
           } | to_json }}
-

--- a/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/45-gns3-healthcheck@v1.0/stack/playbook.yml
@@ -1,0 +1,32 @@
+---
+- name: platform/linux/gns3-healthcheck
+  hosts: targets
+  become: true
+  gather_facts: true
+
+  vars:
+    _hyops_gns3_healthcheck_password: >-
+      {{ lookup('env', gns3_healthcheck_password_env | default('GNS3_SERVER_PASSWORD')) }}
+
+  tasks:
+    - name: Run GNS3 health checks
+      ansible.builtin.include_role:
+        name: "{{ gns3_healthcheck_role_fqcn }}"
+      vars:
+        gns3_healthcheck_password: "{{ _hyops_gns3_healthcheck_password }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.health': 'checked',
+            'gns3_health_status': gns3_healthcheck_results.status,
+            'gns3_health_version': gns3_healthcheck_results.version,
+            'gns3_health_deep_check': gns3_healthcheck_results.deep_check
+          } | to_json }}
+

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -6,7 +6,7 @@ collections:
     version: "0.1.7"
 
   - name: hybridops.app
-    version: "0.1.8"
+    version: "0.1.9"
 
   - name: ansible.posix
     version: "1.6.2"


### PR DESCRIPTION
Closes #110

## Summary

- add `platform/linux/gns3-healthcheck`
- publish concise GNS3 readiness outputs
- add a required deep health stage to `onprem/gns3@v1`
- update the module count to 76

## Validation

- four-stage Proxmox blueprint preflight passed
- live deep check passed on Ubuntu 22.04 with GNS3 2.2.55
- service, authentication, local compute, KVM, emulator commands and data paths checked
- disposable VPCS create, start, stop and cleanup passed
- run-record scan found no GNS3 password
- `python3 -m unittest discover -s hyops -p "test_*.py"` (97 tests)

## Dependencies

- stacked on #109
- collection role supplied by hybridops-tech/ansible-collection-app#8