### PR TITLE
Protect EVE-NG labs during teardown

### DIFF
--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -92,9 +92,18 @@ GCP firewall. Use `--no-browser` when only the printed local URL is required.
 
 After an interactive access session closes, the blueprint reports billing
 status and resource-state age, provides the project-specific GCP Billing link
-for trial, credit and spend details, then offers to destroy the lab.
-Destruction requires the operator to type `destroy <environment>`. Declining
-leaves the environment available and prints the explicit destroy command.
+for trial, credit and spend details, then offers to keep the environment,
+export its lab definitions before teardown, or destroy without an export.
+Destruction requires the operator to type `destroy <environment>`.
+
+Automation must state the intended archive behaviour:
+
+```bash
+hyops blueprint destroy --env dev --ref gcp/eve-ng@v1 --execute --yes \
+  --archive-before-destroy
+```
+
+Use `--skip-archive` only when the current lab definitions are disposable.
 
 Deploy:
 

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -90,6 +90,12 @@ through the existing IAP SSH path with the declared HybridOps key, opens the
 browser, and keeps access active until `Ctrl-C`. Port 80 remains closed at the
 GCP firewall. Use `--no-browser` when only the printed local URL is required.
 
+After an interactive access session closes, the blueprint reports billing
+status and resource-state age, provides the project-specific GCP Billing link
+for trial, credit and spend details, then offers to destroy the lab.
+Destruction requires the operator to type `destroy <environment>`. Declining
+leaves the environment available and prints the explicit destroy command.
+
 Deploy:
 
 ```bash

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -25,6 +25,7 @@ access:
   guest_network_label: "Cloud9"
   guest_gateway: "172.29.129.1"
   guest_dhcp_range: "172.29.129.50-172.29.129.200"
+  offer_destroy_on_close: true
 
 steps:
   - id: gcp_eve_ng_network

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -27,6 +27,20 @@ access:
   guest_dhcp_range: "172.29.129.50-172.29.129.200"
   offer_destroy_on_close: true
 
+archive_before_destroy:
+  module_ref: "platform/linux/eve-ng-lab-archive"
+  state_instance: "gcp_eve_ng_lab_archive"
+  inputs:
+    inventory_state_ref: "platform/gcp/platform-vm#gcp_eve_ng_vm"
+    inventory_vm_groups:
+      targets:
+        - "eve-ng-01"
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: "~/.ssh/id_ed25519"
+    ssh_access_mode: "gcp-iap"
+    eveng_lab_archive_action: "export"
+
 steps:
   - id: gcp_eve_ng_network
     module_ref: "platform/gcp/lab-network"

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -80,6 +80,17 @@ hyops blueprint deploy \
   --execute
 ```
 
+Open the private UI:
+
+```bash
+hyops blueprint access --env dev --ref onprem/eve-ng@v1
+```
+
+When access closes, HybridOps offers to keep the environment, export its lab
+definitions before teardown, or destroy without an export. Direct interactive
+destroy uses the same choices. Automation must pass either
+`--archive-before-destroy` or `--skip-archive` with `--yes`.
+
 ## Default Shape
 
 The shipped blueprint provisions one VM:

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -25,6 +25,23 @@ access:
   guest_network_label: "Cloud9"
   guest_gateway: "172.29.129.1"
   guest_dhcp_range: "172.29.129.50-172.29.129.200"
+  offer_destroy_on_close: true
+
+archive_before_destroy:
+  module_ref: "platform/linux/eve-ng-lab-archive"
+  state_instance: "eve_ng_lab_archive"
+  inputs:
+    inventory_state_ref: "platform/onprem/platform-vm#eve_ng_vm"
+    inventory_vm_groups:
+      targets:
+        - "eve-ng-01"
+    target_user: "opsadmin"
+    ssh_private_key_file: "~/.ssh/id_ed25519"
+    ssh_proxy_jump_auto: true
+    ssh_proxy_jump_user: "root"
+    become: true
+    become_user: "root"
+    eveng_lab_archive_action: "export"
 
 steps:
   - id: template_image_jammy

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import errno
+import hashlib
 import ipaddress
 import json
 import os
@@ -366,6 +367,17 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Proceed without interactive confirmation.",
     )
