### PR TITLE
Tighten blueprint payload install message

### DIFF
--- a/tools/install/lib/payload.sh
+++ b/tools/install/lib/payload.sh
@@ -8,7 +8,7 @@ hyops_install_copy_payload() {
   echo "[install] copying payload"
   mkdir -p "${APP_DIR}"
   cp -a "${SRC_ROOT}/." "${APP_DIR}/"
-  echo "[install] hardening shipped blueprint payload"
+  echo "[install] hardening blueprint payload"
   hyops_install_set_blueprint_payload_read_only "${APP_DIR}"
 }
 


### PR DESCRIPTION
## Summary

Use the concise blueprint payload message during installation.

## Validation

- `bash -n tools/install/lib/payload.sh`
- `bash tools/ci/check-install.sh`
- `git diff --check`