### PR TITLE
Add a private GCP GNS3 teaching lab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - added a private GCP GNS3 teaching blueprint with IAP desktop-client access
   - added an idempotent zero-image GNS3 starter-lab module and blueprint stage
   - added structured GNS3 health checks with an optional disposable VPCS lifecycle
   - added private desktop-client TCP access for the Proxmox GNS3 blueprint

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <table align="center">
   <tr>
     <td align="center"><strong>77</strong><br><sub>runtime modules</sub></td>
-    <td align="center"><strong>27</strong><br><sub>reference blueprints</sub></td>
+    <td align="center"><strong>28</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported surfaces</sub></td>
   </tr>

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -45,6 +45,7 @@ Each shipped blueprint directory contains a `blueprint.yml` contract and a local
 | [`gcp/linux-desktop@v1`](gcp/linux-desktop@v1) | Ubuntu desktop VM with XFCE and XRDP. |
 | [`gcp/windows-desktop@v1`](gcp/windows-desktop@v1) | Windows Server VM with scoped RDP access. |
 | [`gcp/eve-ng@v1`](gcp/eve-ng@v1) | Private nested-virtualization-capable EVE-NG host on GCP. |
+| [`gcp/gns3@v1`](gcp/gns3@v1) | Private nested-virtualization-capable GNS3 server on GCP. |
 
 ### Networking
 

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -1,0 +1,52 @@
+# GCP GNS3 Teaching Lab
+
+Deploy a private GNS3 server and a zero-image starter topology on Google Cloud.
+The VM has no public IP; SSH and desktop-client access use IAP.
+
+## Execution chain
+
+```text
+platform/gcp/lab-network
+  -> platform/gcp/platform-vm
+  -> platform/linux/gns3-server
+  -> platform/linux/gns3-starter-lab
+  -> platform/linux/gns3-healthcheck
+```
+
+## Prerequisites
+
+Initialise the GCP environment and seed the GNS3 API password:
+
+```bash
+hyops init gcp --env gns3-gcp
+hyops secrets ensure --env gns3-gcp GNS3_SERVER_PASSWORD
+```
+
+GCP initialisation and module preflight confirm project, authentication and
+billing readiness before resources are created.
+
+## Deploy
+
+```bash
+hyops blueprint preflight --env gns3-gcp --ref gcp/gns3@v1
+hyops blueprint deploy --env gns3-gcp --ref gcp/gns3@v1 --execute
+```
+
+## Connect a desktop client
+
+```bash
+hyops blueprint access --env gns3-gcp --ref gcp/gns3@v1
+```
+
+Keep the command running and configure the GNS3 desktop client to use the
+printed loopback endpoint. Retrieve the API password when required:
+
+```bash
+hyops secrets show --env gns3-gcp GNS3_SERVER_PASSWORD
+```
+
+## Remove the lab
+
+```bash
+hyops blueprint destroy --env gns3-gcp --ref gcp/gns3@v1 --execute
+```

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -1,0 +1,169 @@
+api_version: hybridops/v1
+kind: BlueprintSpec
+
+blueprint_ref: "gcp/gns3@v1"
+mode: "hybrid"
+
+metadata:
+  title: "GCP GNS3 Teaching Lab"
+  description: "Provision a private nested-virtualization-capable GNS3 server on Google Cloud."
+  outcome: "An authenticated GNS3 server and zero-image starter lab are ready through private IAP access."
+
+policy:
+  fail_fast: true
+  evidence_required: true
+  ipam_authority: "none"
+
+access:
+  type: "gcp-iap-ssh-forward"
+  state_ref: "platform/gcp/platform-vm#gcp_gns3_vm"
+  remote_port: 3080
+  local_port: 3080
+  open_browser: false
+  ssh_user: "opsadmin"
+  ssh_key_file: "~/.ssh/id_ed25519"
+
+steps:
+  - id: gcp_gns3_network
+    module_ref: "platform/gcp/lab-network"
+    execution_profile: "gcp-local@v1.0"
+    state_instance: "gcp_gns3_network"
+    action: "deploy"
+    phase: "bootstrap"
+    with_deps: false
+    skip_if_state_ok: true
+    verify_state_on_skip: true
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      name_prefix: "platform"
+      context_id: "gns3-lab"
+      subnetwork_cidr: "10.80.60.0/24"
+
+  - id: gcp_gns3_vm
+    module_ref: "platform/gcp/platform-vm"
+    execution_profile: "gcp-local@v1.0"
+    state_instance: "gcp_gns3_vm"
+    action: "deploy"
+    phase: "bootstrap"
+    requires:
+      - gcp_gns3_network
+    with_deps: true
+    skip_if_state_ok: true
+    verify_state_on_skip: true
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      name_prefix: "platform"
+      context_id: "gns3-lab"
+      network_state_ref: "platform/gcp/lab-network#gcp_gns3_network"
+      subnetwork_output_key: "subnetwork_name"
+      zone: ""
+      zone_from_init_region: true
+      machine_type: "n2-standard-8"
+      boot_disk_size_gb: 128
+      boot_disk_type: "pd-standard"
+      source_image_project: "ubuntu-os-cloud"
+      source_image_family: "ubuntu-2204-lts"
+      assign_public_ip: false
+      enable_nested_virtualization: true
+      ssh_username: "opsadmin"
+      ssh_keys_from_init: true
+      post_apply_ssh_readiness:
+        enabled: true
+        required: true
+        target_user: "opsadmin"
+        connectivity_wait_s: 90
+      tags:
+        - "platform"
+        - "gcp"
+        - "gns3"
+        - "lab"
+        - "allow-iap-ssh"
+      labels:
+        role: "gns3"
+        workload: "network-lab"
+      vms:
+        gns3-01:
+          role: "gns3"
+
+  - id: gcp_gns3_server
+    module_ref: "platform/linux/gns3-server"
+    state_instance: "gcp_gns3_server"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_gns3_vm
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_gns3_vm"
+      inventory_vm_groups:
+        targets:
+          - "gns3-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      gns3_server_bind_address: "127.0.0.1"
+      gns3_server_port: 3080
+      gns3_server_enable_kvm: true
+      gns3_server_require_kvm: true
+      gns3_server_install_emulators: true
+
+  - id: gcp_gns3_starter_lab
+    module_ref: "platform/linux/gns3-starter-lab"
+    state_instance: "gcp_gns3_starter_lab"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_gns3_server
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_gns3_vm"
+      inventory_vm_groups:
+        targets:
+          - "gns3-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      gns3_starter_lab_project_name: "HybridOps Starter Lab"
+
+  - id: gcp_gns3_healthcheck
+    module_ref: "platform/linux/gns3-healthcheck"
+    state_instance: "gcp_gns3_healthcheck"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_gns3_starter_lab
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_gns3_vm"
+      inventory_vm_groups:
+        targets:
+          - "gns3-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      gns3_healthcheck_require_kvm: true
+      gns3_healthcheck_require_local_compute: true
+      gns3_healthcheck_deep: true

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -902,8 +902,12 @@ def run_access(ns) -> int:
                 "--project", project, "--zone", zone,
                 f"--local-host-port=127.0.0.1:{port}",
             ]
