### PR TITLE
Correct macOS release checksum paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,9 @@ jobs:
             --archive "${TARBALL}" \
             --version "${HYOPS_RELEASE_LABEL}" \
             --output "${PKG}"
-          shasum -a 256 "${PKG}" >"${PKG}.sha256"
+          PKG_DIR="$(dirname "${PKG}")"
+          PKG_NAME="$(basename "${PKG}")"
+          (cd "${PKG_DIR}" && shasum -a 256 "${PKG_NAME}" >"${PKG_NAME}.sha256")
 
       - name: Verify macOS package
         shell: bash
@@ -98,7 +100,9 @@ jobs:
           EXPANDED="${RUNNER_TEMP}/hybridops-core-pkg"
           test "$(uname -m)" = "${{ matrix.architecture }}"
           test "$(stat -f '%z' "${PKG}")" -gt 1000000
-          shasum -a 256 -c "${PKG}.sha256"
+          PKG_DIR="$(dirname "${PKG}")"
+          PKG_NAME="$(basename "${PKG}")"
+          (cd "${PKG_DIR}" && shasum -a 256 -c "${PKG_NAME}.sha256")
           pkgutil --expand "${PKG}" "${EXPANDED}"
           test -f "${EXPANDED}/Distribution"
           grep -Fq "<title>HybridOps.Core</title>" "${EXPANDED}/Distribution"


### PR DESCRIPTION
Closes #143

## Summary

- generate macOS package checksums against the package basename
- verify each checksum from the package directory
- keep the published checksum portable after download

## Root cause

The package checksum recorded `dist/releases/<package>`. The publish job verifies checksums from inside `dist/releases`, so the macOS entry resolved to a non-existent nested path.

## Validation

- parsed the release workflow as YAML
- generated and verified a representative macOS checksum
- confirmed the checksum contains no directory path
- `git diff --check`