### PR TITLE
Pin hybridops.helper 0.1.8

### DIFF
--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -3,7 +3,7 @@ collections:
     version: "0.1.6"
 
   - name: hybridops.helper
-    version: "0.1.7"
+    version: "0.1.8"
 
   - name: hybridops.app
     version: "0.1.7"


### PR DESCRIPTION
Closes #165

## Summary
- update the helper collection pin from 0.1.7 to 0.1.8
- leave all other Galaxy dependencies unchanged

## Verification
- 165 Python tests
- installation quality checks