### PR TITLE
Add cloud lab access cost controls

### DIFF
--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -90,6 +90,12 @@ through the existing IAP SSH path with the declared HybridOps key, opens the
 browser, and keeps access active until `Ctrl-C`. Port 80 remains closed at the
 GCP firewall. Use `--no-browser` when only the printed local URL is required.
 
+After an interactive access session closes, the blueprint reports billing
+status and resource-state age, provides the project-specific GCP Billing link
+for trial, credit and spend details, then offers to destroy the lab.
+Destruction requires the operator to type `destroy <environment>`. Declining
+leaves the environment available and prints the explicit destroy command.
+
 Deploy:
 
 ```bash

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -25,6 +25,7 @@ access:
   guest_network_label: "Cloud9"
   guest_gateway: "172.29.129.1"
   guest_dhcp_range: "172.29.129.50-172.29.129.200"
+  offer_destroy_on_close: true
 
 steps:
   - id: gcp_eve_ng_network

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -13,6 +13,7 @@ import socket
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,7 @@ from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.browser import open_operator_url
 from hyops.runtime.evidence import new_run_id
 from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
+from hyops.runtime.gcp import diagnose_project_billing
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import read_module_state, split_module_state_ref
 from hyops.runtime.paths import resolve_runtime_paths
@@ -662,6 +664,90 @@ def _print_guest_network_guidance(access: dict[str, Any]) -> None:
     print(f"guest setup: connect a node interface to {guest_network} and use DHCP")
 
 
+def _state_age(updated_at: Any) -> str:
+    raw = str(updated_at or "").strip()
+    if not raw:
+        return "unknown"
+    try:
+        recorded = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if recorded.tzinfo is None:
+            recorded = recorded.replace(tzinfo=timezone.utc)
+        seconds = max(0, int((datetime.now(timezone.utc) - recorded).total_seconds()))
+    except ValueError:
+        return "unknown"
+    minutes = seconds // 60
+    hours, remaining_minutes = divmod(minutes, 60)
+    days, remaining_hours = divmod(hours, 24)
+    if days:
+        return f"{days}d {remaining_hours}h"
+    if hours:
+        return f"{hours}h {remaining_minutes}m"
+    return f"{minutes}m"
+
+
+def _offer_access_close_destroy(
+    ns,
+    payload: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    project_id: str = "",
+) -> int:
+    access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
+    if not bool(access.get("offer_destroy_on_close", False)):
+        return 0
+
+    env_name = str(getattr(ns, "env", None) or "default").strip() or "default"
+    print()
+    print(f"environment: {env_name}")
+    if project_id:
+        print(f"GCP project: {project_id}")
+        validated, enabled, _detail = diagnose_project_billing(project_id)
+        if validated:
+            print(f"billing: {'enabled' if enabled else 'disabled'}")
+        else:
+            print("billing: unable to verify")
+        print(
+            "trial, credit and spend details: "
+            f"https://console.cloud.google.com/billing?project={project_id}"
+        )
+    print(f"resource state age: {_state_age(state.get('updated_at'))}")
+    print("billable resources may remain active after access closes")
+
+    destroy_command = (
+        f"hyops blueprint destroy --env {env_name} "
+        f"--ref {payload.get('blueprint_ref', '')} --execute"
+    )
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        print(f"destroy when finished: {destroy_command}")
+        return 0
+
+    try:
+        answer = input("Destroy this environment now? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        print(f"environment retained; destroy when finished: {destroy_command}")
+        return 0
+    if answer not in {"y", "yes"}:
+        print(f"environment retained; destroy when finished: {destroy_command}")
+        return 0
+
+    confirmation = f"destroy {env_name}"
+    try:
+        typed = input(f'Type "{confirmation}" to confirm: ').strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        print("destroy cancelled")
+        return 0
+    if typed != confirmation:
+        print("destroy cancelled; confirmation did not match")
+        return 0
+
+    destroy_ns = argparse.Namespace(**vars(ns))
+    destroy_ns.execute = True
+    destroy_ns.yes = True
+    return run_destroy(destroy_ns)
+
+
 def _access_known_hosts_file(paths, state_ref: str, state: dict[str, Any]) -> Path:
     run_id = str(state.get("run_id") or "current").strip() or "current"
     scope = re.sub(r"[^A-Za-z0-9_.-]+", "_", f"{state_ref}-{run_id}").strip("._")
@@ -815,7 +901,7 @@ def run_access(ns) -> int:
             except KeyboardInterrupt:
                 _stop_process(proc)
                 print("access closed")
-                return 0
+                return _offer_access_close_destroy(ns, payload, state)
 
         vm_id = str(vm.get("vm_id") or "").strip()
         match = re.fullmatch(r"projects/([^/]+)/zones/([^/]+)/instances/([^/]+)", vm_id)
@@ -914,7 +1000,12 @@ def run_access(ns) -> int:
             _stop_process(proc)
             _stop_process(iap_proc)
             print("access closed")
-            return 0
+            return _offer_access_close_destroy(
+                ns,
+                payload,
+                state,
+                project_id=project,
+            )
     except Exception as exc:
         if "iap_proc" in locals():
             _stop_process(iap_proc)
@@ -1351,10 +1442,8 @@ def run_destroy(ns) -> int:
                 print("ERR: blueprint destroy cancelled by operator")
                 return OPERATOR_ERROR
         else:
-            print(
-                "WARN: non-interactive session detected; proceeding without prompt "
-                "(use --yes to silence)."
-            )
+            print("ERR: non-interactive blueprint destroy requires --yes")
+            return OPERATOR_ERROR
 
     fail_fast = bool(payload["policy"].get("fail_fast", True))
     step_results: list[dict[str, Any]] = []

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -199,6 +199,10 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             "guest_dhcp_range": str(
                 raw_access.get("guest_dhcp_range") or ""
             ).strip(),
+            "offer_destroy_on_close": bool_field(
+                raw_access.get("offer_destroy_on_close"),
+                "access.offer_destroy_on_close",
+            ),
         }
         if not 1 <= access["remote_port"] <= 65535:
             raise ValueError("access.remote_port must be between 1 and 65535")

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
+import io
 import socket
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from hyops.blueprint.command import (
     _access_known_hosts_file,
     _extract_access_host,
     _native_console_status,
+    _offer_access_close_destroy,
     _parse_eve_qemu_console_ports,
     _require_local_ports_available,
     _ssh_access_error,
     _wait_for_local_port,
 )
+
+
+class _TTY(io.StringIO):
+    def isatty(self) -> bool:
+        return True
 
 
 class BlueprintAccessTests(unittest.TestCase):
@@ -114,6 +122,57 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
                 listener.accept()
         finally:
             listener.close()
+
+    def test_access_close_destroy_requires_environment_phrase(self) -> None:
+        ns = SimpleNamespace(env="student-lab", root=None, ref="gcp/eve-ng@v1")
+        stdout = _TTY()
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {"offer_destroy_on_close": True},
+        }
+        with (
+            patch("hyops.blueprint.command.sys.stdin", _TTY()),
+            patch("hyops.blueprint.command.sys.stdout", stdout),
+            patch("builtins.input", side_effect=["y", "destroy student-lab"]),
+            patch(
+                "hyops.blueprint.command.diagnose_project_billing",
+                return_value=(True, True, ""),
+            ),
+            patch("hyops.blueprint.command.run_destroy", return_value=0) as destroy,
+        ):
+            rc = _offer_access_close_destroy(
+                ns,
+                payload,
+                {"updated_at": "2026-07-14T08:00:00Z"},
+                project_id="student-project",
+            )
+
+        self.assertEqual(rc, 0)
+        destroy.assert_called_once()
+        destroy_ns = destroy.call_args.args[0]
+        self.assertTrue(destroy_ns.execute)
+        self.assertTrue(destroy_ns.yes)
+        self.assertIn(
+            "https://console.cloud.google.com/billing?project=student-project",
+            stdout.getvalue(),
+        )
+
+    def test_access_close_destroy_rejects_wrong_phrase(self) -> None:
+        ns = SimpleNamespace(env="student-lab")
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {"offer_destroy_on_close": True},
+        }
+        with (
+            patch("hyops.blueprint.command.sys.stdin", _TTY()),
+            patch("hyops.blueprint.command.sys.stdout", _TTY()),
+            patch("builtins.input", side_effect=["y", "destroy another-lab"]),
+            patch("hyops.blueprint.command.run_destroy") as destroy,
+        ):
+            rc = _offer_access_close_destroy(ns, payload, {})
+
+        self.assertEqual(rc, 0)
+        destroy.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -1,3 +1,4 @@
+import io
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
@@ -104,3 +105,25 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertEqual(rc, 2)
         self.assertEqual(inputs_file.call_count, 1)
         self.assertEqual(command.call_count, 1)
+
+    def test_non_interactive_destroy_requires_explicit_yes(self):
+        paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
+        ns = _namespace()
+        ns.yes = False
+        stdout = io.StringIO()
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=_payload()),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+            patch("hyops.blueprint.command.sys.stdin", io.StringIO()),
+            patch("hyops.blueprint.command.sys.stdout", stdout),
+            patch("hyops.blueprint.command.run_step_module_command") as command,
+        ):
+            rc = run_destroy(ns)
+
+        self.assertEqual(rc, 2)
+        self.assertIn("requires --yes", stdout.getvalue())
+        command.assert_not_called()

--- a/hyops/blueprint/tests/test_gcp_eve_ng.py
+++ b/hyops/blueprint/tests/test_gcp_eve_ng.py
@@ -12,6 +12,8 @@ class GcpEveNgBlueprintTest(TestCase):
         path = root / "blueprints" / "gcp" / "eve-ng@v1" / "blueprint.yml"
         validated = validate_blueprint(load_blueprint(path), path)
 
+        self.assertTrue(validated["access"]["offer_destroy_on_close"])
+
         self.assertEqual(
             validated["order"],
             [
@@ -41,4 +43,3 @@ class GcpEveNgBlueprintTest(TestCase):
         self.assertEqual(
             by_id["gcp_eve_ng_healthcheck"]["requires"], ["gcp_eve_ng_images"]
         )
-

--- a/hyops/blueprint/tests/test_onprem_eve_ng.py
+++ b/hyops/blueprint/tests/test_onprem_eve_ng.py
@@ -14,6 +14,7 @@ class OnPremEveNgBlueprintTest(TestCase):
         validated = validate_blueprint(payload, path)
 
         self.assertEqual(validated["policy"]["ipam_authority"], "none")
+        self.assertFalse(validated["access"]["offer_destroy_on_close"])
         self.assertEqual(len(validated["steps"]), 5)
         vm_step = next(
             step for step in validated["steps"] if step["id"] == "eve_ng_vm"


### PR DESCRIPTION
Closes #118

## Summary

Adds an opt-in close-time safeguard for private blueprint access. When enabled, closing a cloud lab session reports the environment, GCP project billing status, resource-state age and project billing link before offering teardown.

Teardown remains optional and requires the operator to type an environment-specific confirmation phrase. Non-interactive blueprint destroy now requires `--yes`.

The GCP EVE-NG blueprint enables the safeguard. Other cloud lab blueprints can opt in through the same access contract.

## Validation

- focused access, destroy and blueprint tests
- full Core unit suite (91 tests)
- module catalog check
- Python compilation check
- Ruff check
- clean diff check
