### PR TITLE
Make setup readiness target-aware

### DIFF
--- a/hyops/runtime/command_evidence.py
+++ b/hyops/runtime/command_evidence.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import json
 from pathlib import Path
 import platform
+import signal
 import subprocess
 import sys
 from typing import Callable, IO, Mapping, Sequence
@@ -42,7 +43,11 @@ def write_result(
         "started_at": started_at,
         "finished_at": _utc_now(),
         "exit_code": int(exit_code),
-        "status": "ok" if int(exit_code) == 0 else "failed",
+        "status": (
+            "ok"
+            if int(exit_code) == 0
+            else ("cancelled" if int(exit_code) == 130 else "failed")
+        ),
         "platform": {
             "system": platform.system(),
             "machine": platform.machine(),
@@ -79,16 +84,30 @@ def run_streamed(
             bufsize=1,
         )
         assert process.stdout is not None
-        for raw_line in process.stdout:
-            safe_line = redact_text(raw_line)
-            if line_callback is not None:
-                line_callback(safe_line.rstrip("\r\n"))
-            if stream_output:
-                sys.stdout.write(safe_line)
-                sys.stdout.flush()
-            output.write(safe_line)
-            output.flush()
-        exit_code = int(process.wait())
+        try:
+            for raw_line in process.stdout:
+                safe_line = redact_text(raw_line)
+                if line_callback is not None:
+                    line_callback(safe_line.rstrip("\r\n"))
+                if stream_output:
+                    sys.stdout.write(safe_line)
+                    sys.stdout.flush()
+                output.write(safe_line)
+                output.flush()
+            exit_code = int(process.wait())
+        except KeyboardInterrupt:
+            if process.poll() is None:
+                try:
+                    process.send_signal(signal.SIGINT)
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait()
+            exit_code = 130
     write_result(
         evidence_dir,
         command=command,

--- a/hyops/runtime/proc.py
+++ b/hyops/runtime/proc.py
@@ -31,6 +31,26 @@ class ProcResult:
     stderr: str
 
 
+def _start_error_result(
+    argv: Sequence[str], cwd: str | None, start: float, error: OSError
+) -> ProcResult:
+    command = str(argv[0]) if argv else "command"
+    if isinstance(error, FileNotFoundError):
+        rc = 127
+        stderr = f"command not found: {command}\n"
+    else:
+        rc = 126
+        stderr = f"unable to start command '{command}': {error}\n"
+    return ProcResult(
+        argv=list(argv),
+        cwd=cwd,
+        rc=rc,
+        duration_ms=int((time.time() - start) * 1000),
+        stdout="",
+        stderr=stderr,
+    )
+
+
 def run(
     argv: Sequence[str],
     cwd: str | None = None,
@@ -38,15 +58,18 @@ def run(
     timeout_s: int | None = None,
 ) -> ProcResult:
     start = time.time()
-    p = subprocess.run(
-        list(argv),
-        cwd=cwd,
-        env=dict(env) if env else None,
-        text=True,
-        capture_output=True,
-        timeout=timeout_s,
-        check=False,
-    )
+    try:
+        p = subprocess.run(
+            list(argv),
+            cwd=cwd,
+            env=dict(env) if env else None,
+            text=True,
+            capture_output=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except OSError as error:
+        return _start_error_result(argv, cwd, start, error)
     dur = int((time.time() - start) * 1000)
     return ProcResult(
         argv=list(argv),
@@ -90,6 +113,7 @@ def run_capture(
     env: Mapping[str, str] | None = None,
     timeout_s: int | None = None,
     redact: bool = True,
+    progress: bool = True,
 ) -> ProcResult:
     r = _run_with_delayed_progress(
         argv,
@@ -97,6 +121,7 @@ def run_capture(
         cwd=cwd,
         env=env,
         timeout_s=timeout_s,
+        progress=progress,
     )
 
     out = r.stdout
@@ -123,10 +148,15 @@ def _run_with_delayed_progress(
     cwd: str | None,
     env: Mapping[str, str] | None,
     timeout_s: int | None,
+    progress: bool = True,
 ) -> ProcResult:
     """Show progress for a captured command only when it outlasts a quick probe."""
 
-    enabled = concise_enabled() and str(os.getenv("HYOPS_PROGRESS_CHILD") or "").strip() != "1"
+    enabled = (
+        progress
+        and concise_enabled()
+        and str(os.getenv("HYOPS_PROGRESS_CHILD") or "").strip() != "1"
+    )
     if not enabled:
         return run(argv, cwd=cwd, env=env, timeout_s=timeout_s)
 
@@ -179,14 +209,17 @@ def run_interactive(
     timeout_s: int | None = None,
 ) -> ProcResult:
     start = time.time()
-    p = subprocess.run(
-        list(argv),
-        cwd=cwd,
-        env=dict(env) if env else None,
-        text=True,
-        timeout=timeout_s,
-        check=False,
-    )
+    try:
+        p = subprocess.run(
+            list(argv),
+            cwd=cwd,
+            env=dict(env) if env else None,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except OSError as error:
+        return _start_error_result(argv, cwd, start, error)
     dur = int((time.time() - start) * 1000)
     return ProcResult(
         argv=list(argv),
@@ -291,15 +324,29 @@ def run_capture_stream(
             except Exception:
                 pass
 
-    p = subprocess.Popen(
-        list(argv),
-        cwd=cwd,
-        env=dict(env) if env else None,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        bufsize=1,
-    )
+    try:
+        p = subprocess.Popen(
+            list(argv),
+            cwd=cwd,
+            env=dict(env) if env else None,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=1,
+        )
+    except OSError as error:
+        result = _start_error_result(argv, cwd, start, error)
+        message = redact_text(result.stderr) if redact else result.stderr
+        err_path.write_text(message, encoding="utf-8")
+        if tee_f:
+            try:
+                tee_f.write(message)
+                tee_f.write(f"[hyops] {label} end rc={result.rc}\n")
+                tee_f.close()
+            except Exception:
+                pass
+        _write_result_envelope(evidence_dir, label, result, redact=redact)
+        return result
     if stream_progress.enabled:
         stream_progress.start(
             label,

--- a/hyops/runtime/progress.py
+++ b/hyops/runtime/progress.py
@@ -33,6 +33,7 @@ class ProgressDisplay:
     """Render stable plain output or concise interactive status lines."""
 
     enabled: bool = field(default_factory=concise_enabled)
+    show_elapsed: bool = True
     _started: dict[str, float] = field(default_factory=dict)
     _labels: dict[str, str] = field(default_factory=dict)
     _stops: dict[str, threading.Event] = field(default_factory=dict)
@@ -44,18 +45,16 @@ class ProgressDisplay:
         while not stopped.wait(0.2):
             started = self._started.get(key, time.monotonic())
             current_label = self._labels.get(key, label)
-            print(
-                f"\r\033[2K{frames[frame]} {current_label}  {_elapsed(started)}",
-                end="",
-                flush=True,
-            )
+            elapsed = f"  {_elapsed(started)}" if self.show_elapsed else ""
+            print(f"\r\033[2K{frames[frame]} {current_label}{elapsed}", end="", flush=True)
             frame = (frame + 1) % len(frames)
 
     def start(self, key: str, label: str, *, plain: str) -> None:
         self._started[key] = time.monotonic()
         self._labels[key] = label
         if self.enabled:
-            print(f"| {label}  0s", end="", flush=True)
+            elapsed = "  0s" if self.show_elapsed else ""
+            print(f"| {label}{elapsed}", end="", flush=True)
             stopped = threading.Event()
             thread = threading.Thread(
                 target=self._animate,
@@ -102,7 +101,7 @@ class ProgressDisplay:
             "cancelled": "!",
             "failed-optional": "!",
         }.get(status, "✗")
-        suffix = f"  {_elapsed(started)}"
+        suffix = f"  {_elapsed(started)}" if self.show_elapsed else ""
         if detail:
             suffix += f"  {detail}"
         print(f"\r\033[2K{symbol} {label}{suffix}", flush=True)

--- a/hyops/runtime/tests/test_proc_progress.py
+++ b/hyops/runtime/tests/test_proc_progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -23,6 +24,44 @@ class _ImmediateTimer:
 
 
 class CapturedProcessProgressTests(unittest.TestCase):
+    def test_missing_command_returns_standard_result_and_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            result = proc.run_capture(
+                ["hyops-command-that-does-not-exist"],
+                evidence_dir=evidence_dir,
+                label="missing_command",
+            )
+
+            record = json.loads(
+                (evidence_dir / "missing_command.result.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(result.rc, 127)
+        self.assertEqual(record["rc"], 127)
+        self.assertEqual(result.stderr, "command not found: hyops-command-that-does-not-exist\n")
+
+    def test_missing_interactive_command_returns_standard_result(self) -> None:
+        result = proc.run_interactive(["hyops-command-that-does-not-exist"])
+
+        self.assertEqual(result.rc, 127)
+
+    def test_missing_streamed_command_returns_standard_result_and_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            result = proc.run_capture_stream(
+                ["hyops-command-that-does-not-exist"],
+                evidence_dir=evidence_dir,
+                label="missing_stream_command",
+            )
+
+            error_text = (evidence_dir / "missing_stream_command.stderr.txt").read_text(
+                encoding="utf-8"
+            )
+
+        self.assertEqual(result.rc, 127)
+        self.assertIn("command not found", error_text)
+
     def test_quick_capture_does_not_start_progress_outside_tty(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, patch.object(
             proc, "concise_enabled", return_value=False
@@ -53,6 +92,22 @@ class CapturedProcessProgressTests(unittest.TestCase):
         self.assertEqual(result.rc, 0)
         display.start.assert_called_once()
         display.finish.assert_called_once()
+
+    def test_probe_can_disable_delayed_progress(self) -> None:
+        with patch.object(proc, "concise_enabled", return_value=True), patch.object(
+            proc.threading, "Timer"
+        ) as timer:
+            result = proc._run_with_delayed_progress(
+                ["bash", "-lc", "exit 0"],
+                label="credentials_check",
+                cwd=None,
+                env=None,
+                timeout_s=None,
+                progress=False,
+            )
+
+        self.assertEqual(result.rc, 0)
+        timer.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/hyops/runtime/tests/test_progress.py
+++ b/hyops/runtime/tests/test_progress.py
@@ -52,6 +52,24 @@ class ProgressDisplayTests(unittest.TestCase):
         ):
             self.assertFalse(concise_enabled())
 
+    def test_tty_can_show_stage_percentage_without_elapsed_time(self) -> None:
+        output = _Stream(True)
+        display = ProgressDisplay(enabled=True, show_elapsed=False)
+        with redirect_stdout(output), patch.object(display, "_animate"):
+            display.start("network", "Network  overall 0%", plain="ignored")
+            display.finish(
+                "network",
+                "Network",
+                "ok",
+                plain="ignored",
+                detail="overall 20%",
+            )
+
+        self.assertEqual(
+            output.getvalue(),
+            "| Network  overall 0%\r\x1b[2K✓ Network  overall 20%\n",
+        )
+
     def test_tty_label_can_be_updated(self) -> None:
         output = _Stream(True)
         display = ProgressDisplay(enabled=True)

--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -7,12 +7,14 @@ maintainer: HybridOps.Tech
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-from hyops.runtime.exitcodes import OK, INTERNAL_ERROR, OPERATOR_ERROR
+from hyops.runtime.exitcodes import CANCELLED, OK, INTERNAL_ERROR, OPERATOR_ERROR
 from hyops.runtime.command_evidence import PythonCommandEvidence, command_evidence_dir, run_streamed
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
@@ -23,6 +25,7 @@ TARGET_STEPS = {
     "gcp": ("base", "cloud-gcp", "galaxy"),
     "azure": ("base", "cloud-azure", "galaxy"),
     "proxmox": ("base", "galaxy"),
+    "all": ("base", "cloud-azure", "cloud-gcp", "galaxy"),
 }
 
 SETUP_LABELS = {
@@ -33,8 +36,73 @@ SETUP_LABELS = {
     "all": "All setup components",
 }
 
-TARGET_LABELS = {"gcp": "GCP", "azure": "Azure", "proxmox": "Proxmox"}
+SETUP_PHASE_COUNTS = {
+    "base": 7,
+    "cloud-gcp": 3,
+    "cloud-azure": 3,
+    "galaxy": 3,
+}
+
+TARGET_LABELS = {
+    "gcp": "GCP",
+    "azure": "Azure",
+    "proxmox": "Proxmox",
+    "all": "All components",
+}
+
+READINESS_TARGETS = ("all", "base", "gcp", "azure", "proxmox")
+READINESS_GROUPS = {
+    "base-runtime": (
+        ("python3", ("python3",)),
+        ("ssh", ("ssh",)),
+        ("scp", ("scp",)),
+        ("ansible-vault", ("ansible-vault",)),
+        ("ansible-galaxy", ("ansible-galaxy",)),
+        ("terraform", ("terraform",)),
+        ("terragrunt", ("terragrunt",)),
+        ("packer", ("packer",)),
+        ("kubectl", ("kubectl",)),
+    ),
+    "vault-support": (
+        ("gpg", ("gpg",)),
+        ("pass", ("pass",)),
+        (
+            "pinentry",
+            (
+                "pinentry",
+                "pinentry-mac",
+                "pinentry-curses",
+                "pinentry-tty",
+                "pinentry-gtk-2",
+            ),
+        ),
+    ),
+    "gcp-support": (
+        ("gcloud", ("gcloud",)),
+        ("gke-gcloud-auth-plugin", ("gke-gcloud-auth-plugin",)),
+    ),
+    "azure-support": (("az", ("az",)),),
+}
+READINESS_GROUPS_BY_TARGET = {
+    "base": ("base-runtime", "vault-support"),
+    "gcp": ("base-runtime", "vault-support", "gcp-support", "galaxy-dependencies"),
+    "azure": ("base-runtime", "vault-support", "azure-support", "galaxy-dependencies"),
+    "proxmox": ("base-runtime", "vault-support", "galaxy-dependencies"),
+    "all": (
+        "base-runtime",
+        "vault-support",
+        "gcp-support",
+        "azure-support",
+        "galaxy-dependencies",
+    ),
+}
 PROGRESS_PREFIX = "[hyops-progress] "
+
+
+def _setup_phase_count(step: str) -> int:
+    if step == "base" and os.uname().sysname == "Darwin":
+        return 5
+    return SETUP_PHASE_COUNTS.get(step, 1)
 
 
 def _update_setup_progress(
@@ -42,11 +110,21 @@ def _update_setup_progress(
     step: str,
     base_label: str,
     line: str,
+    *,
+    completed_phases: int = 0,
+    total_phases: int = 1,
+    phase_positions: dict[str, int] | None = None,
 ) -> None:
     if line.startswith(PROGRESS_PREFIX):
         phase = line[len(PROGRESS_PREFIX) :].strip()
         if phase:
-            progress.update(step, f"{base_label}: {phase}")
+            position = 1
+            if phase_positions is not None:
+                position = phase_positions.get(step, 0) + 1
+                phase_positions[step] = position
+            started = completed_phases + max(0.5, position - 0.5)
+            percent = min(99, int((started * 100) / max(1, total_phases)))
+            progress.update(step, f"{base_label}: {phase}  {percent}%")
 
 
 def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
@@ -142,7 +220,19 @@ def add_setup_subparser(sp: argparse._SubParsersAction) -> None:
     _add(ssp, "cloud-azure", "Install Azure CLI prerequisites.", parents=[common])
     _add(ssp, "cloud-gcp", "Install GCP SDK prerequisites.", parents=[common])
     _add(ssp, "all", "Run base + ansible + cloud installers.", parents=[common])
-    _add(ssp, "check", "Check presence of common tools (no installs).", parents=[common])
+    check = _add(
+        ssp,
+        "check",
+        "Check readiness for one setup target (no installs).",
+        parents=[common],
+    )
+    check.add_argument(
+        "target",
+        nargs="?",
+        choices=READINESS_TARGETS,
+        default="all",
+        help="Readiness target (default: all).",
+    )
 
     # Compatibility aliases and complete target setup commands.
     _add(ssp, "ansible", "Compatibility alias for: galaxy.", parents=[common])
@@ -161,9 +251,10 @@ def _add(
     help_text: str,
     *,
     parents: list[argparse.ArgumentParser] | None = None,
-) -> None:
+) -> argparse.ArgumentParser:
     q = sp.add_parser(name, help=help_text, parents=parents or [])
     q.set_defaults(_setup_action=name)
+    return q
 
 
 def _find_core_root(ns_root: str | None) -> Path | None:
@@ -242,50 +333,45 @@ def _setup_argv(
     return argv
 
 
-def _run_check() -> int:
-    checks: list[tuple[str, list[str]]] = [
-        ("python3", ["python3"]),
-        ("ssh", ["ssh"]),
-        ("scp", ["scp"]),
-        ("ansible-vault", ["ansible-vault"]),
-        ("ansible-galaxy", ["ansible-galaxy"]),
-        ("terraform", ["terraform"]),
-        ("packer", ["packer"]),
-        ("kubectl", ["kubectl"]),
-        ("gh", ["gh"]),
-        ("az", ["az"]),
-        ("gcloud", ["gcloud"]),
-        ("gpg", ["gpg"]),
-        ("pass", ["pass"]),
-        # Different distros provide different pinentry flavors.
-        (
-            "pinentry",
-            [
-                "pinentry",
-                "pinentry-mac",
-                "pinentry-curses",
-                "pinentry-tty",
-                "pinentry-gtk-2",
-            ],
-        ),
-    ]
-    ok = True
+def _missing_commands(
+    checks: tuple[tuple[str, tuple[str, ...]], ...],
+) -> list[str]:
+    missing: list[str] = []
     for label, candidates in checks:
-        found = ""
-        for cand in candidates:
-            rc = subprocess.call(
-                ["/usr/bin/env", "bash", "-lc", f"command -v {cand} >/dev/null 2>&1"]
-            )
-            if rc == 0:
-                found = cand
-                break
-        if found:
-            suffix = f" ({found})" if found != label else ""
-            print(f"installed {label}{suffix}")
+        if not any(shutil.which(candidate) for candidate in candidates):
+            missing.append(label)
+    return missing
+
+
+def _galaxy_readiness(runtime_root: Path) -> list[str]:
+    marker = runtime_root / "state" / "ansible" / ".installed.json"
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        collections_dir = Path(str(payload["collections_dir"])).expanduser()
+    except (OSError, ValueError, KeyError, TypeError):
+        return ["run: hyops setup galaxy"]
+    if not collections_dir.is_dir():
+        return ["run: hyops setup galaxy"]
+    return []
+
+
+def _run_check(target: str, runtime_root: Path) -> int:
+    print(f"setup target: {target}")
+    ready = True
+    for group in READINESS_GROUPS_BY_TARGET[target]:
+        if group == "galaxy-dependencies":
+            missing = _galaxy_readiness(runtime_root)
         else:
-            print(f"missing   {label}")
-            ok = False
-    return OK if ok else 2
+            missing = _missing_commands(READINESS_GROUPS[group])
+
+        if missing:
+            print(f"missing {group}: {', '.join(missing)}")
+            ready = False
+        else:
+            print(f"ok      {group}")
+
+    print(f"status={'ready' if ready else 'not-ready'}")
+    return OK if ready else OPERATOR_ERROR
 
 
 def run(ns) -> int:
@@ -315,7 +401,7 @@ def run(ns) -> int:
             command="setup check",
             argv=sys.argv[1:],
         ) as evidence:
-            evidence.exit_code = _run_check()
+            evidence.exit_code = _run_check(ns.target, evidence_paths.root)
             return evidence.exit_code
 
     if canonical_action in ("galaxy", "all", *TARGET_STEPS):
@@ -368,10 +454,13 @@ def run(ns) -> int:
 
         evidence_paths = resolve_runtime_paths(root=runtime_root_arg, env=env_arg)
         ensure_layout(evidence_paths)
-        progress = ProgressDisplay()
+        progress = ProgressDisplay(show_elapsed=False)
         print(f"Setup target: {TARGET_LABELS[canonical_action]}")
         if progress.enabled:
             print("First-time setup may take several minutes.")
+        total_phases = sum(_setup_phase_count(step) for step in steps)
+        completed_phases = 0
+        phase_positions: dict[str, int] = {}
         requires_sudo = os.uname().sysname != "Darwin" and any(
             step != "galaxy" for step in steps
         )
@@ -380,7 +469,7 @@ def run(ns) -> int:
             if subprocess.call(["sudo", "-v"]) != 0:
                 print("ERR: administrator authentication failed")
                 return OPERATOR_ERROR
-        for step in steps:
+        for step_index, step in enumerate(steps, start=1):
             step_script = (
                 core_root / "tools" / "setup" / str(_script_for(step))
             ).resolve()
@@ -397,6 +486,8 @@ def run(ns) -> int:
                 elevate=step != "galaxy" and os.uname().sysname != "Darwin",
             )
             label = SETUP_LABELS[step]
+            running_percent = (completed_phases * 100) // max(1, total_phases)
+            running_label = f"{label}  {step_index}/{len(steps)}  {running_percent}%"
             evidence_dir = command_evidence_dir(
                 evidence_paths.logs_dir,
                 "setup",
@@ -404,8 +495,11 @@ def run(ns) -> int:
             )
             progress.start(
                 step,
-                label,
-                plain=f"setup={canonical_action} stage={step} status=running",
+                running_label,
+                plain=(
+                    f"setup={canonical_action} stage={step} status=running "
+                    f"progress={running_percent}%"
+                ),
             )
             rc = run_streamed(
                 argv,
@@ -414,25 +508,42 @@ def run(ns) -> int:
                 command=f"setup {canonical_action} {step}",
                 stream_output=verbose_enabled(),
                 announce=False,
-                line_callback=lambda line, step=step, label=label: _update_setup_progress(
-                    progress, step, label, line
+                line_callback=lambda line, step=step, label=label, completed_phases=completed_phases: _update_setup_progress(
+                    progress,
+                    step,
+                    label,
+                    line,
+                    completed_phases=completed_phases,
+                    total_phases=total_phases,
+                    phase_positions=phase_positions,
                 ),
             )
             if rc != 0:
+                confirmed = completed_phases + max(0, phase_positions.get(step, 1) - 1)
+                failed_percent = min(99, (confirmed * 100) // max(1, total_phases))
                 progress.finish(
                     step,
-                    label,
-                    "failed",
-                    plain=f"setup={canonical_action} stage={step} status=failed",
+                    f"{label}  {step_index}/{len(steps)}  {failed_percent}%",
+                    "cancelled" if rc == CANCELLED else "failed",
+                    plain=(
+                        f"setup={canonical_action} stage={step} "
+                        f"status={'cancelled' if rc == CANCELLED else 'failed'} "
+                        f"progress={failed_percent}%"
+                    ),
                 )
                 print(f"run record: {evidence_dir}")
                 print(f"rerun: hyops setup {canonical_action} --verbose")
                 return rc
+            completed_phases += _setup_phase_count(step)
+            completed_percent = (completed_phases * 100) // max(1, total_phases)
             progress.finish(
                 step,
-                label,
+                f"{label}  {step_index}/{len(steps)}  {completed_percent}%",
                 "ok",
-                plain=f"setup={canonical_action} stage={step} status=ok",
+                plain=(
+                    f"setup={canonical_action} stage={step} status=ok "
+                    f"progress={completed_percent}%"
+                ),
             )
         print(f"setup={canonical_action} status=ok")
         print(f"run records: {evidence_paths.logs_dir / 'setup' / canonical_action}")
@@ -455,6 +566,22 @@ def run(ns) -> int:
         if (env_arg or "").strip():
             env["HYOPS_ENV"] = str(env_arg).strip()
 
+    auto_elevate = (
+        os.uname().sysname != "Darwin"
+        and canonical_action in ("base", "cloud-gcp", "cloud-azure", "all")
+    )
+    elevate = sudo or auto_elevate
+    if (
+        elevate
+        and os.uname().sysname != "Darwin"
+        and sys.stdin.isatty()
+        and sys.stdout.isatty()
+    ):
+        print("Administrator access is required for system setup.")
+        if subprocess.call(["sudo", "-v"]) != 0:
+            print("ERR: administrator authentication failed")
+            return OPERATOR_ERROR
+
     argv = _setup_argv(
         canonical_action,
         script,
@@ -462,16 +589,22 @@ def run(ns) -> int:
         force=force,
         hybridops_source=hybridops_source,
         hybridops_git_manifest=hybridops_git_manifest,
-        elevate=sudo,
+        elevate=elevate,
     )
     evidence_paths = resolve_runtime_paths(root=runtime_root_arg, env=env_arg)
     ensure_layout(evidence_paths)
     evidence_dir = command_evidence_dir(evidence_paths.logs_dir, "setup", canonical_action)
     label = SETUP_LABELS.get(canonical_action, canonical_action)
-    progress = ProgressDisplay()
+    progress = ProgressDisplay(show_elapsed=False)
     if progress.enabled:
         print("First-time setup may take several minutes.")
-    progress.start(canonical_action, label, plain=f"setup={canonical_action} status=running")
+    total_phases = _setup_phase_count(canonical_action)
+    phase_positions: dict[str, int] = {}
+    progress.start(
+        canonical_action,
+        f"{label}  0%",
+        plain=f"setup={canonical_action} status=running progress=0%",
+    )
     rc = run_streamed(
         argv,
         env=env,
@@ -480,17 +613,33 @@ def run(ns) -> int:
         stream_output=verbose_enabled(),
         announce=False,
         line_callback=lambda line: _update_setup_progress(
-            progress, canonical_action, label, line
+            progress,
+            canonical_action,
+            label,
+            line,
+            total_phases=total_phases,
+            phase_positions=phase_positions,
         ),
     )
     if rc == 0:
-        progress.finish(canonical_action, label, "ok", plain=f"setup={canonical_action} status=ok")
-    else:
         progress.finish(
             canonical_action,
-            label,
-            "failed",
-            plain=f"setup={canonical_action} status=failed",
+            f"{label}  100%",
+            "ok",
+            plain=f"setup={canonical_action} status=ok progress=100%",
+        )
+    else:
+        completed = max(0, phase_positions.get(canonical_action, 1) - 1)
+        failed_percent = min(99, (completed * 100) // max(1, total_phases))
+        progress.finish(
+            canonical_action,
+            f"{label}  {failed_percent}%",
+            "cancelled" if rc == CANCELLED else "failed",
+            plain=(
+                f"setup={canonical_action} "
+                f"status={'cancelled' if rc == CANCELLED else 'failed'} "
+                f"progress={failed_percent}%"
+            ),
         )
     print(f"run record: {evidence_dir}")
     if rc != 0:

--- a/hyops/setup/tests/test_command.py
+++ b/hyops/setup/tests/test_command.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from hyops.cli import main
 
@@ -13,12 +13,159 @@ from hyops.cli import main
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
+def _write_galaxy_marker(runtime: str) -> None:
+    collections = Path(runtime) / "state" / "ansible" / "galaxy_collections"
+    collections.mkdir(parents=True)
+    marker = collections.parent / ".installed.json"
+    marker.write_text(
+        f'{{"collections_dir": "{collections}"}}\n',
+        encoding="utf-8",
+    )
+
+
 class SetupCommandTests(unittest.TestCase):
+    def test_gcp_check_does_not_require_azure(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.shutil.which",
+            side_effect=lambda command: None if command == "az" else f"/bin/{command}",
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            (Path(runtime) / "run-record").mkdir()
+            _write_galaxy_marker(runtime)
+            output = io.StringIO()
+            with redirect_stdout(output):
+                rc = main(
+                    ["setup", "check", "gcp", "--runtime-root", runtime]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertIn("ok      gcp-support", output.getvalue())
+        self.assertNotIn("azure-support", output.getvalue())
+
+    def test_gcp_check_requires_auth_plugin(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.shutil.which",
+            side_effect=lambda command: (
+                None if command == "gke-gcloud-auth-plugin" else f"/bin/{command}"
+            ),
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            (Path(runtime) / "run-record").mkdir()
+            _write_galaxy_marker(runtime)
+            output = io.StringIO()
+            with redirect_stdout(output):
+                rc = main(
+                    ["setup", "check", "gcp", "--runtime-root", runtime]
+                )
+
+        self.assertEqual(rc, 2)
+        self.assertIn(
+            "missing gcp-support: gke-gcloud-auth-plugin",
+            output.getvalue(),
+        )
+        self.assertIn("status=not-ready", output.getvalue())
+
+    def test_proxmox_check_requires_galaxy_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.shutil.which", return_value="/bin/tool"
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            (Path(runtime) / "run-record").mkdir()
+            output = io.StringIO()
+            with redirect_stdout(output):
+                rc = main(
+                    ["setup", "check", "proxmox", "--runtime-root", runtime]
+                )
+
+        self.assertEqual(rc, 2)
+        self.assertIn(
+            "missing galaxy-dependencies: run: hyops setup galaxy",
+            output.getvalue(),
+        )
+
+    def test_base_check_does_not_require_provider_or_galaxy(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.shutil.which", return_value="/bin/tool"
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            (Path(runtime) / "run-record").mkdir()
+            output = io.StringIO()
+            with redirect_stdout(output):
+                rc = main(
+                    ["setup", "check", "base", "--runtime-root", runtime]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertNotIn("gcp-support", output.getvalue())
+        self.assertNotIn("azure-support", output.getvalue())
+        self.assertNotIn("galaxy-dependencies", output.getvalue())
+
+    def test_target_progress_reaches_100_percent(self) -> None:
+        display = MagicMock()
+        display.enabled = True
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", return_value=0
+        ), patch(
+            "hyops.setup.command.ProgressDisplay", return_value=display
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            rc = main(
+                [
+                    "setup",
+                    "proxmox",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertIn("100%", display.finish.call_args_list[-1].args[1])
+
+    def test_target_progress_stops_at_failed_stage(self) -> None:
+        display = MagicMock()
+        display.enabled = True
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", side_effect=[0, 7]
+        ), patch(
+            "hyops.setup.command.ProgressDisplay", return_value=display
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            rc = main(
+                [
+                    "setup",
+                    "proxmox",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                ]
+            )
+
+        self.assertEqual(rc, 7)
+        failed_label = display.finish.call_args_list[-1].args[1]
+        self.assertIn("70%", failed_label)
+        self.assertNotIn("100%", failed_label)
+
     def test_target_dry_run_lists_composed_steps(self) -> None:
         cases = {
             "gcp": ("base", "cloud-gcp", "galaxy"),
             "azure": ("base", "cloud-azure", "galaxy"),
             "proxmox": ("base", "galaxy"),
+            "all": ("base", "cloud-azure", "cloud-gcp", "galaxy"),
         }
         for target, expected in cases.items():
             with self.subTest(target=target), tempfile.TemporaryDirectory() as runtime:
@@ -80,6 +227,113 @@ class SetupCommandTests(unittest.TestCase):
                 ]
             )
         self.assertEqual(rc, 0)
+
+    def test_individual_base_setup_elevates_automatically_on_linux(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", return_value=0
+        ) as run_streamed, patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            rc = main(
+                [
+                    "setup",
+                    "base",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            run_streamed.call_args.args[0][:3],
+            ["sudo", "-H", "-E"],
+        )
+
+    def test_all_setup_elevates_system_stages_only(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", return_value=0
+        ) as run_streamed, patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            rc = main(
+                [
+                    "setup",
+                    "all",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(run_streamed.call_count, 4)
+        for call in run_streamed.call_args_list[:3]:
+            self.assertEqual(call.args[0][:3], ["sudo", "-H", "-E"])
+        self.assertEqual(run_streamed.call_args_list[3].args[0][0], "bash")
+
+    def test_individual_setup_uses_percentage_without_elapsed_time(self) -> None:
+        display = MagicMock()
+        display.enabled = True
+
+        def run_with_progress(*args, **kwargs):
+            callback = kwargs["line_callback"]
+            callback("[hyops-progress] Preparing system packages")
+            callback("[hyops-progress] Installing automation runtime")
+            return 0
+
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", side_effect=run_with_progress
+        ), patch(
+            "hyops.setup.command.ProgressDisplay", return_value=display
+        ) as progress_class, patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            rc = main(
+                [
+                    "setup",
+                    "base",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        progress_class.assert_called_once_with(show_elapsed=False)
+        self.assertIn("21%", display.update.call_args_list[-1].args[1])
+        self.assertIn("100%", display.finish.call_args.args[1])
+
+    def test_individual_setup_reports_cancellation(self) -> None:
+        display = MagicMock()
+        display.enabled = True
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", return_value=130
+        ), patch(
+            "hyops.setup.command.ProgressDisplay", return_value=display
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            rc = main(
+                [
+                    "setup",
+                    "base",
+                    "--root",
+                    str(REPO_ROOT),
+                    "--runtime-root",
+                    runtime,
+                ]
+            )
+
+        self.assertEqual(rc, 130)
+        self.assertEqual(display.finish.call_args.args[2], "cancelled")
 
 
 if __name__ == "__main__":

--- a/tools/setup/setup-base-macos.sh
+++ b/tools/setup/setup-base-macos.sh
@@ -2,6 +2,11 @@
 # purpose: Install base HybridOps prerequisites on macOS with Homebrew.
 set -euo pipefail
 
+progress() {
+  echo "[hyops-progress] $1"
+}
+
+progress "Checking Homebrew"
 if [[ "${EUID}" -eq 0 ]]; then
   echo "ERR: Homebrew setup must run as your macOS user (omit --sudo)" >&2
   exit 2
@@ -13,11 +18,15 @@ command -v brew >/dev/null 2>&1 || {
 }
 
 echo "[setup] macOS Homebrew base prerequisites"
+progress "Preparing package repositories"
 brew tap hashicorp/tap
+progress "Installing infrastructure runtime"
 brew install hashicorp/tap/terraform hashicorp/tap/packer
-brew install python terragrunt kubectl ansible pipx
+progress "Installing automation and vault support"
+brew install python terragrunt kubectl ansible pipx gnupg pass pinentry-mac
 
-for required_cmd in python3 terraform terragrunt packer kubectl ansible-playbook pipx; do
+progress "Verifying base setup"
+for required_cmd in python3 terraform terragrunt packer kubectl ansible-playbook pipx gpg pass pinentry-mac; do
   command -v "${required_cmd}" >/dev/null 2>&1 || {
     echo "ERR: ${required_cmd} was installed but is not available on PATH" >&2
     exit 1

--- a/tools/setup/setup-base.sh
+++ b/tools/setup/setup-base.sh
@@ -9,7 +9,7 @@ if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
   exec bash "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/setup-base-macos.sh" "$@"
 fi
 
-[[ "${EUID}" -eq 0 ]] || { echo "ERR: requires root (use: hyops setup base --sudo)"; exit 2; }
+[[ "${EUID}" -eq 0 ]] || { echo "ERR: requires root (run: hyops setup base)"; exit 2; }
 
 export PATH="/usr/local/bin:/usr/local/sbin:${PATH}"
 
@@ -546,24 +546,30 @@ ensure_vault_pass_deps() {
   ensure_foundation
   case "${PKG_MANAGER}" in
     apt)
-      if pkg_install_optional pass pinentry-curses; then
-        return 0
-      fi
+      pkg_install pass pinentry-curses
       ;;
     dnf|yum)
-      if pkg_install_optional pass pinentry; then
-        return 0
-      fi
+      pkg_install pass pinentry
       ;;
   esac
-  echo "[setup] pass/pinentry unavailable from configured package repositories; skipping"
+  have pass || {
+    echo "ERR: pass was installed but is not available on PATH" >&2
+    exit 1
+  }
+  if ! have pinentry && ! have pinentry-curses && ! have pinentry-tty; then
+    echo "ERR: pinentry was installed but is not available on PATH" >&2
+    exit 1
+  fi
 }
 
 main() {
   toolchain__load
   print_header
-  progress "Preparing system packages"
+  progress "Refreshing package information"
+  pkg_update_once
+  progress "Installing system utilities"
   ensure_foundation
+  progress "Installing Python runtime"
   ensure_python
   progress "Installing automation runtime"
   ensure_ansible

--- a/tools/setup/setup-cloud-azure-macos.sh
+++ b/tools/setup/setup-cloud-azure-macos.sh
@@ -2,6 +2,11 @@
 # purpose: Install Azure CLI prerequisites on macOS with Homebrew.
 set -euo pipefail
 
+progress() {
+  echo "[hyops-progress] $1"
+}
+
+progress "Checking Homebrew"
 if [[ "${EUID}" -eq 0 ]]; then
   echo "ERR: Homebrew setup must run as your macOS user (omit --sudo)" >&2
   exit 2
@@ -12,6 +17,8 @@ command -v brew >/dev/null 2>&1 || {
   exit 2
 }
 
+progress "Installing Azure support"
 brew install azure-cli
+progress "Verifying Azure support"
 command -v az >/dev/null 2>&1 || { echo "ERR: Azure CLI install failed" >&2; exit 1; }
 echo "[setup] Azure CLI installed"

--- a/tools/setup/setup-cloud-azure.sh
+++ b/tools/setup/setup-cloud-azure.sh
@@ -5,11 +5,19 @@
 
 set -euo pipefail
 
+progress() {
+  echo "[hyops-progress] $1"
+}
+
 if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]]; then
   exec bash "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/setup-cloud-azure-macos.sh" "$@"
 fi
 
-command -v az >/dev/null 2>&1 && { echo "[setup] azure-cli present"; exit 0; }
+command -v az >/dev/null 2>&1 && {
+  progress "Verifying cloud setup"
+  echo "[setup] azure-cli present"
+  exit 0
+}
 
 [[ "${EUID}" -eq 0 ]] || { echo "ERR: requires root (use: hyops setup cloud-azure --sudo)"; exit 2; }
 
@@ -19,6 +27,7 @@ RELEASE_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=/dev/null
 source "${RELEASE_ROOT}/tools/setup/lib/toolchain_lock.sh"
 
+progress "Preparing cloud packages"
 apt-get update -y
 apt-get install -y ca-certificates curl gnupg lsb-release
 
@@ -36,6 +45,7 @@ EOF
 
 apt-get update -y
 
+progress "Installing cloud integration"
 az_ver="$(toolchain_get AZ_CLI_VERSION)"
 if [[ -n "${az_ver}" ]]; then
   apt-get install -y "azure-cli=${az_ver}" || {
@@ -47,6 +57,7 @@ else
   apt-get install -y azure-cli
 fi
 
+progress "Verifying cloud setup"
 command -v az >/dev/null 2>&1 || { echo "ERR: az install failed"; exit 1; }
 
 echo "[setup] azure-cli installed"

--- a/tools/setup/setup-cloud-gcp-macos.sh
+++ b/tools/setup/setup-cloud-gcp-macos.sh
@@ -2,6 +2,11 @@
 # purpose: Install Google Cloud CLI prerequisites on macOS with Homebrew.
 set -euo pipefail
 
+progress() {
+  echo "[hyops-progress] $1"
+}
+
+progress "Checking Homebrew"
 if [[ "${EUID}" -eq 0 ]]; then
   echo "ERR: Homebrew setup must run as your macOS user (omit --sudo)" >&2
   exit 2
@@ -12,8 +17,10 @@ command -v brew >/dev/null 2>&1 || {
   exit 2
 }
 
+progress "Installing Google Cloud support"
 brew install --cask google-cloud-sdk
 
+progress "Verifying Google Cloud support"
 command -v gcloud >/dev/null 2>&1 || {
   echo "ERR: gcloud was installed but is not on PATH; start a new shell and retry" >&2
   exit 2


### PR DESCRIPTION
Closes #157

## Summary

- check workstation readiness against the selected setup target
- verify provider-specific commands and installed Galaxy runtime state
- report staged setup progress without elapsed-time noise
- preserve run records and distinguish interrupted setup from failure

## Verification

- `python3 -m unittest hyops.setup.tests.test_command`
- `python3 -m unittest discover -s hyops -p 'test_*.py'`
- `tools/ci/check-install.sh`
