### PR TITLE
Add managed images to GNS3 blueprints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - added checksum-verified GNS3 image installation and template registration
   - added a private GCP GNS3 teaching blueprint with IAP desktop-client access
   - added an idempotent zero-image GNS3 starter-lab module and blueprint stage
   - added structured GNS3 health checks with an optional disposable VPCS lifecycle

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <table align="center">
   <tr>
-    <td align="center"><strong>77</strong><br><sub>runtime modules</sub></td>
+    <td align="center"><strong>78</strong><br><sub>runtime modules</sub></td>
     <td align="center"><strong>28</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported surfaces</sub></td>

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -9,6 +9,7 @@ The VM has no public IP; SSH and desktop-client access use IAP.
 platform/gcp/lab-network
   -> platform/gcp/platform-vm
   -> platform/linux/gns3-server
+  -> platform/linux/gns3-images
   -> platform/linux/gns3-starter-lab
   -> platform/linux/gns3-healthcheck
 ```

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -116,13 +116,46 @@ steps:
       gns3_server_require_kvm: true
       gns3_server_install_emulators: true
 
+  - id: gcp_gns3_images
+    module_ref: "platform/linux/gns3-images"
+    state_instance: "gcp_gns3_images"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_gns3_server
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_gns3_vm"
+      inventory_vm_groups:
+        targets:
+          - "gns3-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      gns3_images_items:
+        - name: "Alpine Linux 3.24"
+          url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"
+          filename: "alpine-virt-3.24.1-x86_64.iso"
+          checksum: "sha256:e73a6241bd5f3c5c2d4d38c02cc52c378c0415a7c888bd292066bf36e0f41a39"
+          disk_type: "cdrom"
+          template:
+            ram: 512
+            adapters: 2
+
   - id: gcp_gns3_starter_lab
     module_ref: "platform/linux/gns3-starter-lab"
     state_instance: "gcp_gns3_starter_lab"
     action: "deploy"
     phase: "operations"
     requires:
-      - gcp_gns3_server
+      - gcp_gns3_images
     with_deps: false
     skip_if_state_ok: false
     contracts:

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -14,6 +14,7 @@ network by this blueprint.
 core/onprem/template-image
   -> platform/onprem/platform-vm
   -> platform/linux/gns3-server
+  -> platform/linux/gns3-images
   -> platform/linux/gns3-starter-lab
   -> platform/linux/gns3-healthcheck
 ```

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -90,13 +90,42 @@ steps:
       gns3_server_require_kvm: true
       gns3_server_install_emulators: true
 
+  - id: gns3_images
+    module_ref: "platform/linux/gns3-images"
+    action: "deploy"
+    phase: "operations"
+    with_deps: false
+    requires:
+      - gns3_server
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+      inventory_vm_groups:
+        targets:
+          - "gns3-01"
+      target_user: "opsadmin"
+      ssh_proxy_jump_auto: true
+      ssh_proxy_jump_user: "root"
+      become: true
+      become_user: "root"
+      gns3_images_items:
+        - name: "Alpine Linux 3.24"
+          url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"
+          filename: "alpine-virt-3.24.1-x86_64.iso"
+          checksum: "sha256:e73a6241bd5f3c5c2d4d38c02cc52c378c0415a7c888bd292066bf36e0f41a39"
+          disk_type: "cdrom"
+          template:
+            ram: 512
+            adapters: 2
+
   - id: gns3_starter_lab
     module_ref: "platform/linux/gns3-starter-lab"
     action: "deploy"
     phase: "operations"
     with_deps: false
     requires:
-      - gns3_server
+      - gns3_images
     contracts:
       addressing_mode: "static"
     inputs:

--- a/hyops/blueprint/tests/test_gcp_gns3.py
+++ b/hyops/blueprint/tests/test_gcp_gns3.py
@@ -10,13 +10,14 @@ class GCPGNS3BlueprintTest(TestCase):
         path = root / "blueprints" / "gcp" / "gns3@v1" / "blueprint.yml"
         self.blueprint = validate_blueprint(load_blueprint(path), path)
 