+        open_browser = bool(access.get("open_browser", True))
         print("opening private GCP IAP access")
-        print(f"local URL: {url}")
+        if open_browser:
+            print(f"local URL: {url}")
+        else:
+            print(f"local endpoint: 127.0.0.1:{port}")
         _print_guest_network_guidance(access)
         if bool(getattr(ns, "native_consoles", False)):
             print(_native_console_status(console_ports))
@@ -915,7 +919,7 @@ def run_access(ns) -> int:
         if proc.poll() is not None:
             _stop_process(iap_proc)
             return OPERATOR_ERROR
-        if not bool(getattr(ns, "no_browser", False)):
+        if open_browser and not bool(getattr(ns, "no_browser", False)):
             open_operator_url(url)
         try:
             rc = int(proc.wait())

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -189,6 +189,7 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             "remote_port": int(raw_access.get("remote_port") or 80),
             "local_port": int(raw_access.get("local_port") or 0),
             "path": str(raw_access.get("path") or "/").strip() or "/",
+            "open_browser": bool(raw_access.get("open_browser", True)),
             "ssh_user": str(raw_access.get("ssh_user") or "").strip(),
             "ssh_key_file": str(raw_access.get("ssh_key_file") or "").strip(),
             "native_console_mode": str(

--- a/hyops/blueprint/tests/test_gcp_gns3.py
+++ b/hyops/blueprint/tests/test_gcp_gns3.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from unittest import TestCase
+
+from hyops.blueprint.schema import load_blueprint, validate_blueprint
+
+
+class GCPGNS3BlueprintTest(TestCase):
+    def setUp(self) -> None:
+        root = Path(__file__).resolve().parents[3]
+        path = root / "blueprints" / "gcp" / "gns3@v1" / "blueprint.yml"
+        self.blueprint = validate_blueprint(load_blueprint(path), path)
+
+    def test_private_five_stage_chain(self) -> None:
+        self.assertEqual(
+            [step["id"] for step in self.blueprint["steps"]],
+            [
+                "gcp_gns3_network",
+                "gcp_gns3_vm",
+                "gcp_gns3_server",
+                "gcp_gns3_starter_lab",
+                "gcp_gns3_healthcheck",
+            ],
+        )
+        vm_inputs = self.blueprint["steps"][1]["inputs"]
+        self.assertFalse(vm_inputs["assign_public_ip"])
+        self.assertTrue(vm_inputs["enable_nested_virtualization"])
+
+    def test_operations_use_iap(self) -> None:
+        for step in self.blueprint["steps"][2:]:
+            self.assertEqual(step["inputs"]["ssh_access_mode"], "gcp-iap")
+
+    def test_access_uses_loopback_iap_forward(self) -> None:
+        access = self.blueprint["access"]
+        self.assertEqual(access["type"], "gcp-iap-ssh-forward")
+        self.assertEqual(access["remote_port"], 3080)
+        self.assertEqual(access["local_port"], 3080)
+        self.assertFalse(access["open_browser"])
+
+    def test_required_health_stage_is_deep(self) -> None:
+        health = self.blueprint["steps"][4]
+        self.assertEqual(health["requires"], ["gcp_gns3_starter_lab"])
+        self.assertTrue(health["inputs"]["gns3_healthcheck_deep"])


### PR DESCRIPTION
Closes #114

## Summary

Adds a five-stage GCP GNS3 teaching blueprint using the existing private lab network, generic VM and reusable GNS3 modules. The VM has nested virtualisation enabled, no public IP, and exposes the authenticated desktop-client endpoint only through an IAP loopback tunnel.

The blueprint also creates the built-in starter topology and requires the deep GNS3 health stage.

## Validation

- focused GCP and GNS3 blueprint tests
- full Core unit suite (102 tests)
- live billing-aware preflight and five-stage deployment on GCP
- verified n2-standard-8, nested virtualisation and private-only address
- unauthenticated API returned 401; vault-authenticated API returned GNS3 2.2.55
- starter VPCS received DHCP and completed three replies from 8.8.8.8
- convergence rerun passed with network and VM state reused
- full destroy passed; provider checks found no remaining lab VM or network