### PR TITLE
Align published collection release pins

### DIFF
--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -6,7 +6,7 @@ collections:
     version: "0.1.7"
 
   - name: hybridops.app
-    version: "0.1.12"
+    version: "0.1.7"
 
   - name: ansible.posix
     version: "1.6.2"


### PR DESCRIPTION
## Summary

- pin hybridops.app to 0.1.7
- retain hybridops.helper at 0.1.7
- align Core with the verified Galaxy releases

## Validation

- clean Galaxy install of `hybridops.app:==0.1.7`
- clean Galaxy install of `hybridops.helper:==0.1.7`
- verified GNS3 application roles and the EVE-NG lab archive role
- `python3 -m hyops.cli setup galaxy --dry-run` with an isolated runtime
- `bash tools/ci/check-python.sh`

Closes #126