### PR TITLE
Check out release tag before publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout tagged source
+        uses: actions/checkout@v7
+
       - name: Collect release assets
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Closes #145

## Summary

- check out the tagged source in `publish-release`
- retain `gh release create --verify-tag`
- keep release creation behind the existing asset verification gates

## Root cause

The publication job downloaded build artifacts but did not check out the repository. `gh release create --verify-tag` therefore failed because no Git repository was available.

## Validation

- parsed the release workflow as YAML
- `git diff --check`
- confirmed all platform build and checksum jobs passed in release run 29439456716 before the publication step