+    archive_choice = d.add_mutually_exclusive_group()
+    archive_choice.add_argument(
+        "--archive-before-destroy",
+        action="store_true",
+        help="Export and verify declared lab data before teardown.",
+    )
+    archive_choice.add_argument(
+        "--skip-archive",
+        action="store_true",
+        help="Destroy without exporting declared lab data.",
+    )
     d.set_defaults(_handler=run_destroy)
 
     b = ssp.add_parser(
@@ -721,30 +733,11 @@ def _offer_access_close_destroy(
         print(f"destroy when finished: {destroy_command}")
         return 0
 
-    try:
-        answer = input("Destroy this environment now? [y/N]: ").strip().lower()
-    except (EOFError, KeyboardInterrupt):
-        print()
-        print(f"environment retained; destroy when finished: {destroy_command}")
-        return 0
-    if answer not in {"y", "yes"}:
-        print(f"environment retained; destroy when finished: {destroy_command}")
-        return 0
-
-    confirmation = f"destroy {env_name}"
-    try:
-        typed = input(f'Type "{confirmation}" to confirm: ').strip()
-    except (EOFError, KeyboardInterrupt):
-        print()
-        print("destroy cancelled")
-        return 0
-    if typed != confirmation:
-        print("destroy cancelled; confirmation did not match")
-        return 0
-
     destroy_ns = argparse.Namespace(**vars(ns))
     destroy_ns.execute = True
-    destroy_ns.yes = True
+    destroy_ns.yes = False
+    destroy_ns.archive_before_destroy = False
+    destroy_ns.skip_archive = False
     return run_destroy(destroy_ns)
 
 
@@ -1360,6 +1353,103 @@ def run_deploy(ns) -> int:
     return 0 if not required_failures else OPERATOR_ERROR
 
 
+def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> str:
+    archive = payload.get("archive_before_destroy")
+    if not isinstance(archive, dict) or not archive:
+        if bool(getattr(ns, "archive_before_destroy", False)) or bool(
+            getattr(ns, "skip_archive", False)
+        ):
+            raise ValueError("this blueprint does not declare a lab archive lifecycle")
+        return "none"
+
+    if bool(getattr(ns, "archive_before_destroy", False)):
+        return "archive"
+    if bool(getattr(ns, "skip_archive", False)):
+        return "skip"
+
+    if bool(getattr(ns, "yes", False)) or not (
+        sys.stdin.isatty() and sys.stdout.isatty()
+    ):
+        raise ValueError(
+            "this blueprint protects lab data; select --archive-before-destroy "
+            "or --skip-archive"
+        )
+
+    print("lab data:")
+    print("  1. Keep the environment running")
+    print("  2. Export labs, verify the archive, then destroy")
+    print("  3. Destroy without exporting labs")
+    try:
+        answer = input("Choose [1-3]: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return "keep"
+    if answer == "1" or not answer:
+        return "keep"
+    if answer == "2":
+        return "archive"
+    if answer == "3":
+        return "skip"
+    print("destroy cancelled; expected 1, 2, or 3")
+    return "keep"
+
+
+def _confirm_archive_destroy(env_name: str) -> bool:
+    confirmation = f"destroy {env_name}"
+    try:
+        typed = input(f'Type "{confirmation}" to confirm: ').strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    return typed == confirmation
+
+
+def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
+    archive = payload["archive_before_destroy"]
+    archive_step = {
+        "id": "archive_before_destroy",
+        "module_ref": archive["module_ref"],
+        "state_instance": archive["state_instance"],
+        "action": "deploy",
+        "phase": "operations",
+        "with_deps": False,
+        "inputs": archive.get("inputs") or {},
+    }
+    print("exporting lab data before teardown")
+    rc = run_step_module_command(archive_step, payload, ns, paths)
+    if rc != 0:
+        print("ERR: lab export failed; no resources were destroyed")
+        return int(rc)
+
+    try:
+        state = read_module_state(
+            paths.state_dir,
+            archive["module_ref"],
+            state_instance=archive["state_instance"],
+        )
+        outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
+        archive_path = Path(
+            str(outputs.get("eveng_lab_archive_path") or "")
+        ).expanduser()
+        expected = str(outputs.get("eveng_lab_archive_sha256") or "").strip().lower()
+        if not archive_path.is_file() or not expected:
+            raise ValueError("lab export did not publish a verifiable archive")
+        digest = hashlib.sha256()
+        with archive_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except (OSError, ValueError) as exc:
+        print(f"ERR: {exc}; no resources were destroyed")
+        return OPERATOR_ERROR
+    actual = digest.hexdigest()
+    if actual != expected:
+        print("ERR: lab archive checksum verification failed; no resources were destroyed")
+        return OPERATOR_ERROR
+    print(f"lab archive: {archive_path}")
+    print(f"sha256: {actual}")
+    return 0
+
+
 def run_destroy(ns) -> int:
     try:
         payload = _resolve_and_validate(ns)
@@ -1414,12 +1504,12 @@ def run_destroy(ns) -> int:
         return OPERATOR_ERROR
 
     by_id = {step["id"]: step for step in payload["steps"]}
+    env_name = (
+        str(getattr(ns, "env", None) or getattr(paths.root, "name", "") or "").strip()
+        or "default"
+    )
 
     if not bool(getattr(ns, "yes", False)) and not json_mode:
-        env_name = (
-            str(getattr(ns, "env", None) or getattr(paths.root, "name", "") or "").strip()
-            or "default"
-        )
         print(f"WARN: blueprint destroy will tear down resources in env={env_name}.")
         print("steps (reverse order):")
         for step_id in destroy_order:
@@ -1432,7 +1522,22 @@ def run_destroy(ns) -> int:
                 f"(state={status} ref={state_ref})"
             )
 
-        if sys.stdin.isatty() and sys.stdout.isatty():
+    try:
+        archive_mode = _select_archive_destroy_mode(ns, payload, env_name)
+    except ValueError as exc:
+        print(f"ERR: {exc}")
+        return OPERATOR_ERROR
+
+    if archive_mode == "keep":
+        print("environment retained")
+        return 0
+
+    if not bool(getattr(ns, "yes", False)) and not json_mode:
+        if payload.get("archive_before_destroy"):
+            if not _confirm_archive_destroy(env_name):
+                print("destroy cancelled; confirmation did not match")
+                return CANCELLED
+        elif sys.stdin.isatty() and sys.stdout.isatty():
             try:
                 answer = input("Proceed with blueprint destroy? [y/N]: ").strip().lower()
             except (EOFError, KeyboardInterrupt):
@@ -1444,6 +1549,11 @@ def run_destroy(ns) -> int:
         else:
             print("ERR: non-interactive blueprint destroy requires --yes")
             return OPERATOR_ERROR
+
+    if archive_mode == "archive":
+        archive_rc = _run_archive_before_destroy(ns, payload, paths)
+        if archive_rc != 0:
+            return archive_rc
 
     fail_fast = bool(payload["policy"].get("fail_fast", True))
     step_results: list[dict[str, Any]] = []
@@ -1699,7 +1809,15 @@ def run_rebuild(ns) -> int:
 
     write_record("running", None, None)
     child_args = dict(vars(ns))
-    child_args.update({"yes": True, "json": False, "execute": True})
+    child_args.update(
+        {
+            "yes": True,
+            "json": False,
+            "execute": True,
+            "archive_before_destroy": False,
+            "skip_archive": True,
+        }
+    )
     print("rebuild_phase=destroy status=running")
     destroy_rc = int(run_destroy(argparse.Namespace(**child_args)))
     if destroy_rc != 0:

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -13,6 +13,7 @@ import socket
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +21,7 @@ from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.browser import open_operator_url
 from hyops.runtime.evidence import new_run_id
 from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
+from hyops.runtime.gcp import diagnose_project_billing
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import read_module_state, split_module_state_ref
 from hyops.runtime.paths import resolve_runtime_paths
@@ -662,6 +664,90 @@ def _print_guest_network_guidance(access: dict[str, Any]) -> None:
     print(f"guest setup: connect a node interface to {guest_network} and use DHCP")
 
 
+def _state_age(updated_at: Any) -> str:
+    raw = str(updated_at or "").strip()
+    if not raw:
+        return "unknown"
+    try:
+        recorded = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if recorded.tzinfo is None:
+            recorded = recorded.replace(tzinfo=timezone.utc)
+        seconds = max(0, int((datetime.now(timezone.utc) - recorded).total_seconds()))
+    except ValueError:
+        return "unknown"
+    minutes = seconds // 60
+    hours, remaining_minutes = divmod(minutes, 60)
+    days, remaining_hours = divmod(hours, 24)
+    if days:
+        return f"{days}d {remaining_hours}h"
+    if hours:
+        return f"{hours}h {remaining_minutes}m"
+    return f"{minutes}m"
+
+
+def _offer_access_close_destroy(
+    ns,
+    payload: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    project_id: str = "",
+) -> int:
+    access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
+    if not bool(access.get("offer_destroy_on_close", False)):
+        return 0
+
+    env_name = str(getattr(ns, "env", None) or "default").strip() or "default"
+    print()
+    print(f"environment: {env_name}")
+    if project_id:
+        print(f"GCP project: {project_id}")
+        validated, enabled, _detail = diagnose_project_billing(project_id)
+        if validated:
+            print(f"billing: {'enabled' if enabled else 'disabled'}")
+        else:
+            print("billing: unable to verify")
+        print(
+            "trial, credit and spend details: "
+            f"https://console.cloud.google.com/billing?project={project_id}"
+        )
+    print(f"resource state age: {_state_age(state.get('updated_at'))}")
+    print("billable resources may remain active after access closes")
+
+    destroy_command = (
+        f"hyops blueprint destroy --env {env_name} "
+        f"--ref {payload.get('blueprint_ref', '')} --execute"
+    )
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        print(f"destroy when finished: {destroy_command}")
+        return 0
+
+    try:
+        answer = input("Destroy this environment now? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        print(f"environment retained; destroy when finished: {destroy_command}")
+        return 0
+    if answer not in {"y", "yes"}:
+        print(f"environment retained; destroy when finished: {destroy_command}")
+        return 0
+
+    confirmation = f"destroy {env_name}"
+    try:
+        typed = input(f'Type "{confirmation}" to confirm: ').strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        print("destroy cancelled")
+        return 0
+    if typed != confirmation:
+        print("destroy cancelled; confirmation did not match")
+        return 0
+
+    destroy_ns = argparse.Namespace(**vars(ns))
+    destroy_ns.execute = True
+    destroy_ns.yes = True
+    return run_destroy(destroy_ns)
+
+
 def _access_known_hosts_file(paths, state_ref: str, state: dict[str, Any]) -> Path:
     run_id = str(state.get("run_id") or "current").strip() or "current"
     scope = re.sub(r"[^A-Za-z0-9_.-]+", "_", f"{state_ref}-{run_id}").strip("._")
@@ -815,7 +901,7 @@ def run_access(ns) -> int:
             except KeyboardInterrupt:
                 _stop_process(proc)
                 print("access closed")
-                return 0
+                return _offer_access_close_destroy(ns, payload, state)
 
         vm_id = str(vm.get("vm_id") or "").strip()
         match = re.fullmatch(r"projects/([^/]+)/zones/([^/]+)/instances/([^/]+)", vm_id)
@@ -914,7 +1000,12 @@ def run_access(ns) -> int:
             _stop_process(proc)
             _stop_process(iap_proc)
             print("access closed")
-            return 0
+            return _offer_access_close_destroy(
+                ns,
+                payload,
+                state,
+                project_id=project,
+            )
     except Exception as exc:
         if "iap_proc" in locals():
             _stop_process(iap_proc)
@@ -1351,10 +1442,8 @@ def run_destroy(ns) -> int:
                 print("ERR: blueprint destroy cancelled by operator")
                 return OPERATOR_ERROR
         else:
-            print(
-                "WARN: non-interactive session detected; proceeding without prompt "
-                "(use --yes to silence)."
-            )
+            print("ERR: non-interactive blueprint destroy requires --yes")
+            return OPERATOR_ERROR
 
     fail_fast = bool(payload["policy"].get("fail_fast", True))
     step_results: list[dict[str, Any]] = []

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -230,6 +230,34 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 "guest_gateway, and guest_dhcp_range"
             )
 
+    archive_before_destroy: dict[str, Any] = {}
+    if spec.get("archive_before_destroy") is not None:
+        raw_archive = as_mapping(
+            spec.get("archive_before_destroy"), "archive_before_destroy"
+        )
+        allowed = {"module_ref", "state_instance", "inputs"}
+        unknown = sorted(str(key) for key in raw_archive if str(key) not in allowed)
+        if unknown:
+            raise ValueError(
+                "archive_before_destroy has unknown keys: " + ", ".join(unknown)
+            )
+        archive_inputs = raw_archive.get("inputs")
+        if archive_inputs is not None:
+            archive_inputs = as_mapping(
+                archive_inputs, "archive_before_destroy.inputs"
+            )
+        archive_before_destroy = {
+            "module_ref": module_ref_field(
+                raw_archive.get("module_ref"),
+                "archive_before_destroy.module_ref",
+            ),
+            "state_instance": as_non_empty_string(
+                raw_archive.get("state_instance"),
+                "archive_before_destroy.state_instance",
+            ),
+            "inputs": archive_inputs if isinstance(archive_inputs, dict) else {},
+        }
+
     raw_steps = spec.get("steps")
     if not isinstance(raw_steps, list) or not raw_steps:
         raise ValueError("steps must be a non-empty list")
@@ -395,6 +423,7 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         "metadata": metadata if isinstance(metadata, dict) else {},
         "policy": policy,
         "access": access,
+        "archive_before_destroy": archive_before_destroy,
         "steps": steps,
         "order": order,
     }

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -199,6 +199,10 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             "guest_dhcp_range": str(
                 raw_access.get("guest_dhcp_range") or ""
             ).strip(),
+            "offer_destroy_on_close": bool_field(
+                raw_access.get("offer_destroy_on_close"),
+                "access.offer_destroy_on_close",
+            ),
         }
         if not 1 <= access["remote_port"] <= 65535:
             raise ValueError("access.remote_port must be between 1 and 65535")

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -133,7 +133,6 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
         with (
             patch("hyops.blueprint.command.sys.stdin", _TTY()),
             patch("hyops.blueprint.command.sys.stdout", stdout),
-            patch("builtins.input", side_effect=["y", "destroy student-lab"]),
             patch(
                 "hyops.blueprint.command.diagnose_project_billing",
                 return_value=(True, True, ""),
@@ -151,13 +150,15 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
         destroy.assert_called_once()
         destroy_ns = destroy.call_args.args[0]
         self.assertTrue(destroy_ns.execute)
-        self.assertTrue(destroy_ns.yes)
+        self.assertFalse(destroy_ns.yes)
+        self.assertFalse(destroy_ns.archive_before_destroy)
+        self.assertFalse(destroy_ns.skip_archive)
         self.assertIn(
             "https://console.cloud.google.com/billing?project=student-project",
             stdout.getvalue(),
         )
 
-    def test_access_close_destroy_rejects_wrong_phrase(self) -> None:
+    def test_access_close_destroy_delegates_confirmation(self) -> None:
         ns = SimpleNamespace(env="student-lab")
         payload = {
             "blueprint_ref": "gcp/eve-ng@v1",
@@ -166,13 +167,12 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
         with (
             patch("hyops.blueprint.command.sys.stdin", _TTY()),
             patch("hyops.blueprint.command.sys.stdout", _TTY()),
-            patch("builtins.input", side_effect=["y", "destroy another-lab"]),
-            patch("hyops.blueprint.command.run_destroy") as destroy,
+            patch("hyops.blueprint.command.run_destroy", return_value=0) as destroy,
         ):
             rc = _offer_access_close_destroy(ns, payload, {})
 
         self.assertEqual(rc, 0)
-        destroy.assert_not_called()
+        destroy.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
+import io
 import socket
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from hyops.blueprint.command import (
     _access_known_hosts_file,
     _extract_access_host,
     _native_console_status,
+    _offer_access_close_destroy,
     _parse_eve_qemu_console_ports,
     _require_local_ports_available,
     _ssh_access_error,
     _wait_for_local_port,
 )
+
+
+class _TTY(io.StringIO):
+    def isatty(self) -> bool:
+        return True
 
 
 class BlueprintAccessTests(unittest.TestCase):
@@ -114,6 +122,57 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
                 listener.accept()
         finally:
             listener.close()
+
+    def test_access_close_destroy_requires_environment_phrase(self) -> None:
+        ns = SimpleNamespace(env="student-lab", root=None, ref="gcp/eve-ng@v1")
+        stdout = _TTY()
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {"offer_destroy_on_close": True},
+        }
+        with (
+            patch("hyops.blueprint.command.sys.stdin", _TTY()),
+            patch("hyops.blueprint.command.sys.stdout", stdout),
+            patch("builtins.input", side_effect=["y", "destroy student-lab"]),
+            patch(
+                "hyops.blueprint.command.diagnose_project_billing",
+                return_value=(True, True, ""),
+            ),
+            patch("hyops.blueprint.command.run_destroy", return_value=0) as destroy,
+        ):
+            rc = _offer_access_close_destroy(
+                ns,
+                payload,
+                {"updated_at": "2026-07-14T08:00:00Z"},
+                project_id="student-project",
+            )
+
+        self.assertEqual(rc, 0)
+        destroy.assert_called_once()
+        destroy_ns = destroy.call_args.args[0]
+        self.assertTrue(destroy_ns.execute)
+        self.assertTrue(destroy_ns.yes)
+        self.assertIn(
+            "https://console.cloud.google.com/billing?project=student-project",
+            stdout.getvalue(),
+        )
+
+    def test_access_close_destroy_rejects_wrong_phrase(self) -> None:
+        ns = SimpleNamespace(env="student-lab")
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {"offer_destroy_on_close": True},
+        }
+        with (
+            patch("hyops.blueprint.command.sys.stdin", _TTY()),
+            patch("hyops.blueprint.command.sys.stdout", _TTY()),
+            patch("builtins.input", side_effect=["y", "destroy another-lab"]),
+            patch("hyops.blueprint.command.run_destroy") as destroy,
+        ):
+            rc = _offer_access_close_destroy(ns, payload, {})
+
+        self.assertEqual(rc, 0)
+        destroy.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -1,9 +1,16 @@
 import io
+import hashlib
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
-from hyops.blueprint.command import run_destroy
+from hyops.blueprint.command import (
+    _run_archive_before_destroy,
+    _select_archive_destroy_mode,
+    run_destroy,
+)
 
 
 def _payload():
@@ -37,6 +44,8 @@ def _namespace():
         root=None,
         env="test",
         file=None,
+        archive_before_destroy=False,
+        skip_archive=False,
     )
 
 
