### PR TITLE
Use helper collection 0.1.8

### DIFF
--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -3,7 +3,7 @@ collections:
     version: "0.1.6"
 
   - name: hybridops.helper
-    version: "0.1.7"
+    version: "0.1.8"
 
   - name: hybridops.app
     version: "0.1.7"


### PR DESCRIPTION
Closes #170

Updates the released helper collection pin so new setup runs include guarded EVE-NG image downloads.

Checks:
- installed the complete pinned requirements into an isolated collection path
- confirmed `hybridops.helper:0.1.8` resolves from Galaxy
- `git diff --check`