### PR TITLE
Add EVE-NG lab archive lifecycle

### DIFF
--- a/hyops/validators/builtin/register.py
+++ b/hyops/validators/builtin/register.py
@@ -48,6 +48,7 @@ from hyops.validators.platform.linux import (
     eve_ng as linux_eve_ng,
     eve_ng_healthcheck,
     eve_ng_images,
+    eve_ng_lab_archive,
     eve_ng_labs,
 )
 from hyops.validators.platform.onprem import (
@@ -103,6 +104,7 @@ def register_all() -> None:
     register("platform/gcp/lab-network", lab_network.validate)
     register("platform/linux/eve-ng", linux_eve_ng.validate)
     register("platform/linux/eve-ng-images", eve_ng_images.validate)
+    register("platform/linux/eve-ng-lab-archive", eve_ng_lab_archive.validate)
     register("platform/linux/eve-ng-labs", eve_ng_labs.validate)
     register("platform/linux/eve-ng-healthcheck", eve_ng_healthcheck.validate)
     register("platform/network/vyos-edge-wan", vyos_edge_wan.validate)

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -1,0 +1,87 @@
+"""
+purpose: Validate inputs for platform/linux/eve-ng-lab-archive module.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePath
+import re
+from typing import Any
+
+from hyops.validators.common import (
+    normalize_required_env,
+    require_mapping,
+    require_non_empty_str,
+    require_str_list,
+)
+from hyops.validators.platform.linux._eve_ng_common import validate_target_access
+
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def _relative_paths(value: Any, field: str) -> None:
+    for index, path in enumerate(require_str_list(value, field), start=1):
+        if path.startswith("/") or ".." in PurePath(path).parts:
+            raise ValueError(f"{field}[{index}] must be a safe relative path")
+
+
+def validate(inputs: dict[str, Any]) -> None:
+    data = require_mapping(inputs, "inputs")
+    validate_target_access(
+        data,
+        module_ref="platform/linux/eve-ng-lab-archive",
+        require_ubuntu=True,
+        require_eveng=True,
+    )
+    require_non_empty_str(
+        data.get("eveng_lab_archive_role_fqcn"),
+        "inputs.eveng_lab_archive_role_fqcn",
+    )
+    action = require_non_empty_str(
+        data.get("eveng_lab_archive_action"),
+        "inputs.eveng_lab_archive_action",
+    ).lower()
+    if action not in {"export", "restore"}:
+        raise ValueError("inputs.eveng_lab_archive_action must be export or restore")
+
+    require_non_empty_str(
+        data.get("eveng_lab_archive_labs_root"),
+        "inputs.eveng_lab_archive_labs_root",
+    )
+    _relative_paths(
+        data.get("eveng_lab_archive_folders"),
+        "inputs.eveng_lab_archive_folders",
+    )
+    require_non_empty_str(
+        data.get("eveng_lab_archive_remote_dir"),
+        "inputs.eveng_lab_archive_remote_dir",
+    )
+    if action == "export":
+        archive_name = require_non_empty_str(
+            data.get("eveng_lab_archive_name"),
+            "inputs.eveng_lab_archive_name",
+        )
+        if archive_name != PurePath(archive_name).name:
+            raise ValueError("inputs.eveng_lab_archive_name must be a safe filename")
+    else:
+        archive_path = require_non_empty_str(
+            data.get("eveng_lab_archive_path"),
+            "inputs.eveng_lab_archive_path",
+        )
+        if not archive_path.startswith("/"):
+            raise ValueError("inputs.eveng_lab_archive_path must be an absolute path")
+        checksum = require_non_empty_str(
+            data.get("eveng_lab_archive_expected_sha256"),
+            "inputs.eveng_lab_archive_expected_sha256",
+        )
+        if not _SHA256_RE.fullmatch(checksum):
+            raise ValueError(
+                "inputs.eveng_lab_archive_expected_sha256 must contain 64 hexadecimal characters"
+            )
+    if not isinstance(data.get("eveng_lab_archive_overwrite"), bool):
+        raise ValueError("inputs.eveng_lab_archive_overwrite must be a boolean")
+    if data.get("required_env_destroy") is not None:
+        require_str_list(data.get("required_env_destroy"), "inputs.required_env_destroy")
+    normalize_required_env(data.get("required_env"), "inputs.required_env")

--- a/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
@@ -1,0 +1,58 @@
+"""Tests for the EVE-NG lab archive module validator."""
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from hyops.validators.platform.linux.eve_ng_lab_archive import validate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MODULE_ROOT = REPO_ROOT / "modules" / "platform" / "linux" / "eve-ng-lab-archive"
+
+
+def valid_inputs() -> dict:
+    spec = yaml.safe_load((MODULE_ROOT / "spec.yml").read_text(encoding="utf-8"))
+    inputs = deepcopy(spec["inputs"]["defaults"])
+    inputs.update(
+        {
+            "target_host": "127.0.0.1",
+            "ssh_private_key_file": "~/.ssh/id_ed25519",
+            "connectivity_check": False,
+        }
+    )
+    return inputs
+
+
+class EveNgLabArchiveValidatorTests(unittest.TestCase):
+    def test_export_defaults_are_valid(self) -> None:
+        validate(valid_inputs())
+
+    def test_restore_requires_archive_and_checksum(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_action"] = "restore"
+        with self.assertRaises(ValueError):
+            validate(inputs)
+
+    def test_restore_accepts_verified_archive(self) -> None:
+        inputs = valid_inputs()
+        inputs.update(
+            {
+                "eveng_lab_archive_action": "restore",
+                "eveng_lab_archive_path": "/tmp/labs.tar.gz",
+                "eveng_lab_archive_expected_sha256": "a" * 64,
+            }
+        )
+        validate(inputs)
+
+    def test_unsafe_folder_is_rejected(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_folders"] = ["../images"]
+        with self.assertRaises(ValueError):
+            validate(inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -1,0 +1,17 @@
+# platform/linux/eve-ng-lab-archive
+
+Export learner-created EVE-NG lab definitions before workload teardown and
+restore them after redeployment. The archive contains topology data under
+`/opt/unetlab/labs`; device images and temporary node runtime data are not
+included.
+
+When `eveng_lab_archive_path` is empty during export, the archive is written to
+the environment artifact directory:
+
+```text
+artifacts/eveng/labs/eve-ng-labs.tar.gz
+```
+
+Restore requires the archive path and its recorded SHA-256 checksum. Existing
+lab content is protected unless `eveng_lab_archive_overwrite` is enabled.
+

--- a/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
@@ -1,0 +1,7 @@
+target_host: "CHANGE_ME_TARGET_HOST"
+target_user: "opsadmin"
+ssh_private_key_file: "~/.ssh/id_ed25519"
+
+eveng_lab_archive_action: "export"
+eveng_lab_archive_folders: []
+

--- a/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
@@ -4,4 +4,3 @@ ssh_private_key_file: "~/.ssh/id_ed25519"
 
 eveng_lab_archive_action: "export"
 eveng_lab_archive_folders: []
-

--- a/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
@@ -1,0 +1,9 @@
+target_host: "CHANGE_ME_TARGET_HOST"
+target_user: "opsadmin"
+ssh_private_key_file: "~/.ssh/id_ed25519"
+
+eveng_lab_archive_action: "restore"
+eveng_lab_archive_path: "CHANGE_ME_ARCHIVE_PATH"
+eveng_lab_archive_expected_sha256: "CHANGE_ME_SHA256"
+eveng_lab_archive_overwrite: false
+

--- a/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
@@ -6,4 +6,3 @@ eveng_lab_archive_action: "restore"
 eveng_lab_archive_path: "CHANGE_ME_ARCHIVE_PATH"
 eveng_lab_archive_expected_sha256: "CHANGE_ME_SHA256"
 eveng_lab_archive_overwrite: false
-

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -69,4 +69,3 @@ outputs:
 
 probes: []
 constraints: []
-

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -1,0 +1,72 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/eve-ng-lab-archive"
+
+metadata:
+  title: "Linux EVE-NG Lab Archive"
+  description: "Export or restore portable EVE-NG lab definitions without retaining the workload VM."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+
+    required_env: []
+    required_env_destroy: []
+    load_vault_env: false
+
+    eveng_lab_archive_role_fqcn: "hybridops.helper.eveng_lab_archive"
+    eveng_lab_archive_action: "export"
+    eveng_lab_archive_labs_root: "/opt/unetlab/labs"
+    eveng_lab_archive_folders: []
+    eveng_lab_archive_name: "eve-ng-labs.tar.gz"
+    eveng_lab_archive_path: ""
+    eveng_lab_archive_expected_sha256: ""
+    eveng_lab_archive_overwrite: false
+    eveng_lab_archive_remote_dir: "/tmp/hyops-eveng-lab-archive"
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/48-eve-ng-lab-archive@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.eveng.archive
+    - eveng_lab_archive_action
+    - eveng_lab_archive_path
+    - eveng_lab_archive_manifest_path
+    - eveng_lab_archive_sha256
+    - eveng_lab_archive_created_at
+    - eveng_lab_archive_folders
+
+probes: []
+constraints: []
+

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,20 @@
+---
+- name: Destroy platform/linux/eve-ng-lab-archive
+  hosts: targets
+  become: false
+  gather_facts: false
+
+  tasks: []
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.eveng.archive': 'retained'
+          } | to_json }}
+

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
@@ -17,4 +17,3 @@
           {{ {
             'cap.lab.eveng.archive': 'retained'
           } | to_json }}
-

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -49,4 +49,3 @@
             'eveng_lab_archive_created_at': eveng_lab_archive_results.created_at | default(''),
             'eveng_lab_archive_folders': eveng_lab_archive_results.folders
           } | to_json }}
-

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -1,0 +1,52 @@
+---
+- name: platform/linux/eve-ng-lab-archive
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_runtime_root: "{{ lookup('env', 'HYOPS_RUNTIME_ROOT') | default('', true) | trim }}"
+    _hyops_archive_path: >-
+      {{
+        (eveng_lab_archive_path | default('') | trim)
+        if (eveng_lab_archive_path | default('') | trim | length > 0)
+        else (
+          _hyops_runtime_root ~ '/artifacts/eveng/labs/' ~
+          (eveng_lab_archive_name | default('eve-ng-labs.tar.gz'))
+        )
+      }}
+
+  tasks:
+    - name: Require HybridOps runtime root for the default archive path
+      ansible.builtin.assert:
+        that:
+          - _hyops_archive_path | trim | length > 0
+          - >-
+            (eveng_lab_archive_path | default('') | trim | length > 0)
+            or (_hyops_runtime_root | length > 0)
+        fail_msg: "HYOPS_RUNTIME_ROOT is required when eveng_lab_archive_path is empty"
+
+    - name: Export or restore EVE-NG labs
+      ansible.builtin.include_role:
+        name: "{{ eveng_lab_archive_role_fqcn }}"
+      vars:
+        eveng_lab_archive_path: "{{ _hyops_archive_path }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.eveng.archive': 'ready',
+            'eveng_lab_archive_action': eveng_lab_archive_results.action,
+            'eveng_lab_archive_path': eveng_lab_archive_results.archive_path,
+            'eveng_lab_archive_manifest_path': eveng_lab_archive_results.manifest_path | default(''),
+            'eveng_lab_archive_sha256': eveng_lab_archive_results.sha256,
+            'eveng_lab_archive_created_at': eveng_lab_archive_results.created_at | default(''),
+            'eveng_lab_archive_folders': eveng_lab_archive_results.folders
+          } | to_json }}
+

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -3,7 +3,7 @@ collections:
     version: "0.1.6"
 
   - name: hybridops.helper
-    version: "0.1.6"
+    version: "0.1.7"
 
   - name: hybridops.app
     version: "0.1.7"


### PR DESCRIPTION
Closes #122

## Summary

Adds `platform/linux/eve-ng-lab-archive` for exporting learner-created EVE-NG lab definitions before workload teardown and restoring them after redeployment.

Exports default to the environment artifact directory and publish the archive path, manifest path, SHA-256 checksum, creation time and selected folders through normal module state and run records. Restore requires an explicit archive path and checksum. Ordinary blueprint destroy does not claim or imply that an export was created.

Pins the published `hybridops.helper:0.1.7` collection that provides the archive role.

## Validation

- focused validator tests
- full Core unit suite
- module catalog check
- Python compilation and Ruff checks
- Ansible pack syntax check
- clean Galaxy install of `hybridops.helper:0.1.7`
- live Proxmox export, destroy, redeploy and checksum-verified restore
- archive failure confirmed to stop teardown before resource destruction
- clean diff check

GCP uses the same archive module and inventory contract through its established IAP path.