### PR TITLE
Report Galaxy setup progress by dependency set

### DIFF
--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -40,7 +40,7 @@ SETUP_PHASE_COUNTS = {
     "base": 7,
     "cloud-gcp": 3,
     "cloud-azure": 3,
-    "galaxy": 3,
+    "galaxy": 8,
 }
 
 TARGET_LABELS = {

--- a/hyops/setup/tests/test_command.py
+++ b/hyops/setup/tests/test_command.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from hyops.cli import main
+from hyops.setup.command import _update_setup_progress
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -24,6 +25,37 @@ def _write_galaxy_marker(runtime: str) -> None:
 
 
 class SetupCommandTests(unittest.TestCase):
+    def test_galaxy_progress_advances_across_dependency_sets(self) -> None:
+        display = MagicMock()
+        positions: dict[str, int] = {}
+        phases = (
+            "Installing shared runtime dependencies",
+            "Shared runtime dependencies ready",
+            "Installing workload dependencies 1/5",
+            "Installing workload dependencies 2/5",
+            "Installing workload dependencies 3/5",
+            "Installing workload dependencies 4/5",
+            "Installing workload dependencies 5/5",
+            "Verifying runtime dependencies",
+        )
+
+        for phase in phases:
+            _update_setup_progress(
+                display,
+                "galaxy",
+                "Galaxy dependencies",
+                f"[hyops-progress] {phase}",
+                completed_phases=10,
+                total_phases=18,
+                phase_positions=positions,
+            )
+
+        percentages = [
+            int(call.args[1].rsplit(" ", 1)[-1].removesuffix("%"))
+            for call in display.update.call_args_list
+        ]
+        self.assertEqual(percentages, [58, 63, 69, 75, 80, 86, 91, 97])
+
     def test_gcp_check_does_not_require_azure(self) -> None:
         with tempfile.TemporaryDirectory() as runtime, patch(
             "hyops.setup.command.shutil.which",
@@ -157,7 +189,7 @@ class SetupCommandTests(unittest.TestCase):
 
         self.assertEqual(rc, 7)
         failed_label = display.finish.call_args_list[-1].args[1]
-        self.assertIn("70%", failed_label)
+        self.assertIn("46%", failed_label)
         self.assertNotIn("100%", failed_label)
 
     def test_target_dry_run_lists_composed_steps(self) -> None:

--- a/tools/setup/setup-ansible.sh
+++ b/tools/setup/setup-ansible.sh
@@ -369,26 +369,31 @@ export HYOPS_RELEASE_ROOT="${RELEASE_ROOT}"
 # Shared/common set (compatible across most workflows)
 progress "Installing shared runtime dependencies"
 install_set "common" "common" "" "${REQ_FILE}" "${RUNTIME_ROOT}/state/ansible"
+progress "Shared runtime dependencies ready"
 
 # Module-specific sets are installed into isolated paths to avoid Galaxy dependency conflicts.
 # These paths are added automatically at runtime by the Ansible driver when the module runs.
-progress "Installing workload dependencies"
+progress "Installing workload dependencies 1/5"
 install_set "platform/postgresql-ha" "module" "platform/postgresql-ha" \
   "${RELEASE_ROOT}/tools/setup/requirements/ansible.postgresql-ha.galaxy.yml" \
   "${RUNTIME_ROOT}/state/ansible/modules/platform__postgresql-ha"
 
+progress "Installing workload dependencies 2/5"
 install_set "platform/onprem/postgresql-ha (legacy alias)" "module" "platform/onprem/postgresql-ha" \
   "${RELEASE_ROOT}/tools/setup/requirements/ansible.postgresql-ha.galaxy.yml" \
   "${RUNTIME_ROOT}/state/ansible/modules/platform__onprem__postgresql-ha"
 
+progress "Installing workload dependencies 3/5"
 install_set "platform/postgresql-ha-backup" "module" "platform/postgresql-ha-backup" \
   "${RELEASE_ROOT}/tools/setup/requirements/ansible.postgresql-ha.galaxy.yml" \
   "${RUNTIME_ROOT}/state/ansible/modules/platform__postgresql-ha-backup"
 
+progress "Installing workload dependencies 4/5"
 install_set "platform/onprem/postgresql-ha-backup (legacy alias)" "module" "platform/onprem/postgresql-ha-backup" \
   "${RELEASE_ROOT}/tools/setup/requirements/ansible.postgresql-ha.galaxy.yml" \
   "${RUNTIME_ROOT}/state/ansible/modules/platform__onprem__postgresql-ha-backup"
 
+progress "Installing workload dependencies 5/5"
 install_set "platform/onprem/rke2-cluster" "module" "platform/onprem/rke2-cluster" \
   "${RELEASE_ROOT}/tools/setup/requirements/ansible.rke2-cluster.galaxy.yml" \
   "${RUNTIME_ROOT}/state/ansible/modules/platform__onprem__rke2-cluster"


### PR DESCRIPTION
Closes #161

## Summary

- assign Galaxy setup progress to its declared dependency sets
- emit a milestone as each workload dependency set begins processing
- keep 100% reserved for successful verification

## Verification

- `python3 -m unittest hyops.setup.tests.test_command`
- `tools/ci/check-install.sh`
