### PR TITLE
feat: add controlled Core update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ hyops blueprint deploy --env dev --ref onprem/rke2@v1 --execute
 
 The runtime root defaults to `~/.hybridops`. Override with `--root <path>` or `$HYOPS_RUNTIME_ROOT`.
 
+Check the installed release when required:
+
+```bash
+hyops update check
+```
+
+Core also performs a cached, non-blocking release check during interactive use.
+Set `HYOPS_UPDATE_CHECK=0` for offline or controlled environments. Release
+checks do not collect command or environment data, install updates, or prevent
+destroy and recovery operations.
+
 ## Execution model
 
 ```mermaid

--- a/hyops/cli.py
+++ b/hyops/cli.py
@@ -27,6 +27,7 @@ from hyops.test.command import add_test_subparser
 from hyops.terragrunt.command import add_terragrunt_subparser
 from hyops.tfc.command import add_tfc_subparser
 from hyops.vault.command import add_vault_subparser
+from hyops.update.command import add_update_subparser
 
 from hyops.drivers.builtin.register import register_all as register_builtin_drivers
 from hyops.drivers.plugins import register_plugins as register_driver_plugins
@@ -109,6 +110,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_runner_subparser(sp)
     add_setup_subparser(sp)
     add_state_subparser(sp)
+    add_update_subparser(sp)
     add_secrets_subparser(sp)
     add_inventory_subparser(sp)
     try:
@@ -158,7 +160,12 @@ def main(argv: list[str] | None = None) -> int:
             with PythonCommandEvidence(evidence_dir, command="preflight", argv=argv) as evidence:
                 evidence.exit_code = int(ns._handler(ns))
                 return evidence.exit_code
-        return int(ns._handler(ns))
+        result = int(ns._handler(ns))
+        if result == 0:
+            from hyops.update.checker import maybe_print_update_notice
+
+            maybe_print_update_notice(ns.cmd)
+        return result
     except KeyboardInterrupt:
         print("Cancelled by user.", file=sys.stderr)
         return CANCELLED

--- a/hyops/tests/test_update_checker.py
+++ b/hyops/tests/test_update_checker.py
@@ -1,0 +1,75 @@
+"""Tests for Core release awareness."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from hyops.update import checker
+
+
+class UpdateCheckerTests(unittest.TestCase):
+    def test_development_build_skips_network(self) -> None:
+        with patch.object(checker, "__version__", "0.0.0-dev"), patch.object(
+            checker.requests, "get"
+        ) as request:
+            status = checker.check_for_update()
+        self.assertEqual(status.state, "development")
+        request.assert_not_called()
+
+    def test_reports_available_release_and_writes_cache(self) -> None:
+        response = Mock()
+        response.json.return_value = {
+            "tag_name": "v1.3.0",
+            "html_url": "https://example.test/releases/v1.3.0",
+        }
+        response.raise_for_status.return_value = None
+        with tempfile.TemporaryDirectory() as directory, patch.object(
+            checker, "__version__", "1.2.0"
+        ), patch.object(checker.requests, "get", return_value=response):
+            status = checker.check_for_update(root=directory, now=1000)
+            cache = Path(directory) / "meta" / "core-update.json"
+            data = json.loads(cache.read_text(encoding="utf-8"))
+        self.assertEqual(status.state, "update_available")
+        self.assertEqual(status.latest, "1.3.0")
+        self.assertEqual(data["tag_name"], "v1.3.0")
+
+    def test_uses_fresh_cache_without_network(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            cache = Path(directory) / "meta" / "core-update.json"
+            cache.parent.mkdir(parents=True)
+            cache.write_text(
+                json.dumps({"checked_at": 900, "tag_name": "v1.2.0", "html_url": ""}),
+                encoding="utf-8",
+            )
+            with patch.object(checker, "__version__", "1.2.0"), patch.object(
+                checker.requests, "get"
+            ) as request:
+                status = checker.check_for_update(root=directory, now=1000)
+        self.assertEqual(status.state, "current")
+        self.assertTrue(status.cached)
+        request.assert_not_called()
+
+    def test_new_release_line_is_reported_as_unsupported(self) -> None:
+        response = Mock()
+        response.json.return_value = {"tag_name": "v0.2.0", "html_url": ""}
+        response.raise_for_status.return_value = None
+        with tempfile.TemporaryDirectory() as directory, patch.object(
+            checker, "__version__", "0.1.9"
+        ), patch.object(checker.requests, "get", return_value=response):
+            status = checker.check_for_update(root=directory, use_cache=False)
+        self.assertEqual(status.state, "unsupported")
+
+    def test_network_failure_is_non_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as directory, patch.object(
+            checker, "__version__", "1.2.0"
+        ), patch.object(checker.requests, "get", side_effect=checker.requests.ConnectionError("down")):
+            status = checker.check_for_update(root=directory, use_cache=False)
+        self.assertEqual(status.state, "offline")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hyops/update/__init__.py
+++ b/hyops/update/__init__.py
@@ -1,0 +1,1 @@
+"""HybridOps.Core release awareness."""

--- a/hyops/update/checker.py
+++ b/hyops/update/checker.py
@@ -1,0 +1,168 @@
+"""
+purpose: Check the installed Core version against the latest published release.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from hyops import __version__
+from hyops.runtime.paths import resolve_runtime_paths
+
+
+DEFAULT_RELEASE_URL = "https://api.github.com/repos/hybridops-tech/hybridops-core/releases/latest"
+DEFAULT_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    state: str
+    installed: str
+    latest: str | None = None
+    release_url: str | None = None
+    detail: str | None = None
+    cached: bool = False
+
+
+def _version_tuple(value: str) -> tuple[int, int, int] | None:
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", value.strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def _cache_path(root: str | None = None) -> Path:
+    return resolve_runtime_paths(root).meta_dir / "core-update.json"
+
+
+def _read_cache(path: Path, now: float, max_age: int) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        checked_at = float(data.get("checked_at", 0))
+    except (OSError, ValueError, TypeError):
+        return None
+    if checked_at <= 0 or now - checked_at > max_age:
+        return None
+    return data
+
+
+def _write_cache(path: Path, data: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(data, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.replace(path)
+    except OSError:
+        return
+
+
+def check_for_update(
+    *,
+    root: str | None = None,
+    use_cache: bool = True,
+    timeout: float = 2.0,
+    now: float | None = None,
+) -> UpdateStatus:
+    installed_tuple = _version_tuple(__version__)
+    if installed_tuple is None:
+        return UpdateStatus(state="development", installed=__version__)
+
+    checked_at = time.time() if now is None else now
+    try:
+        interval = max(0, int(os.environ.get("HYOPS_UPDATE_CHECK_INTERVAL", DEFAULT_INTERVAL_SECONDS)))
+    except ValueError:
+        interval = DEFAULT_INTERVAL_SECONDS
+    cache_path = _cache_path(root)
+    payload = _read_cache(cache_path, checked_at, interval) if use_cache else None
+    cached = payload is not None
+
+    if payload is None:
+        endpoint = os.environ.get("HYOPS_UPDATE_RELEASE_URL", DEFAULT_RELEASE_URL).strip()
+        try:
+            response = requests.get(
+                endpoint,
+                headers={"Accept": "application/vnd.github+json"},
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            remote = response.json()
+            payload = {
+                "checked_at": checked_at,
+                "tag_name": str(remote.get("tag_name") or ""),
+                "html_url": str(remote.get("html_url") or ""),
+            }
+            _write_cache(cache_path, payload)
+        except (requests.RequestException, ValueError, TypeError) as exc:
+            return UpdateStatus(
+                state="offline",
+                installed=__version__,
+                detail=str(exc),
+            )
+
+    latest = str(payload.get("tag_name") or "").removeprefix("v")
+    latest_tuple = _version_tuple(latest)
+    if latest_tuple is None:
+        return UpdateStatus(
+            state="unavailable",
+            installed=__version__,
+            detail="latest release did not contain a numeric version",
+            cached=cached,
+        )
+
+    unsupported = latest_tuple[0] > installed_tuple[0] or (
+        installed_tuple[0] == 0 and latest_tuple[1] > installed_tuple[1]
+    )
+    if unsupported:
+        state = "unsupported"
+    else:
+        state = "update_available" if latest_tuple > installed_tuple else "current"
+    return UpdateStatus(
+        state=state,
+        installed=__version__,
+        latest=latest,
+        release_url=str(payload.get("html_url") or "") or None,
+        cached=cached,
+    )
+
+
+def automatic_checks_enabled() -> bool:
+    return os.environ.get("HYOPS_UPDATE_CHECK", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def maybe_print_update_notice(command: str | None) -> None:
+    if command in {None, "update", "destroy"}:
+        return
+    if not automatic_checks_enabled() or not sys.stderr.isatty():
+        return
+    try:
+        status = check_for_update()
+    except Exception:
+        return
+    if status.state not in {"update_available", "unsupported"}:
+        return
+    if status.state == "unsupported":
+        message = (
+            f"Core release {status.installed} is outside the current release line "
+            f"({status.latest}). Run: hyops update check"
+        )
+    else:
+        message = (
+            f"Update available: HybridOps.Core {status.latest} "
+            f"(installed {status.installed}). Run: hyops update check"
+        )
+    print(message, file=sys.stderr)

--- a/hyops/update/command.py
+++ b/hyops/update/command.py
@@ -1,0 +1,50 @@
+"""
+purpose: Expose explicit Core release checks through the HybridOps CLI.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from hyops.runtime.exitcodes import OK
+from hyops.update.checker import UpdateStatus, check_for_update
+
+
+def add_update_subparser(sp: argparse._SubParsersAction) -> None:
+    parser = sp.add_parser("update", help="Check Core release status.")
+    commands = parser.add_subparsers(dest="update_cmd", required=True)
+    check = commands.add_parser("check", help="Compare the installed and current releases.")
+    check.add_argument("--no-cache", action="store_true", help="Query the release service now.")
+    check.add_argument("--json", action="store_true", help="Print machine-readable output.")
+    check.add_argument("--root", help="Runtime root used for the update-check cache.")
+    check.set_defaults(_handler=run_check)
+
+
+def _message(status: UpdateStatus) -> str:
+    if status.state == "current":
+        return f"HybridOps.Core {status.installed} is current."
+    if status.state == "update_available":
+        suffix = f"\nRelease: {status.release_url}" if status.release_url else ""
+        return f"HybridOps.Core {status.latest} is available (installed {status.installed}).{suffix}"
+    if status.state == "unsupported":
+        suffix = f"\nRelease: {status.release_url}" if status.release_url else ""
+        return (
+            f"HybridOps.Core {status.installed} is outside the current release line "
+            f"({status.latest}). Update before starting a new deployment.{suffix}"
+        )
+    if status.state == "development":
+        return f"HybridOps.Core {status.installed} is a development build; release comparison skipped."
+    if status.state == "offline":
+        return "Release status is unavailable. The installed CLI remains usable."
+    return "Release status could not be determined."
+
+
+def run_check(ns: argparse.Namespace) -> int:
+    status = check_for_update(root=ns.root, use_cache=not ns.no_cache)
+    if ns.json:
+        print(json.dumps(status.__dict__, sort_keys=True))
+    else:
+        print(_message(status))
+    return OK

--- a/tools/install/lib/installer.sh
+++ b/tools/install/lib/installer.sh
@@ -157,4 +157,7 @@ _hyops_install_run_transaction() {
     echo "Run:"
     echo "  ${WRAPPER} --help"
   fi
+  echo "Project: https://github.com/hybridops-tech/hybridops-core"
+  echo "Discuss: https://github.com/hybridops-tech/hybridops-core/discussions"
+  echo "Sponsor: https://github.com/sponsors/hybridops-tech"
 }


### PR DESCRIPTION
Closes #133

## Summary
- add `hyops update check` with text and JSON output
- cache interactive release checks for 24 hours
- distinguish current, update-available, unsupported release-line, offline, and development states
- allow offline and controlled environments to disable checks with `HYOPS_UPDATE_CHECK=0`
- add project, discussion, and sponsor links to installer completion

## Safety
- no usage telemetry or automatic installation
- network failure does not fail operator commands
- automatic checks are silent when current and do not run after destroy
- release status is advisory and cannot block teardown or recovery

## Checks
- `python -m unittest hyops.tests.test_update_checker hyops.tests.test_cli`
- Ruff checks for changed Python files
- `bash tools/ci/check-install.sh`
- `git diff --check`