-    def test_private_five_stage_chain(self) -> None:
+    def test_private_six_stage_chain(self) -> None:
         self.assertEqual(
             [step["id"] for step in self.blueprint["steps"]],
             [
                 "gcp_gns3_network",
                 "gcp_gns3_vm",
                 "gcp_gns3_server",
+                "gcp_gns3_images",
                 "gcp_gns3_starter_lab",
                 "gcp_gns3_healthcheck",
             ],
@@ -37,6 +38,13 @@ class GCPGNS3BlueprintTest(TestCase):
         self.assertFalse(access["open_browser"])
 
     def test_required_health_stage_is_deep(self) -> None:
-        health = self.blueprint["steps"][4]
+        health = self.blueprint["steps"][5]
         self.assertEqual(health["requires"], ["gcp_gns3_starter_lab"])
         self.assertTrue(health["inputs"]["gns3_healthcheck_deep"])
+
+    def test_images_are_verified_before_starter_lab(self) -> None:
+        image_step = self.blueprint["steps"][3]
+        self.assertEqual(image_step["requires"], ["gcp_gns3_server"])
+        image = image_step["inputs"]["gns3_images_items"][0]
+        self.assertEqual(image["disk_type"], "cdrom")
+        self.assertRegex(image["checksum"], r"^sha256:[0-9a-f]{64}$")

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -20,6 +20,7 @@ class OnPremGNS3BlueprintTest(TestCase):
                 "template_image_jammy",
                 "gns3_vm",
                 "gns3_server",
+                "gns3_images",
                 "gns3_starter_lab",
                 "gns3_healthcheck",
             ],
@@ -59,7 +60,7 @@ class OnPremGNS3BlueprintTest(TestCase):
         )
 
     def test_healthcheck_runs_disposable_vpcs_lifecycle(self) -> None:
-        health_step = self.blueprint["steps"][4]
+        health_step = self.blueprint["steps"][5]
         self.assertEqual(health_step["requires"], ["gns3_starter_lab"])
         self.assertEqual(
             health_step["module_ref"], "platform/linux/gns3-healthcheck"
@@ -67,8 +68,8 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertTrue(health_step["inputs"]["gns3_healthcheck_deep"])
 
     def test_starter_lab_uses_builtin_topology(self) -> None:
-        starter_step = self.blueprint["steps"][3]
-        self.assertEqual(starter_step["requires"], ["gns3_server"])
+        starter_step = self.blueprint["steps"][4]
+        self.assertEqual(starter_step["requires"], ["gns3_images"])
         self.assertEqual(
             starter_step["module_ref"], "platform/linux/gns3-starter-lab"
         )
@@ -76,3 +77,10 @@ class OnPremGNS3BlueprintTest(TestCase):
             starter_step["inputs"]["gns3_starter_lab_project_name"],
             "HybridOps Starter Lab",
         )
+
+    def test_images_are_verified_before_starter_lab(self) -> None:
+        image_step = self.blueprint["steps"][3]
+        self.assertEqual(image_step["requires"], ["gns3_server"])
+        image = image_step["inputs"]["gns3_images_items"][0]
+        self.assertEqual(image["disk_type"], "cdrom")
+        self.assertRegex(image["checksum"], r"^sha256:[0-9a-f]{64}$")

