### PR TITLE
Clarify supported installer paths in the Core README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ The full reference scenario library is published at **[docs.hybridops.tech/refer
 
 ## Quick start
 
-```bash
-python3 -m venv .venv && . .venv/bin/activate
-pip install .
-```
+Install the release package for your workstation:
+
+| Platform | Installation |
+|---|---|
+| Linux | Extract the versioned archive and run `./install.sh` |
+| macOS | Open the package for Apple silicon or Intel |
+| Windows 11 | Extract the Windows ZIP and run `install-windows.cmd` |
+
+See the [Quickstart](https://docs.hybridops.tech/guides/getting-started/quickstart/)
+for downloads, verification, and workstation setup.
 
 Initialise a target environment:
 


### PR DESCRIPTION
Closes #137.\n\nReplaces the source-development install commands in the main Quick Start with the supported Linux, macOS and Windows release paths. Detailed download, verification and setup instructions remain in the documentation Quick Start.