### PR TITLE
Add a zero-image GNS3 starter lab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - added an idempotent zero-image GNS3 starter-lab module and blueprint stage
   - added structured GNS3 health checks with an optional disposable VPCS lifecycle
   - added private desktop-client TCP access for the Proxmox GNS3 blueprint
   - added a standalone Proxmox GNS3 blueprint with a private authenticated API

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <table align="center">
   <tr>
-    <td align="center"><strong>76</strong><br><sub>runtime modules</sub></td>
+    <td align="center"><strong>77</strong><br><sub>runtime modules</sub></td>
     <td align="center"><strong>27</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported surfaces</sub></td>

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -14,6 +14,7 @@ network by this blueprint.
 core/onprem/template-image
   -> platform/onprem/platform-vm
   -> platform/linux/gns3-server
+  -> platform/linux/gns3-starter-lab
   -> platform/linux/gns3-healthcheck
 ```
 

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -90,13 +90,34 @@ steps:
       gns3_server_require_kvm: true
       gns3_server_install_emulators: true
 
+  - id: gns3_starter_lab
+    module_ref: "platform/linux/gns3-starter-lab"
+    action: "deploy"
+    phase: "operations"
+    with_deps: false
+    requires:
+      - gns3_server
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+      inventory_vm_groups:
+        targets:
+          - "gns3-01"
+      target_user: "opsadmin"
+      ssh_proxy_jump_auto: true
+      ssh_proxy_jump_user: "root"
+      become: true
+      become_user: "root"
+      gns3_starter_lab_project_name: "HybridOps Starter Lab"
+
   - id: gns3_healthcheck
     module_ref: "platform/linux/gns3-healthcheck"
     action: "deploy"
     phase: "operations"
     with_deps: false
     requires:
-      - gns3_server
+      - gns3_starter_lab
     contracts:
       addressing_mode: "static"
     inputs:

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -16,7 +16,13 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(self.blueprint["policy"]["ipam_authority"], "none")
         self.assertEqual(
             [step["id"] for step in self.blueprint["steps"]],
-            ["template_image_jammy", "gns3_vm", "gns3_server", "gns3_healthcheck"],
+            [
+                "template_image_jammy",
+                "gns3_vm",
+                "gns3_server",
+                "gns3_starter_lab",
+                "gns3_healthcheck",
+            ],
         )
 
         vm_step = self.blueprint["steps"][1]
@@ -53,9 +59,20 @@ class OnPremGNS3BlueprintTest(TestCase):
         )
 
     def test_healthcheck_runs_disposable_vpcs_lifecycle(self) -> None:
-        health_step = self.blueprint["steps"][3]
-        self.assertEqual(health_step["requires"], ["gns3_server"])
+        health_step = self.blueprint["steps"][4]
+        self.assertEqual(health_step["requires"], ["gns3_starter_lab"])
         self.assertEqual(
             health_step["module_ref"], "platform/linux/gns3-healthcheck"
         )
         self.assertTrue(health_step["inputs"]["gns3_healthcheck_deep"])
+
+    def test_starter_lab_uses_builtin_topology(self) -> None:
+        starter_step = self.blueprint["steps"][3]
+        self.assertEqual(starter_step["requires"], ["gns3_server"])
+        self.assertEqual(
+            starter_step["module_ref"], "platform/linux/gns3-starter-lab"
+        )
+        self.assertEqual(
+            starter_step["inputs"]["gns3_starter_lab_project_name"],
+            "HybridOps Starter Lab",
+        )

--- a/modules/platform/linux/gns3-starter-lab/README.md
+++ b/modules/platform/linux/gns3-starter-lab/README.md
@@ -1,0 +1,12 @@
+# platform/linux/gns3-starter-lab
+
+Create a zero-image GNS3 teaching topology from built-in node types. The project
+contains NAT, an Ethernet switch and two VPCS nodes.
+
+An existing project is retained so tutor or learner changes are not overwritten.
+
+```bash
+hyops apply --env lab \
+  --module platform/linux/gns3-starter-lab \
+  --inputs modules/platform/linux/gns3-starter-lab/examples/inputs.min.yml
+```

--- a/modules/platform/linux/gns3-starter-lab/examples/inputs.min.yml
+++ b/modules/platform/linux/gns3-starter-lab/examples/inputs.min.yml
@@ -1,0 +1,6 @@
+inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+inventory_vm_groups:
+  targets:
+    - "gns3-01"
+target_user: "opsadmin"
+gns3_starter_lab_project_name: "HybridOps Starter Lab"

--- a/modules/platform/linux/gns3-starter-lab/spec.yml
+++ b/modules/platform/linux/gns3-starter-lab/spec.yml
@@ -1,0 +1,66 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/gns3-starter-lab"
+
+metadata:
+  title: "Linux GNS3 Starter Lab"
+  description: "Create or retain a zero-image GNS3 teaching topology using built-in NAT, Ethernet switch, and VPCS nodes."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+
+    required_env:
+      - "GNS3_SERVER_PASSWORD"
+    required_env_destroy: []
+    load_vault_env: true
+
+    gns3_starter_lab_role_fqcn: "hybridops.app.gns3_starter_lab"
+    gns3_starter_lab_port: 3080
+    gns3_starter_lab_username: "gns3"
+    gns3_starter_lab_password_env: "GNS3_SERVER_PASSWORD"
+    gns3_starter_lab_project_name: "HybridOps Starter Lab"
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/46-gns3-starter-lab@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.gns3.starter
+    - gns3_starter_project_name
+    - gns3_starter_project_id
+    - gns3_starter_node_count
+    - gns3_starter_link_count
+
+probes: []
+constraints: []

--- a/packs/config/ansible/linux/common/platform/46-gns3-starter-lab@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/46-gns3-starter-lab@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,23 @@
+---
+- name: Destroy platform/linux/gns3-starter-lab
+  hosts: targets
+  become: false
+  gather_facts: false
+
+  tasks: []
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.starter': 'not-run',
+            'gns3_starter_project_name': '',
+            'gns3_starter_project_id': '',
+            'gns3_starter_node_count': 0,
+            'gns3_starter_link_count': 0
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/46-gns3-starter-lab@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/46-gns3-starter-lab@v1.0/stack/playbook.yml
@@ -1,0 +1,32 @@
+---
+- name: platform/linux/gns3-starter-lab
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_gns3_starter_password: >-
+      {{ lookup('env', gns3_starter_lab_password_env | default('GNS3_SERVER_PASSWORD')) }}
+
+  tasks:
+    - name: Create or retain GNS3 starter lab
+      ansible.builtin.include_role:
+        name: "{{ gns3_starter_lab_role_fqcn }}"
+      vars:
+        gns3_starter_lab_password: "{{ _hyops_gns3_starter_password }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.starter': 'ready',
+            'gns3_starter_project_name': gns3_starter_lab_results.project_name,
+            'gns3_starter_project_id': gns3_starter_lab_results.project_id,
+            'gns3_starter_node_count': gns3_starter_lab_results.node_count,
+            'gns3_starter_link_count': gns3_starter_lab_results.link_count
+          } | to_json }}

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -6,7 +6,7 @@ collections:
     version: "0.1.7"
 
   - name: hybridops.app
-    version: "0.1.9"
+    version: "0.1.11"
 
   - name: ansible.posix
     version: "1.6.2"


### PR DESCRIPTION
Closes #112

## Summary

Adds an idempotent starter-lab module to the Proxmox GNS3 blueprint. The project uses built-in NAT, Ethernet switch and VPCS nodes, so a first lab is available without licensed appliance images. Existing learner or tutor changes are retained.

## Validation

- focused GNS3 blueprint tests
- full Core unit suite (98 tests)
- five-stage Proxmox preflight and deploy
- destroy with template retention followed by a clean redeploy
- repeated deploy retained the same project with four nodes and three links
- deep GNS3 health check passed after redeploy