--- a/hyops/tests/test_gns3_images_module.py
+++ b/hyops/tests/test_gns3_images_module.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from unittest import TestCase
+
+import yaml
+
+
+class GNS3ImagesModuleTest(TestCase):
+    def setUp(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        self.spec = yaml.safe_load(
+            (root / "modules/platform/linux/gns3-images/spec.yml").read_text()
+        )
+
+    def test_module_uses_collection_role_and_vault_password(self) -> None:
+        defaults = self.spec["inputs"]["defaults"]
+        self.assertEqual(defaults["gns3_images_role_fqcn"], "hybridops.app.gns3_images")
+        self.assertEqual(defaults["required_env"], ["GNS3_SERVER_PASSWORD"])
+
+    def test_module_publishes_image_and_template_counts(self) -> None:
+        self.assertEqual(
+            self.spec["outputs"]["publish"],
+            [
+                "cap.lab.gns3.images",
+                "gns3_images_requested_count",
+                "gns3_images_installed_count",
+                "gns3_images_template_names",
+            ],
+        )

--- a/hyops/validators/builtin/register.py
+++ b/hyops/validators/builtin/register.py
@@ -49,6 +49,7 @@ from hyops.validators.platform.linux import (
     eve_ng_healthcheck,
     eve_ng_images,
     eve_ng_labs,
+    gns3_images,
 )
 from hyops.validators.platform.onprem import (
     argocd_bootstrap,
@@ -105,6 +106,7 @@ def register_all() -> None:
     register("platform/linux/eve-ng-images", eve_ng_images.validate)
     register("platform/linux/eve-ng-labs", eve_ng_labs.validate)
     register("platform/linux/eve-ng-healthcheck", eve_ng_healthcheck.validate)
+    register("platform/linux/gns3-images", gns3_images.validate)
     register("platform/network/vyos-edge-wan", vyos_edge_wan.validate)
     register("platform/network/edge-observability", edge_observability.validate)
     register("platform/network/cloudflare-traffic-steering", cloudflare_traffic_steering.validate)

--- a/hyops/validators/platform/linux/gns3_images.py
+++ b/hyops/validators/platform/linux/gns3_images.py
@@ -1,0 +1,108 @@
+"""
+purpose: Validate inputs for platform/linux/gns3-images module.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePath
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+from hyops.validators.common import (
+    normalize_required_env,
+    require_mapping,
+    require_non_empty_str,
+    require_port,
+    require_str_list,
+)
+from hyops.validators.platform.linux._eve_ng_common import validate_target_access
+
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label} must be an integer >= 1")
+    return value
+
+
+def _validate_template(value: Any, label: str) -> None:
+    template = require_mapping(value, label)
+    for key in ("ram", "cpus", "adapters"):
+        if key in template:
+            _positive_int(template[key], f"{label}.{key}")
+    for key in (
+        "adapter_type",
+        "category",
+        "console_type",
+        "hda_disk_interface",
+        "platform",
+        "qemu_path",
+        "symbol",
+    ):
+        if key in template:
+            require_non_empty_str(template[key], f"{label}.{key}")
+    if "linked_clone" in template and not isinstance(template["linked_clone"], bool):
+        raise ValueError(f"{label}.linked_clone must be a boolean")
+
+
+def _validate_images(value: Any) -> None:
+    if not isinstance(value, list) or not value:
+        raise ValueError("inputs.gns3_images_items must be a non-empty list")
+
+    names: set[str] = set()
+    filenames: set[str] = set()
+    for index, raw in enumerate(value, start=1):
+        label = f"inputs.gns3_images_items[{index}]"
+        item = require_mapping(raw, label)
+        name = require_non_empty_str(item.get("name"), f"{label}.name")
+        url = require_non_empty_str(item.get("url"), f"{label}.url")
+        filename = require_non_empty_str(item.get("filename"), f"{label}.filename")
+        checksum = require_non_empty_str(item.get("checksum"), f"{label}.checksum")
+        disk_type = require_non_empty_str(
+            item.get("disk_type", "hda"), f"{label}.disk_type"
+        ).lower()
+
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"{label}.url must be an HTTP or HTTPS URL")
+        if filename != PurePath(filename).name or filename in {".", ".."}:
+            raise ValueError(f"{label}.filename must be a safe basename")
+        if not _SHA256_RE.fullmatch(checksum):
+            raise ValueError(f"{label}.checksum must use sha256:<64 hex characters>")
+        if disk_type not in {"hda", "cdrom"}:
+            raise ValueError(f"{label}.disk_type must be hda or cdrom")
+        if name in names:
+            raise ValueError(f"{label}.name duplicates an earlier declaration")
+        if filename in filenames:
+            raise ValueError(f"{label}.filename duplicates an earlier declaration")
+        names.add(name)
+        filenames.add(filename)
+
+        if item.get("timeout") is not None:
+            _positive_int(item["timeout"], f"{label}.timeout")
+        if item.get("template") is not None:
+            _validate_template(item["template"], f"{label}.template")
+
+
+def validate(inputs: dict[str, Any]) -> None:
+    data = require_mapping(inputs, "inputs")
+    validate_target_access(
+        data,
+        module_ref="platform/linux/gns3-images",
+        require_ubuntu=True,
+        require_eveng=False,
+    )
+    require_non_empty_str(data.get("gns3_images_role_fqcn"), "inputs.gns3_images_role_fqcn")
+    require_port(data.get("gns3_images_port"), "inputs.gns3_images_port")
+    require_non_empty_str(data.get("gns3_images_username"), "inputs.gns3_images_username")
+    require_non_empty_str(
+        data.get("gns3_images_password_env"), "inputs.gns3_images_password_env"
+    )
+    normalize_required_env(data.get("required_env"), "inputs.required_env")
+    if data.get("required_env_destroy") is not None:
+        require_str_list(data.get("required_env_destroy"), "inputs.required_env_destroy")
+    _validate_images(data.get("gns3_images_items"))

--- a/hyops/validators/platform/linux/tests/test_gns3_images.py
+++ b/hyops/validators/platform/linux/tests/test_gns3_images.py
@@ -1,0 +1,81 @@
+"""Tests for the GNS3 image module validator."""
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from hyops.validators.platform.linux.gns3_images import validate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MODULE_ROOT = REPO_ROOT / "modules" / "platform" / "linux" / "gns3-images"
+
+
+def valid_inputs() -> dict:
+    spec = yaml.safe_load((MODULE_ROOT / "spec.yml").read_text(encoding="utf-8"))
+    example = yaml.safe_load(
+        (MODULE_ROOT / "examples" / "inputs.min.yml").read_text(encoding="utf-8")
+    )
+    inputs = deepcopy(spec["inputs"]["defaults"])
+    inputs.update(example)
+    return inputs
+
+
+class GNS3ImagesValidatorTests(unittest.TestCase):
+    def test_minimal_example_is_valid(self) -> None:
+        validate(valid_inputs())
+
+    def test_invalid_image_declarations_are_rejected(self) -> None:
+        cases = {
+            "empty list": [],
+            "unsafe filename": [
+                {
+                    "name": "test",
+                    "url": "https://example.test/image.qcow2",
+                    "filename": "../image.qcow2",
+                    "checksum": "sha256:" + "a" * 64,
+                    "disk_type": "hda",
+                }
+            ],
+            "missing checksum": [
+                {
+                    "name": "test",
+                    "url": "https://example.test/image.qcow2",
+                    "filename": "image.qcow2",
+                    "disk_type": "hda",
+                }
+            ],
+            "unsupported URL": [
+                {
+                    "name": "test",
+                    "url": "file:///tmp/image.qcow2",
+                    "filename": "image.qcow2",
+                    "checksum": "sha256:" + "a" * 64,
+                    "disk_type": "hda",
+                }
+            ],
+        }
+        for label, images in cases.items():
+            with self.subTest(label=label):
+                inputs = valid_inputs()
+                inputs["gns3_images_items"] = images
+                with self.assertRaises(ValueError):
+                    validate(inputs)
+
+    def test_duplicate_names_and_filenames_are_rejected(self) -> None:
+        for key in ("name", "filename"):
+            with self.subTest(key=key):
+                inputs = valid_inputs()
+                duplicate = deepcopy(inputs["gns3_images_items"][0])
+                duplicate["name"] = "Another image"
+                duplicate["filename"] = "another.iso"
+                duplicate[key] = inputs["gns3_images_items"][0][key]
+                inputs["gns3_images_items"].append(duplicate)
+                with self.assertRaises(ValueError):
+                    validate(inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/platform/linux/gns3-images/README.md
+++ b/modules/platform/linux/gns3-images/README.md
@@ -1,0 +1,14 @@
+# platform/linux/gns3-images
+
+Install declared QEMU images and register them as templates on an authenticated
+GNS3 server. Every URL requires a SHA-256 checksum. Existing matching templates
+are retained; conflicting template names fail without replacement.
+
+```bash
+hyops apply --env lab \
+  --module platform/linux/gns3-images \
+  --inputs modules/platform/linux/gns3-images/examples/inputs.min.yml
+```
+
+No proprietary image is bundled. Operators remain responsible for image
+licensing and distribution rights.

--- a/modules/platform/linux/gns3-images/examples/inputs.min.yml
+++ b/modules/platform/linux/gns3-images/examples/inputs.min.yml
@@ -1,0 +1,14 @@
+inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+inventory_vm_groups:
+  targets:
+    - "gns3-01"
+target_user: "opsadmin"
+gns3_images_items:
+  - name: "Alpine Linux 3.24"
+    url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"
+    filename: "alpine-virt-3.24.1-x86_64.iso"
+    checksum: "sha256:e73a6241bd5f3c5c2d4d38c02cc52c378c0415a7c888bd292066bf36e0f41a39"
+    disk_type: "cdrom"
+    template:
+      ram: 512
+      adapters: 2

--- a/modules/platform/linux/gns3-images/spec.yml
+++ b/modules/platform/linux/gns3-images/spec.yml
@@ -1,0 +1,65 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/gns3-images"
+
+metadata:
+  title: "Linux GNS3 Images"
+  description: "Install checksum-verified QEMU images and register usable GNS3 templates."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+
+    required_env:
+      - "GNS3_SERVER_PASSWORD"
+    required_env_destroy: []
+    load_vault_env: true
+
+    gns3_images_role_fqcn: "hybridops.app.gns3_images"
+    gns3_images_port: 3080
+    gns3_images_username: "gns3"
+    gns3_images_password_env: "GNS3_SERVER_PASSWORD"
+    gns3_images_items: []
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/47-gns3-images@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.gns3.images
+    - gns3_images_requested_count
+    - gns3_images_installed_count
+    - gns3_images_template_names
+
+probes: []
+constraints: []

--- a/packs/config/ansible/linux/common/platform/47-gns3-images@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/47-gns3-images@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,22 @@
+---
+- name: Destroy platform/linux/gns3-images
+  hosts: targets
+  become: false
+  gather_facts: false
+
+  tasks: []
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.images': 'retained',
+            'gns3_images_requested_count': 0,
+            'gns3_images_installed_count': 0,
+            'gns3_images_template_names': []
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/47-gns3-images@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/47-gns3-images@v1.0/stack/playbook.yml
@@ -1,0 +1,31 @@
+---
+- name: platform/linux/gns3-images
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_gns3_images_password: >-
+      {{ lookup('env', gns3_images_password_env | default('GNS3_SERVER_PASSWORD')) }}
+
+  tasks:
+    - name: Install GNS3 images and templates
+      ansible.builtin.include_role:
+        name: "{{ gns3_images_role_fqcn }}"
+      vars:
+        gns3_images_password: "{{ _hyops_gns3_images_password }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.images': 'ready',
+            'gns3_images_requested_count': gns3_images_results.requested_count,
+            'gns3_images_installed_count': gns3_images_results.installed_count,
+            'gns3_images_template_names': gns3_images_results.template_names
+          } | to_json }}

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -6,7 +6,7 @@ collections:
     version: "0.1.7"
 
   - name: hybridops.app
-    version: "0.1.11"
+    version: "0.1.12"
 
   - name: ansible.posix
     version: "1.6.2"


### PR DESCRIPTION
Closes #116

## Summary

Adds a reusable GNS3 image module and a required image stage to the Proxmox and GCP teaching blueprints. The shipped sample uses Alpine Linux 3.24 from its official distribution URL with the published SHA-256 checksum.

The image stage runs after the authenticated GNS3 server and before starter-lab creation. Core preflight rejects unsafe filenames, unsupported sources, invalid checksums, duplicate declarations and invalid template settings before deployment. Proprietary images are not bundled.

## Validation

- focused module, validator and blueprint tests
- full Core unit suite (106 tests)
- Python and Ruff repository checks
- six-stage Proxmox preflight and deployment
- verified ISO download, checksum and registered QEMU template
- disposable node created from the template and reached started state
- repeated image apply retained the existing image and template
- full workload destroy with Ubuntu template retention
- clean VM redeploy downloaded and registered the image again
- fresh-template node start passed after redeploy