@@ -105,6 +114,74 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertEqual(rc, 2)
         self.assertEqual(inputs_file.call_count, 1)
         self.assertEqual(command.call_count, 1)
+
+    def test_non_interactive_archive_choice_must_be_explicit(self):
+        ns = _namespace()
+        payload = {"archive_before_destroy": {"module_ref": "platform/test/archive"}}
+
+        with self.assertRaisesRegex(ValueError, "select --archive-before-destroy"):
+            _select_archive_destroy_mode(ns, payload, "test")
+
+    def test_archive_flag_requires_blueprint_lifecycle(self):
+        ns = _namespace()
+        ns.archive_before_destroy = True
+
+        with self.assertRaisesRegex(ValueError, "does not declare"):
+            _select_archive_destroy_mode(ns, _payload(), "test")
+
+    def test_verified_archive_is_accepted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive_path = Path(tmp) / "labs.tar.gz"
+            archive_path.write_bytes(b"portable labs")
+            checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+            payload = {
+                "archive_before_destroy": {
+                    "module_ref": "platform/test/archive",
+                    "state_instance": "lab_archive",
+                    "inputs": {},
+                }
+            }
+            paths = SimpleNamespace(state_dir=Path(tmp) / "state")
+            state = {
+                "outputs": {
+                    "eveng_lab_archive_path": str(archive_path),
+                    "eveng_lab_archive_sha256": checksum,
+                }
+            }
+
+            with (
+                patch("hyops.blueprint.command.run_step_module_command", return_value=0),
+                patch("hyops.blueprint.command.read_module_state", return_value=state),
+            ):
+                rc = _run_archive_before_destroy(_namespace(), payload, paths)
+
+        self.assertEqual(rc, 0)
+
+    def test_failed_archive_stops_before_resource_destroy(self):
+        paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
+        payload = _payload()
+        payload["archive_before_destroy"] = {
+            "module_ref": "platform/test/archive",
+            "state_instance": "lab_archive",
+            "inputs": {"archive_action": "export"},
+        }
+        ns = _namespace()
+        ns.archive_before_destroy = True
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=payload),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+            patch("hyops.blueprint.command.resolved_step_inputs_file", return_value=None),
+            patch("hyops.blueprint.command.run_step_module_command", return_value=2) as command,
+        ):
+            rc = run_destroy(ns)
+
+        self.assertEqual(rc, 2)
+        command.assert_called_once()
+        self.assertEqual(command.call_args.args[0]["id"], "archive_before_destroy")
 
     def test_non_interactive_destroy_requires_explicit_yes(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -1,3 +1,4 @@
+import io
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
@@ -104,3 +105,25 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertEqual(rc, 2)
         self.assertEqual(inputs_file.call_count, 1)
         self.assertEqual(command.call_count, 1)
+
+    def test_non_interactive_destroy_requires_explicit_yes(self):
+        paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
+        ns = _namespace()
+        ns.yes = False
+        stdout = io.StringIO()
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=_payload()),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+            patch("hyops.blueprint.command.sys.stdin", io.StringIO()),
+            patch("hyops.blueprint.command.sys.stdout", stdout),
+            patch("hyops.blueprint.command.run_step_module_command") as command,
+        ):
+            rc = run_destroy(ns)
+
+        self.assertEqual(rc, 2)
+        self.assertIn("requires --yes", stdout.getvalue())
+        command.assert_not_called()

