### PR TITLE
Expose the licence in the Windows release ZIP

### DIFF
--- a/pkg/build_release.sh
+++ b/pkg/build_release.sh
@@ -258,6 +258,7 @@ mkdir -p "${WINDOWS_STAGE}"
 cp "${TARBALL_PATH}" "${SHA256_PATH}" "${WINDOWS_INSTALLER_PATH}" "${WINDOWS_HELPER_PATH}" \
   "${WINDOWS_LAUNCHER_PATH}" "${REPO_ROOT}/assets/windows/hybridops.ico" \
   "${WINDOWS_STAGE}/"
+cp "${REPO_ROOT}/LICENSE" "${WINDOWS_STAGE}/LICENSE.txt"
 cat >"${WINDOWS_STAGE}/README-WINDOWS.txt" <<EOF
 HybridOps.Core for Windows 11 (WSL2)
 


### PR DESCRIPTION
Closes #153

## Summary

- include the canonical Core licence beside the Windows installer files
- leave the nested release archive and licence terms unchanged

## Validation

- `bash -n pkg/build_release.sh`
- local Windows bundle build
- ZIP content and licence-text assertion
- `git diff --check`

ShellCheck was not available locally; CI remains authoritative for that check.
