### PR TITLE
Reuse existing Windows desktop shortcut

### DIFF
--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -79,6 +79,12 @@ grep -Fq 'test -e \"${HOME}/.hybridops/core\"' "${WINDOWS_INSTALLER}"
 grep -Fq 'Existing HybridOps.Core installation found.' "${WINDOWS_INSTALLER}"
 grep -Fq 'set "FORCE=true"' "${WINDOWS_INSTALLER}"
 grep -Fq "Copy-Item -Force -LiteralPath '%PAYLOAD_DIR%\hybridops.ico'" "${WINDOWS_INSTALLER}"
+grep -Fq "Test-Path -LiteralPath" "${WINDOWS_INSTALLER}"
+grep -Fq "set \"SHORTCUT_EXISTS=true\"" "${WINDOWS_INSTALLER}"
+if grep -Fq "Desktop shortcut updated:" "${WINDOWS_INSTALLER}"; then
+  echo "ERR: Windows update announces routine shortcut refresh" >&2
+  exit 1
+fi
 grep -Fq 'Create a HybridOps.Core desktop shortcut? [y/N]:' "${WINDOWS_INSTALLER}"
 grep -Fq 'set "WSL_SETUP_MARKER=%HYOPS_USER_DIR%\wsl-setup.pending"' "${WINDOWS_INSTALLER}"
 grep -Fq "Get-Process -Name 'wslsettings'" "${WINDOWS_INSTALLER}"

--- a/tools/install/windows/install-windows.cmd
+++ b/tools/install/windows/install-windows.cmd
@@ -310,7 +310,14 @@ if errorlevel 1 (
 echo.
 set "CREATE_SHORTCUT="
 set "SHORTCUT_CREATED=false"
-set /p "CREATE_SHORTCUT=Create a HybridOps.Core desktop shortcut? [y/N]: "
+set "SHORTCUT_EXISTS=false"
+powershell.exe -NoProfile -Command "$path = Join-Path ([Environment]::GetFolderPath('Desktop')) 'HybridOps.Core.lnk'; if (Test-Path -LiteralPath $path) { exit 0 }; exit 1"
+if not errorlevel 1 (
+  set "SHORTCUT_EXISTS=true"
+  set "CREATE_SHORTCUT=y"
+) else (
+  set /p "CREATE_SHORTCUT=Create a HybridOps.Core desktop shortcut? [y/N]: "
+)
 if /I "!CREATE_SHORTCUT!"=="y" (
   set "LAUNCHER_DIR=%HYOPS_USER_DIR%"
   set "LAUNCHER=!LAUNCHER_DIR!\Open HybridOps.cmd"
@@ -326,7 +333,9 @@ if /I "!CREATE_SHORTCUT!"=="y" (
     echo WARN: unable to create the HybridOps.Core desktop shortcut.
   ) else (
     set "SHORTCUT_CREATED=true"
-    echo Desktop shortcut created: HybridOps.Core
+    if not "!SHORTCUT_EXISTS!"=="true" (
+      echo Desktop shortcut created: HybridOps.Core
+    )
   )
 )
 


### PR DESCRIPTION
Closes #172

The Windows installer now detects an existing HybridOps.Core desktop shortcut and refreshes it without asking the creation question again. New installations retain the opt-in prompt.

Checks:
- `bash tools/ci/check-install.sh`
- `git diff --check`