--- a/hyops/blueprint/tests/test_gcp_eve_ng.py
+++ b/hyops/blueprint/tests/test_gcp_eve_ng.py
@@ -12,6 +12,8 @@ class GcpEveNgBlueprintTest(TestCase):
         path = root / "blueprints" / "gcp" / "eve-ng@v1" / "blueprint.yml"
         validated = validate_blueprint(load_blueprint(path), path)
 
+        self.assertTrue(validated["access"]["offer_destroy_on_close"])
+
         self.assertEqual(
             validated["order"],
             [
@@ -41,4 +43,3 @@ class GcpEveNgBlueprintTest(TestCase):
         self.assertEqual(
             by_id["gcp_eve_ng_healthcheck"]["requires"], ["gcp_eve_ng_images"]
         )
-

--- a/hyops/blueprint/tests/test_onprem_eve_ng.py
+++ b/hyops/blueprint/tests/test_onprem_eve_ng.py
@@ -14,6 +14,7 @@ class OnPremEveNgBlueprintTest(TestCase):
         validated = validate_blueprint(payload, path)
 
         self.assertEqual(validated["policy"]["ipam_authority"], "none")
+        self.assertFalse(validated["access"]["offer_destroy_on_close"])
         self.assertEqual(len(validated["steps"]), 5)
         vm_step = next(
             step for step in validated["steps"] if step["id"] == "eve_ng_vm"

--- a/hyops/blueprint/tests/test_onprem_eve_ng.py
+++ b/hyops/blueprint/tests/test_onprem_eve_ng.py
@@ -14,7 +14,11 @@ class OnPremEveNgBlueprintTest(TestCase):
         validated = validate_blueprint(payload, path)
 
         self.assertEqual(validated["policy"]["ipam_authority"], "none")
-        self.assertFalse(validated["access"]["offer_destroy_on_close"])
+        self.assertTrue(validated["access"]["offer_destroy_on_close"])
+        self.assertEqual(
+            validated["archive_before_destroy"]["module_ref"],
+            "platform/linux/eve-ng-lab-archive",
+        )
         self.assertEqual(len(validated["steps"]), 5)
         vm_step = next(
             step for step in validated["steps"] if step["id"] == "eve_ng_vm"

--- a/hyops/drivers/config/ansible/driver.py
+++ b/hyops/drivers/config/ansible/driver.py
@@ -57,6 +57,18 @@ _DRIVER_DIR = Path(__file__).resolve().parent
 _PROFILES_DIR = _DRIVER_DIR / "profiles"
 _PGHA_MODULE_REFS = {"platform/postgresql-ha", "platform/onprem/postgresql-ha"}
 
+
+def _should_load_vault_env(
+    *,
+    load_vault_env: bool,
+    effective_lifecycle: str,
+    missing_before_vault: list[str],
+) -> bool:
+    if missing_before_vault:
+        return True
+    return load_vault_env and effective_lifecycle != "destroy"
+
+
 def _resolve_hyops_executable() -> str:
     """Resolve a real hyops executable path for delegated local tasks."""
     try:
@@ -305,7 +317,11 @@ def run(request: dict[str, Any]) -> dict[str, Any]:
 
     vault_loaded: dict[str, str] = {}
     vault_error = ""
-    if load_vault_env or missing_before_vault:
+    if _should_load_vault_env(
+        load_vault_env=load_vault_env,
+        effective_lifecycle=effective_lifecycle,
+        missing_before_vault=missing_before_vault,
+    ):
         vault_loaded, vault_error = merge_vault_env(env, runtime_root)
 
     missing_after_vault = missing_env(env, required_env)

--- a/hyops/preflight/command.py
+++ b/hyops/preflight/command.py
@@ -93,6 +93,7 @@ def run_module_driver_preflight(
     state_instance: str | None = None,
     assumed_state_ok: set[str] | None = None,
     allow_state_drift_recreate: bool = False,
+    profile_override: str | None = None,
 ) -> dict[str, Any]:
     module_ref = normalize_module_ref(str(module_ref or "").strip())
     if not module_ref:
@@ -109,6 +110,8 @@ def run_module_driver_preflight(
         invocation_command="preflight",
         assumed_state_ok=assumed_state_ok,
     )
+    if str(profile_override or "").strip():
+        resolved.execution["profile"] = str(profile_override).strip()
 
     driver_ref = str(resolved.execution.get("driver") or "").strip()
     driver_fn = REGISTRY.resolve(driver_ref)

--- a/hyops/preflight/tests/__init__.py
+++ b/hyops/preflight/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Preflight command tests."""

--- a/hyops/preflight/tests/test_profile_override.py
+++ b/hyops/preflight/tests/test_profile_override.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from types import SimpleNamespace
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.preflight.command import run_module_driver_preflight
+
+
+class ModulePreflightProfileOverrideTest(TestCase):
+    def test_profile_override_is_passed_to_driver(self) -> None:
+        captured = {}
+
+        def driver(request):
+            captured.update(request)
+            return {"status": "ok"}
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = SimpleNamespace(
+                root=root,
+                state_dir=root / "state",
+                logs_dir=root / "logs",
+                meta_dir=root / "meta",
+                credentials_dir=root / "credentials",
+                work_dir=root / "work",
+            )
+            resolved = SimpleNamespace(
+                execution={"driver": "test/driver", "profile": "default@v1"},
+                module_dir=root / "module",
+                inputs={},
+                required_credentials=[],
+                outputs_publish=[],
+            )
+
+            with (
+                patch("hyops.preflight.command.ensure_layout"),
+                patch("hyops.preflight.command.resolve_module", return_value=resolved),
+                patch("hyops.preflight.command.REGISTRY.resolve", return_value=driver),
+                patch("hyops.preflight.command.new_run_id", return_value="preflight-test"),
+                patch(
+                    "hyops.preflight.command.init_evidence_dir",
+                    return_value=root / "logs" / "preflight-test",
+                ),
+            ):
+                result = run_module_driver_preflight(
+                    paths=paths,
+                    env_name="test",
+                    module_ref="platform/test/module",
+                    module_root=root / "modules",
+                    inputs_file=None,
+                    profile_override="override@v2",
+                )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(captured["execution"]["profile"], "override@v2")

--- a/hyops/tests/test_ansible_destroy_vault.py
+++ b/hyops/tests/test_ansible_destroy_vault.py
@@ -1,0 +1,34 @@
+"""Tests for lifecycle-aware Ansible vault loading."""
+
+from unittest import TestCase
+
+from hyops.drivers.config.ansible.driver import _should_load_vault_env
+
+
+class AnsibleDestroyVaultTests(TestCase):
+    def test_destroy_skips_optional_vault_loading(self) -> None:
+        self.assertFalse(
+            _should_load_vault_env(
+                load_vault_env=True,
+                effective_lifecycle="destroy",
+                missing_before_vault=[],
+            )
+        )
+
+    def test_destroy_loads_missing_declared_values(self) -> None:
+        self.assertTrue(
+            _should_load_vault_env(
+                load_vault_env=True,
+                effective_lifecycle="destroy",
+                missing_before_vault=["DESTROY_TOKEN"],
+            )
+        )
+
+    def test_apply_keeps_optional_vault_loading(self) -> None:
+        self.assertTrue(
+            _should_load_vault_env(
+                load_vault_env=True,
+                effective_lifecycle="apply",
+                missing_before_vault=[],
+            )
+        )

--- a/hyops/validators/builtin/register.py
+++ b/hyops/validators/builtin/register.py
@@ -48,6 +48,7 @@ from hyops.validators.platform.linux import (
     eve_ng as linux_eve_ng,
     eve_ng_healthcheck,
     eve_ng_images,
+    eve_ng_lab_archive,
     eve_ng_labs,
 )
 from hyops.validators.platform.onprem import (
@@ -103,6 +104,7 @@ def register_all() -> None:
     register("platform/gcp/lab-network", lab_network.validate)
     register("platform/linux/eve-ng", linux_eve_ng.validate)
     register("platform/linux/eve-ng-images", eve_ng_images.validate)
+    register("platform/linux/eve-ng-lab-archive", eve_ng_lab_archive.validate)
     register("platform/linux/eve-ng-labs", eve_ng_labs.validate)
     register("platform/linux/eve-ng-healthcheck", eve_ng_healthcheck.validate)
     register("platform/network/vyos-edge-wan", vyos_edge_wan.validate)

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -1,0 +1,87 @@
+"""
+purpose: Validate inputs for platform/linux/eve-ng-lab-archive module.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePath
+import re
+from typing import Any
+
+from hyops.validators.common import (
+    normalize_required_env,
+    require_mapping,
+    require_non_empty_str,
+    require_str_list,
+)
+from hyops.validators.platform.linux._eve_ng_common import validate_target_access
+
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def _relative_paths(value: Any, field: str) -> None:
+    for index, path in enumerate(require_str_list(value, field), start=1):
+        if path.startswith("/") or ".." in PurePath(path).parts:
+            raise ValueError(f"{field}[{index}] must be a safe relative path")
+
+
+def validate(inputs: dict[str, Any]) -> None:
+    data = require_mapping(inputs, "inputs")
+    validate_target_access(
+        data,
+        module_ref="platform/linux/eve-ng-lab-archive",
+        require_ubuntu=True,
+        require_eveng=True,
+    )
+    require_non_empty_str(
+        data.get("eveng_lab_archive_role_fqcn"),
+        "inputs.eveng_lab_archive_role_fqcn",
+    )
+    action = require_non_empty_str(
+        data.get("eveng_lab_archive_action"),
+        "inputs.eveng_lab_archive_action",
+    ).lower()
+    if action not in {"export", "restore"}:
+        raise ValueError("inputs.eveng_lab_archive_action must be export or restore")
+
+    require_non_empty_str(
+        data.get("eveng_lab_archive_labs_root"),
+        "inputs.eveng_lab_archive_labs_root",
+    )
+    _relative_paths(
+        data.get("eveng_lab_archive_folders"),
+        "inputs.eveng_lab_archive_folders",
+    )
+    require_non_empty_str(
+        data.get("eveng_lab_archive_remote_dir"),
+        "inputs.eveng_lab_archive_remote_dir",
+    )
+    if action == "export":
+        archive_name = require_non_empty_str(
+            data.get("eveng_lab_archive_name"),
+            "inputs.eveng_lab_archive_name",
+        )
+        if archive_name != PurePath(archive_name).name:
+            raise ValueError("inputs.eveng_lab_archive_name must be a safe filename")
+    else:
+        archive_path = require_non_empty_str(
+            data.get("eveng_lab_archive_path"),
+            "inputs.eveng_lab_archive_path",
+        )
+        if not archive_path.startswith("/"):
+            raise ValueError("inputs.eveng_lab_archive_path must be an absolute path")
+        checksum = require_non_empty_str(
+            data.get("eveng_lab_archive_expected_sha256"),
+            "inputs.eveng_lab_archive_expected_sha256",
+        )
+        if not _SHA256_RE.fullmatch(checksum):
+            raise ValueError(
+                "inputs.eveng_lab_archive_expected_sha256 must contain 64 hexadecimal characters"
+            )
+    if not isinstance(data.get("eveng_lab_archive_overwrite"), bool):
+        raise ValueError("inputs.eveng_lab_archive_overwrite must be a boolean")
+    if data.get("required_env_destroy") is not None:
+        require_str_list(data.get("required_env_destroy"), "inputs.required_env_destroy")
+    normalize_required_env(data.get("required_env"), "inputs.required_env")

--- a/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
@@ -1,0 +1,58 @@
+"""Tests for the EVE-NG lab archive module validator."""
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from hyops.validators.platform.linux.eve_ng_lab_archive import validate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MODULE_ROOT = REPO_ROOT / "modules" / "platform" / "linux" / "eve-ng-lab-archive"
+
+
+def valid_inputs() -> dict:
+    spec = yaml.safe_load((MODULE_ROOT / "spec.yml").read_text(encoding="utf-8"))
+    inputs = deepcopy(spec["inputs"]["defaults"])
+    inputs.update(
+        {
+            "target_host": "127.0.0.1",
+            "ssh_private_key_file": "~/.ssh/id_ed25519",
+            "connectivity_check": False,
+        }
+    )
+    return inputs
+
+
+class EveNgLabArchiveValidatorTests(unittest.TestCase):
+    def test_export_defaults_are_valid(self) -> None:
+        validate(valid_inputs())
+
+    def test_restore_requires_archive_and_checksum(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_action"] = "restore"
+        with self.assertRaises(ValueError):
+            validate(inputs)
+
+    def test_restore_accepts_verified_archive(self) -> None:
+        inputs = valid_inputs()
+        inputs.update(
+            {
+                "eveng_lab_archive_action": "restore",
+                "eveng_lab_archive_path": "/tmp/labs.tar.gz",
+                "eveng_lab_archive_expected_sha256": "a" * 64,
+            }
+        )
+        validate(inputs)
+
+    def test_unsafe_folder_is_rejected(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_folders"] = ["../images"]
+        with self.assertRaises(ValueError):
+            validate(inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -1,0 +1,17 @@
+# platform/linux/eve-ng-lab-archive
+
+Export learner-created EVE-NG lab definitions before workload teardown and
+restore them after redeployment. The archive contains topology data under
+`/opt/unetlab/labs`; device images and temporary node runtime data are not
+included.
+
+When `eveng_lab_archive_path` is empty during export, the archive is written to
+the environment artifact directory:
+
+```text
+artifacts/eveng/labs/eve-ng-labs.tar.gz
+```
+
+Restore requires the archive path and its recorded SHA-256 checksum. Existing
+lab content is protected unless `eveng_lab_archive_overwrite` is enabled.
+

--- a/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
@@ -1,0 +1,7 @@
+target_host: "CHANGE_ME_TARGET_HOST"
+target_user: "opsadmin"
+ssh_private_key_file: "~/.ssh/id_ed25519"
+
+eveng_lab_archive_action: "export"
+eveng_lab_archive_folders: []
+

--- a/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/export.yml
@@ -4,4 +4,3 @@ ssh_private_key_file: "~/.ssh/id_ed25519"
 
 eveng_lab_archive_action: "export"
 eveng_lab_archive_folders: []
-

--- a/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
@@ -1,0 +1,9 @@
+target_host: "CHANGE_ME_TARGET_HOST"
+target_user: "opsadmin"
+ssh_private_key_file: "~/.ssh/id_ed25519"
+
+eveng_lab_archive_action: "restore"
+eveng_lab_archive_path: "CHANGE_ME_ARCHIVE_PATH"
+eveng_lab_archive_expected_sha256: "CHANGE_ME_SHA256"
+eveng_lab_archive_overwrite: false
+

--- a/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/examples/restore.yml
@@ -6,4 +6,3 @@ eveng_lab_archive_action: "restore"
 eveng_lab_archive_path: "CHANGE_ME_ARCHIVE_PATH"
 eveng_lab_archive_expected_sha256: "CHANGE_ME_SHA256"
 eveng_lab_archive_overwrite: false
-

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -69,4 +69,3 @@ outputs:
 
 probes: []
 constraints: []
-

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -1,0 +1,72 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/eve-ng-lab-archive"
+
+metadata:
+  title: "Linux EVE-NG Lab Archive"
+  description: "Export or restore portable EVE-NG lab definitions without retaining the workload VM."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+
+    required_env: []
+    required_env_destroy: []
+    load_vault_env: false
+
+    eveng_lab_archive_role_fqcn: "hybridops.helper.eveng_lab_archive"
+    eveng_lab_archive_action: "export"
+    eveng_lab_archive_labs_root: "/opt/unetlab/labs"
+    eveng_lab_archive_folders: []
+    eveng_lab_archive_name: "eve-ng-labs.tar.gz"
+    eveng_lab_archive_path: ""
+    eveng_lab_archive_expected_sha256: ""
+    eveng_lab_archive_overwrite: false
+    eveng_lab_archive_remote_dir: "/tmp/hyops-eveng-lab-archive"
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/48-eve-ng-lab-archive@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.eveng.archive
+    - eveng_lab_archive_action
+    - eveng_lab_archive_path
+    - eveng_lab_archive_manifest_path
+    - eveng_lab_archive_sha256
+    - eveng_lab_archive_created_at
+    - eveng_lab_archive_folders
+
+probes: []
+constraints: []
+

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,20 @@
+---
+- name: Destroy platform/linux/eve-ng-lab-archive
+  hosts: targets
+  become: false
+  gather_facts: false
+
+  tasks: []
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.eveng.archive': 'retained'
+          } | to_json }}
+

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/destroy.playbook.yml
@@ -17,4 +17,3 @@
           {{ {
             'cap.lab.eveng.archive': 'retained'
           } | to_json }}
-

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -49,4 +49,3 @@
             'eveng_lab_archive_created_at': eveng_lab_archive_results.created_at | default(''),
             'eveng_lab_archive_folders': eveng_lab_archive_results.folders
           } | to_json }}
-

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -1,0 +1,52 @@
+---
+- name: platform/linux/eve-ng-lab-archive
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_runtime_root: "{{ lookup('env', 'HYOPS_RUNTIME_ROOT') | default('', true) | trim }}"
+    _hyops_archive_path: >-
+      {{
+        (eveng_lab_archive_path | default('') | trim)
+        if (eveng_lab_archive_path | default('') | trim | length > 0)
+        else (
+          _hyops_runtime_root ~ '/artifacts/eveng/labs/' ~
+          (eveng_lab_archive_name | default('eve-ng-labs.tar.gz'))
+        )
+      }}
+
+  tasks:
+    - name: Require HybridOps runtime root for the default archive path
+      ansible.builtin.assert:
+        that:
+          - _hyops_archive_path | trim | length > 0
+          - >-
+            (eveng_lab_archive_path | default('') | trim | length > 0)
+            or (_hyops_runtime_root | length > 0)
+        fail_msg: "HYOPS_RUNTIME_ROOT is required when eveng_lab_archive_path is empty"
+
+    - name: Export or restore EVE-NG labs
+      ansible.builtin.include_role:
+        name: "{{ eveng_lab_archive_role_fqcn }}"
+      vars:
+        eveng_lab_archive_path: "{{ _hyops_archive_path }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.eveng.archive': 'ready',
+            'eveng_lab_archive_action': eveng_lab_archive_results.action,
+            'eveng_lab_archive_path': eveng_lab_archive_results.archive_path,
+            'eveng_lab_archive_manifest_path': eveng_lab_archive_results.manifest_path | default(''),
+            'eveng_lab_archive_sha256': eveng_lab_archive_results.sha256,
+            'eveng_lab_archive_created_at': eveng_lab_archive_results.created_at | default(''),
+            'eveng_lab_archive_folders': eveng_lab_archive_results.folders
+          } | to_json }}
+

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -26,11 +26,15 @@
             or (_hyops_runtime_root | length > 0)
         fail_msg: "HYOPS_RUNTIME_ROOT is required when eveng_lab_archive_path is empty"
 
