### PR TITLE
Recover local backend state after interrupted summary write

### DIFF
--- a/hyops/drivers/iac/terragrunt/_internal/workspace_binding.py
+++ b/hyops/drivers/iac/terragrunt/_internal/workspace_binding.py
@@ -7,11 +7,30 @@ maintainer: HybridOps.Tech
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import re
 from typing import Any
 
 from hyops.runtime.module_state import module_state_path, read_module_state
+
+
+def _valid_local_terraform_state(
+    state_root: Path,
+    module_ref: str,
+    state_instance: str | None,
+) -> tuple[bool, Path]:
+    identity = str(module_ref or "").strip()
+    instance = str(state_instance or "").strip()
+    if instance:
+        identity = f"{identity}#{instance}"
+    module_id = identity.replace("/", "__").replace("#", "__")
+    state_path = Path(state_root) / "terraform" / f"{module_id}.tfstate"
+    try:
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False, state_path
+    return isinstance(payload, dict) and isinstance(payload.get("version"), int), state_path
 
 
 def build_backend_binding(
@@ -160,6 +179,18 @@ def check_backend_binding_drift(
     try:
         prior = read_module_state(state_root, module_ref, state_instance=state_instance)
     except Exception as exc:
+        current_mode = str(current_binding.get("mode") or "").strip().lower()
+        local_state_ok, local_state_path = _valid_local_terraform_state(
+            state_root,
+            module_ref,
+            state_instance,
+        )
+        if current_mode == "local" and local_state_ok:
+            return "", (
+                "backend binding guard found an unreadable HybridOps module-state summary, "
+                f"but the local Terraform state is valid at {local_state_path}. "
+                "The next successful apply will rebuild the summary."
+            )
         return (
             f"backend binding guard failed to read module state: {state_path} ({exc})",
             "",

--- a/hyops/drivers/iac/terragrunt/tests/test_workspace_binding.py
+++ b/hyops/drivers/iac/terragrunt/tests/test_workspace_binding.py
@@ -1,0 +1,80 @@
+"""Backend binding recovery after an interrupted local state-summary write."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from hyops.drivers.iac.terragrunt._internal.workspace_binding import (
+    check_backend_binding_drift,
+)
+from hyops.runtime.module_state import module_state_path
+
+
+class LocalBackendBindingRecoveryTests(unittest.TestCase):
+    def test_valid_terraform_state_allows_summary_rebuild(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp)
+            summary = module_state_path(
+                state_root,
+                "platform/gcp/lab-network",
+                state_instance="gcp_eve_ng_network",
+            )
+            summary.parent.mkdir(parents=True)
+            summary.write_text("", encoding="utf-8")
+            terraform_state = (
+                state_root
+                / "terraform"
+                / "platform__gcp__lab-network__gcp_eve_ng_network.tfstate"
+            )
+            terraform_state.parent.mkdir(parents=True)
+            terraform_state.write_text(
+                json.dumps({"version": 4, "serial": 1, "resources": []}),
+                encoding="utf-8",
+            )
+
+            error, warning = check_backend_binding_drift(
+                state_root=state_root,
+                module_ref="platform/gcp/lab-network",
+                state_instance="gcp_eve_ng_network",
+                current_binding={"mode": "local"},
+                allow_drift=False,
+            )
+
+        self.assertEqual(error, "")
+        self.assertIn("next successful apply will rebuild", warning)
+
+    def test_corrupt_terraform_state_keeps_guard_blocked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp)
+            summary = module_state_path(
+                state_root,
+                "platform/gcp/lab-network",
+                state_instance="gcp_eve_ng_network",
+            )
+            summary.parent.mkdir(parents=True)
+            summary.write_text("", encoding="utf-8")
+            terraform_state = (
+                state_root
+                / "terraform"
+                / "platform__gcp__lab-network__gcp_eve_ng_network.tfstate"
+            )
+            terraform_state.parent.mkdir(parents=True)
+            terraform_state.write_text("", encoding="utf-8")
+
+            error, warning = check_backend_binding_drift(
+                state_root=state_root,
+                module_ref="platform/gcp/lab-network",
+                state_instance="gcp_eve_ng_network",
+                current_binding={"mode": "local"},
+                allow_drift=False,
+            )
+
+        self.assertIn("failed to read module state", error)
+        self.assertEqual(warning, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #176

Allows a local backend apply to rebuild an unreadable HybridOps summary only when the corresponding Terraform state is valid. Remote backends and invalid state remain blocked.

Checks:
- `python3 -m unittest hyops.drivers.iac.terragrunt.tests.test_workspace_binding`
- `git diff --check`