### PR TITLE
Add consistent terminal status colours

### DIFF
--- a/hyops/cli.py
+++ b/hyops/cli.py
@@ -99,6 +99,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Stream tool output to terminal while also writing run records.",
     )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable terminal status colours.",
+    )
     sp = p.add_subparsers(dest="cmd", required=False, metavar="COMMAND")
 
     add_init_subparser(sp)
@@ -139,6 +144,13 @@ def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
     ns = parser.parse_args(argv)
+
+    if getattr(ns, "no_color", False):
+        os.environ["NO_COLOR"] = "1"
+
+    from hyops.runtime.terminal import configure_status_streams
+
+    configure_status_streams()
 
     if getattr(ns, "version", False):
         from hyops import __version__

--- a/hyops/runtime/progress.py
+++ b/hyops/runtime/progress.py
@@ -8,6 +8,8 @@ import threading
 import time
 from dataclasses import dataclass, field
 
+from hyops.runtime.terminal import colour_enabled, style
+
 
 def verbose_enabled() -> bool:
     return str(os.getenv("HYOPS_VERBOSE") or "").strip().lower() in {
@@ -46,7 +48,12 @@ class ProgressDisplay:
             started = self._started.get(key, time.monotonic())
             current_label = self._labels.get(key, label)
             elapsed = f"  {_elapsed(started)}" if self.show_elapsed else ""
-            print(f"\r\033[2K{frames[frame]} {current_label}{elapsed}", end="", flush=True)
+            symbol = style(
+                frames[frame],
+                "active",
+                enabled=colour_enabled(),
+            )
+            print(f"\r\033[2K{symbol} {current_label}{elapsed}", end="", flush=True)
             frame = (frame + 1) % len(frames)
 
     def start(self, key: str, label: str, *, plain: str) -> None:
@@ -54,7 +61,8 @@ class ProgressDisplay:
         self._labels[key] = label
         if self.enabled:
             elapsed = "  0s" if self.show_elapsed else ""
-            print(f"| {label}{elapsed}", end="", flush=True)
+            symbol = style("|", "active", enabled=colour_enabled())
+            print(f"{symbol} {label}{elapsed}", end="", flush=True)
             stopped = threading.Event()
             thread = threading.Thread(
                 target=self._animate,
@@ -101,6 +109,14 @@ class ProgressDisplay:
             "cancelled": "!",
             "failed-optional": "!",
         }.get(status, "✗")
+        tone = {
+            "ok": "success",
+            "skipped": "warning",
+            "retained": "warning",
+            "cancelled": "warning",
+            "failed-optional": "warning",
+        }.get(status, "error")
+        symbol = style(symbol, tone, enabled=colour_enabled())
         suffix = f"  {_elapsed(started)}" if self.show_elapsed else ""
         if detail:
             suffix += f"  {detail}"

--- a/hyops/runtime/terminal.py
+++ b/hyops/runtime/terminal.py
@@ -1,0 +1,121 @@
+"""Terminal status styling with plain non-interactive output."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import IO
+
+
+RESET = "\033[0m"
+COLOURS = {
+    "success": "\033[32m",
+    "warning": "\033[33m",
+    "error": "\033[31m",
+    "active": "\033[36m",
+    "muted": "\033[2m",
+}
+
+
+def colour_enabled(stream: IO[str] | None = None) -> bool:
+    stream = stream or sys.stdout
+    if "NO_COLOR" in os.environ:
+        return False
+    if str(os.environ.get("TERM") or "").strip().lower() == "dumb":
+        return False
+    try:
+        return bool(stream.isatty())
+    except (AttributeError, OSError):
+        return False
+
+
+def style(text: str, tone: str, *, enabled: bool = True) -> str:
+    if not enabled or not text:
+        return text
+    colour = COLOURS.get(tone)
+    if not colour:
+        return text
+    return f"{colour}{text}{RESET}"
+
+
+def decorate_status_text(text: str, *, enabled: bool) -> str:
+    """Colour stable status tokens without changing their plain representation."""
+    if not enabled or not text or "\033[" in text:
+        return text
+
+    decorated = re.sub(
+        r"(?m)^(\s*)(ERR:|ERROR:)",
+        lambda match: f"{match.group(1)}{style(match.group(2), 'error')}",
+        text,
+    )
+    decorated = re.sub(
+        r"(?m)^(\s*)(WARN:)",
+        lambda match: f"{match.group(1)}{style(match.group(2), 'warning')}",
+        decorated,
+    )
+    decorated = re.sub(
+        r"(?m)^(\s*)(ok|ready)(?=\s|$)",
+        lambda match: f"{match.group(1)}{style(match.group(2), 'success')}",
+        decorated,
+    )
+    decorated = re.sub(
+        r"(?m)^(\s*)(fail|failed|missing)(?=\s|$)",
+        lambda match: f"{match.group(1)}{style(match.group(2), 'error')}",
+        decorated,
+    )
+    decorated = re.sub(
+        r"(?<=status=)(ok|ready)(?=\s|$)",
+        lambda match: style(match.group(1), "success"),
+        decorated,
+    )
+    decorated = re.sub(
+        r"(?<=status=)(failed|error|not-ready)(?=\s|$)",
+        lambda match: style(match.group(1), "error"),
+        decorated,
+    )
+    decorated = re.sub(
+        r"(?<=preflight_status=)(ok|ready)(?=\s|$)",
+        lambda match: style(match.group(1), "success"),
+        decorated,
+    )
+    decorated = re.sub(
+        r"(?<=preflight_status=)(failed|error)(?=\s|$)",
+        lambda match: style(match.group(1), "error"),
+        decorated,
+    )
+    return decorated
+
+
+class StatusStream:
+    """Decorate terminal writes while retaining the wrapped stream contract."""
+
+    def __init__(self, stream: IO[str]) -> None:
+        self.stream = stream
+
+    def write(self, text: str) -> int:
+        rendered = decorate_status_text(
+            text,
+            enabled=colour_enabled(self.stream),
+        )
+        self.stream.write(rendered)
+        return len(text)
+
+    def flush(self) -> None:
+        self.stream.flush()
+
+    def isatty(self) -> bool:
+        return self.stream.isatty()
+
+    def fileno(self) -> int:
+        return self.stream.fileno()
+
+    def __getattr__(self, name: str):
+        return getattr(self.stream, name)
+
+
+def configure_status_streams() -> None:
+    if not isinstance(sys.stdout, StatusStream):
+        sys.stdout = StatusStream(sys.stdout)  # type: ignore[assignment]
+    if not isinstance(sys.stderr, StatusStream):
+        sys.stderr = StatusStream(sys.stderr)  # type: ignore[assignment]

--- a/hyops/runtime/tests/test_progress.py
+++ b/hyops/runtime/tests/test_progress.py
@@ -35,7 +35,9 @@ class ProgressDisplayTests(unittest.TestCase):
     def test_tty_uses_concise_status(self) -> None:
         output = _Stream(True)
         display = ProgressDisplay(enabled=True)
-        with redirect_stdout(output), patch(
+        with redirect_stdout(output), patch.dict(
+            os.environ, {"NO_COLOR": "1"}
+        ), patch(
             "hyops.runtime.progress.time.monotonic", side_effect=[10.0, 15.0]
         ), patch.object(display, "_animate"):
             display.start("network", "Network", plain="ignored")
@@ -55,7 +57,9 @@ class ProgressDisplayTests(unittest.TestCase):
     def test_tty_can_show_stage_percentage_without_elapsed_time(self) -> None:
         output = _Stream(True)
         display = ProgressDisplay(enabled=True, show_elapsed=False)
-        with redirect_stdout(output), patch.object(display, "_animate"):
+        with redirect_stdout(output), patch.dict(
+            os.environ, {"NO_COLOR": "1"}
+        ), patch.object(display, "_animate"):
             display.start("network", "Network  overall 0%", plain="ignored")
             display.finish(
                 "network",

--- a/hyops/runtime/tests/test_terminal.py
+++ b/hyops/runtime/tests/test_terminal.py
@@ -1,0 +1,65 @@
+"""Tests for terminal status styling."""
+
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from unittest.mock import patch
+
+from hyops.runtime.command_evidence import _TeeStream
+from hyops.runtime.terminal import (
+    StatusStream,
+    colour_enabled,
+    decorate_status_text,
+)
+
+
+class _Stream(io.StringIO):
+    def __init__(self, tty: bool) -> None:
+        super().__init__()
+        self.tty = tty
+
+    def isatty(self) -> bool:
+        return self.tty
+
+
+class TerminalStatusTests(unittest.TestCase):
+    def test_tty_status_tokens_are_coloured(self) -> None:
+        rendered = decorate_status_text(
+            "ok      runtime:root\nstatus=ready\nERR: failed\n",
+            enabled=True,
+        )
+
+        self.assertIn("\033[32mok\033[0m", rendered)
+        self.assertIn("status=\033[32mready\033[0m", rendered)
+        self.assertIn("\033[31mERR:\033[0m", rendered)
+
+    def test_no_color_disables_terminal_colours(self) -> None:
+        stream = _Stream(True)
+        with patch.dict(os.environ, {"NO_COLOR": ""}):
+            self.assertFalse(colour_enabled(stream))
+
+    def test_non_tty_disables_terminal_colours(self) -> None:
+        self.assertFalse(colour_enabled(_Stream(False)))
+
+    def test_run_record_remains_plain(self) -> None:
+        terminal = _Stream(True)
+        record = io.StringIO()
+        tee = _TeeStream(StatusStream(terminal), record)
+
+        with patch.dict(os.environ, {"TERM": "xterm"}):
+            os.environ.pop("NO_COLOR", None)
+            tee.write("ok      runtime:root\nERR: failed\n")
+
+        self.assertIn("\033[32m", terminal.getvalue())
+        self.assertIn("\033[31m", terminal.getvalue())
+        self.assertNotIn("\033[", record.getvalue())
+        self.assertEqual(
+            record.getvalue(),
+            "ok      runtime:root\nERR: failed\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #163

## Summary

- apply a restrained shared palette to interactive status tokens and progress symbols
- keep redirected output, JSON and run records free of ANSI sequences
- respect `NO_COLOR` and add the global `--no-color` option
- retain plain status text so colour is never the only signal

## Verification

- `python3 -m unittest hyops.runtime.tests.test_terminal hyops.runtime.tests.test_progress hyops.setup.tests.test_command`
- `python3 -m unittest discover -s hyops -p 'test_*.py'`