+    - name: Resolve controller archive path
+      ansible.builtin.set_fact:
+        _hyops_archive_resolved_path: "{{ _hyops_archive_path }}"
+
     - name: Export or restore EVE-NG labs
       ansible.builtin.include_role:
         name: "{{ eveng_lab_archive_role_fqcn }}"
       vars:
-        eveng_lab_archive_path: "{{ _hyops_archive_path }}"
+        eveng_lab_archive_resolved_path: "{{ _hyops_archive_resolved_path }}"
 
   post_tasks:
     - name: Write HyOps outputs


### PR DESCRIPTION
Closes #124\n\n## What changed\n\n- added a blueprint archive lifecycle for the GCP and Proxmox EVE-NG paths\n- added explicit keep, export-and-destroy, and destroy-without-export choices\n- required automation to select archive behaviour explicitly\n- verified the exported archive and checksum before teardown begins\n- routed the access-close decision through the same destroy path\n- resolved the controller archive path before handing execution to the helper role\n\n## Why\n\nDestroying a teaching environment should not silently discard learner-created EVE-NG lab definitions. The archive remains outside infrastructure state, so cloud or on-premises workload resources can be removed without losing portable lab work.\n\n## Validation\n\n- Core unit suite: 99 tests passed on the stacked branch\n- focused archive and resumable-destroy suite: 14 tests passed\n- Python, shell, YAML, Ansible and installer quality checks passed\n- Proxmox EVE-NG deployment completed from retained template 122\n- seeded lab exported with a SHA-256 checksum before teardown\n- workload VM destroyed while the reusable template was retained\n- environment redeployed and passed the EVE-NG health check\n- archive restored with the original lab checksum, ownership and mode\n- final destroy removed the test VM and retained template 122\n- failed archive attempts stopped before any resource teardown\n\n## Dependencies\n\n- #106\n- #119\n- #121\n- #123