### PR TITLE
Avoid unnecessary vault prompts during destroy

### DIFF
--- a/hyops/drivers/config/ansible/driver.py
+++ b/hyops/drivers/config/ansible/driver.py
@@ -57,6 +57,18 @@ _DRIVER_DIR = Path(__file__).resolve().parent
 _PROFILES_DIR = _DRIVER_DIR / "profiles"
 _PGHA_MODULE_REFS = {"platform/postgresql-ha", "platform/onprem/postgresql-ha"}
 
+
+def _should_load_vault_env(
+    *,
+    load_vault_env: bool,
+    effective_lifecycle: str,
+    missing_before_vault: list[str],
+) -> bool:
+    if missing_before_vault:
+        return True
+    return load_vault_env and effective_lifecycle != "destroy"
+
+
 def _resolve_hyops_executable() -> str:
     """Resolve a real hyops executable path for delegated local tasks."""
     try:
@@ -305,7 +317,11 @@ def run(request: dict[str, Any]) -> dict[str, Any]:
 
     vault_loaded: dict[str, str] = {}
     vault_error = ""
-    if load_vault_env or missing_before_vault:
+    if _should_load_vault_env(
+        load_vault_env=load_vault_env,
+        effective_lifecycle=effective_lifecycle,
+        missing_before_vault=missing_before_vault,
+    ):
         vault_loaded, vault_error = merge_vault_env(env, runtime_root)
 
     missing_after_vault = missing_env(env, required_env)

--- a/hyops/tests/test_ansible_destroy_vault.py
+++ b/hyops/tests/test_ansible_destroy_vault.py
@@ -1,0 +1,34 @@
+"""Tests for lifecycle-aware Ansible vault loading."""
+
+from unittest import TestCase
+
+from hyops.drivers.config.ansible.driver import _should_load_vault_env
+
+
+class AnsibleDestroyVaultTests(TestCase):
+    def test_destroy_skips_optional_vault_loading(self) -> None:
+        self.assertFalse(
+            _should_load_vault_env(
+                load_vault_env=True,
+                effective_lifecycle="destroy",
+                missing_before_vault=[],
+            )
+        )
+
+    def test_destroy_loads_missing_declared_values(self) -> None:
+        self.assertTrue(
+            _should_load_vault_env(
+                load_vault_env=True,
+                effective_lifecycle="destroy",
+                missing_before_vault=["DESTROY_TOKEN"],
+            )
+        )
+
+    def test_apply_keeps_optional_vault_loading(self) -> None:
+        self.assertTrue(
+            _should_load_vault_env(
+                load_vault_env=True,
+                effective_lifecycle="apply",
+                missing_before_vault=[],
+            )
+        )


### PR DESCRIPTION
Closes #120

## Summary

Prevents the Ansible driver from decrypting the runtime vault during destroy when the module declares no destroy-time environment requirements.

Destroy still loads the vault when a value listed in `required_env_destroy` is missing. Apply and deploy keep the existing `load_vault_env` behaviour.

## Root cause

The driver treated `load_vault_env=true` as unconditional across every lifecycle command. Modules that use vault values during deployment therefore invoked pinentry during secret-free teardown.

## Validation

- focused lifecycle-aware vault tests
- full Core unit suite (91 tests)
- module catalog check
- Python compilation check
- Ruff check
- clean diff check