### PR TITLE
Restore archived EVE-NG labs after redeployment

### DIFF
--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -115,6 +115,21 @@ hyops blueprint deploy \
   --execute
 ```
 
+When a verified lab archive exists for the environment, an interactive deploy
+offers to restore it after the host is ready. For non-interactive recovery:
+
+```bash
+hyops blueprint deploy \
+  --env dev \
+  --ref gcp/eve-ng@v1 \
+  --execute \
+  --restore-labs
+```
+
+The restore verifies the recorded checksum and protects existing lab
+definitions. Add `--overwrite-labs` only when replacing existing definitions
+is intentional.
+
 Rebuild the blueprint-managed resources:
 
 ```bash

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -91,6 +91,20 @@ definitions before teardown, or destroy without an export. Direct interactive
 destroy uses the same choices. Automation must pass either
 `--archive-before-destroy` or `--skip-archive` with `--yes`.
 
+After redeployment, an interactive deploy offers to restore a verified archive.
+For non-interactive recovery:
+
+```bash
+hyops blueprint deploy \
+  --env dev \
+  --ref onprem/eve-ng@v1 \
+  --execute \
+  --restore-labs
+```
+
+The archive checksum is verified before restoration. Existing lab definitions
+are protected unless `--overwrite-labs` is also supplied.
+
 ## Default Shape
 
 The shipped blueprint provisions one VM:

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -367,6 +367,22 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Proceed without interactive confirmation when rerun/destructive risk signals are detected.",
     )
+    restore_choice = t.add_mutually_exclusive_group()
+    restore_choice.add_argument(
+        "--restore-labs",
+        action="store_true",
+        help="Restore the latest verified lab archive declared by the blueprint.",
+    )
+    restore_choice.add_argument(
+        "--skip-lab-restore",
+        action="store_true",
+        help="Deploy without restoring an available lab archive.",
+    )
+    t.add_argument(
+        "--overwrite-labs",
+        action="store_true",
+        help="Allow --restore-labs to replace existing lab definitions.",
+    )
     t.set_defaults(_handler=run_deploy)
 
     d = ssp.add_parser(
@@ -1047,6 +1063,114 @@ def run_access(ns) -> int:
         return OPERATOR_ERROR
 
 
+def _verified_lab_archive(
+    payload: dict[str, Any],
+    paths,
+) -> tuple[Path, str] | None:
+    lifecycle = payload.get("archive_before_destroy")
+    if not isinstance(lifecycle, dict) or not lifecycle:
+        return None
+
+    try:
+        state = read_module_state(
+            paths.state_dir,
+            lifecycle["module_ref"],
+            state_instance=lifecycle["state_instance"],
+        )
+    except FileNotFoundError:
+        return None
+    outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
+    archive_path = Path(
+        str(outputs.get("eveng_lab_archive_path") or "")
+    ).expanduser()
+    expected = str(outputs.get("eveng_lab_archive_sha256") or "").strip().lower()
+    if not archive_path.is_file() or not re.fullmatch(r"[0-9a-f]{64}", expected):
+        return None
+
+    digest = hashlib.sha256()
+    with archive_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    if digest.hexdigest() != expected:
+        raise ValueError(f"lab archive checksum verification failed: {archive_path}")
+    return archive_path.resolve(), expected
+
+
+def _select_lab_restore_mode(
+    ns,
+    payload: dict[str, Any],
+    paths,
+) -> tuple[str, tuple[Path, str] | None]:
+    lifecycle = payload.get("archive_before_destroy")
+    requested = bool(getattr(ns, "restore_labs", False))
+    skipped = bool(getattr(ns, "skip_lab_restore", False))
+    overwrite = bool(getattr(ns, "overwrite_labs", False))
+
+    if overwrite and not requested:
+        raise ValueError("--overwrite-labs requires --restore-labs")
+    if (requested or skipped) and not isinstance(lifecycle, dict):
+        raise ValueError("this blueprint does not declare a lab archive lifecycle")
+
+    archive = _verified_lab_archive(payload, paths)
+    if archive is None:
+        if requested:
+            raise ValueError("no verified lab archive is available for this environment")
+        return "none", None
+    if requested:
+        return "restore", archive
+    if skipped:
+        return "skip", archive
+    if bool(getattr(ns, "yes", False)) or bool(getattr(ns, "json", False)):
+        return "skip", archive
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return "skip", archive
+
+    print(f"lab archive available: {archive[0]}")
+    try:
+        answer = input("Restore archived labs? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return "skip", archive
+    return ("restore" if answer in {"y", "yes"} else "skip"), archive
+
+
+def _run_lab_restore(
+    ns,
+    payload: dict[str, Any],
+    paths,
+    archive: tuple[Path, str],
+) -> int:
+    lifecycle = payload["archive_before_destroy"]
+    archive_path, checksum = archive
+    restore_inputs = dict(lifecycle.get("inputs") or {})
+    restore_inputs.update(
+        {
+            "eveng_lab_archive_action": "restore",
+            "eveng_lab_archive_path": str(archive_path),
+            "eveng_lab_archive_expected_sha256": checksum,
+            "eveng_lab_archive_overwrite": bool(
+                getattr(ns, "overwrite_labs", False)
+            ),
+        }
+    )
+    restore_step = {
+        "id": "restore_archived_labs",
+        "module_ref": lifecycle["module_ref"],
+        "state_instance": lifecycle["state_instance"],
+        "action": "deploy",
+        "phase": "operations",
+        "with_deps": False,
+        "inputs": restore_inputs,
+    }
+    print(f"restoring lab archive: {archive_path}")
+    rc = int(run_step_module_command(restore_step, payload, ns, paths))
+    if rc != 0:
+        print("ERR: lab restore failed; deployed resources were retained")
+        return rc
+    print("lab restore: ok")
+    return 0
+
+
 def run_deploy(ns) -> int:
     try:
         payload = _resolve_and_validate(ns)
@@ -1374,6 +1498,52 @@ def run_deploy(ns) -> int:
         )
         if fail_fast:
             break
+
+    if not required_failures and not cancelled:
+        try:
+            restore_mode, lab_archive = _select_lab_restore_mode(
+                ns,
+                payload,
+                paths,
+            )
+        except (OSError, ValueError) as exc:
+            required_failures.append("restore_archived_labs")
+            step_results.append(
+                {
+                    "id": "restore_archived_labs",
+                    "module_ref": str(
+                        (payload.get("archive_before_destroy") or {}).get(
+                            "module_ref", ""
+                        )
+                    ),
+                    "action": "deploy",
+                    "phase": "operations",
+                    "optional": False,
+                    "status": "failed",
+                    "rc": OPERATOR_ERROR,
+                    "reason": str(exc),
+                }
+            )
+            print(f"ERR: lab restore preparation failed: {exc}")
+        else:
+            if restore_mode == "restore" and lab_archive is not None:
+                restore_rc = _run_lab_restore(ns, payload, paths, lab_archive)
+                restore_status = "ok" if restore_rc == 0 else "failed"
+                step_results.append(
+                    {
+                        "id": "restore_archived_labs",
+                        "module_ref": payload["archive_before_destroy"]["module_ref"],
+                        "action": "deploy",
+                        "phase": "operations",
+                        "optional": False,
+                        "status": restore_status,
+                        "rc": restore_rc,
+                    }
+                )
+                if restore_rc != 0:
+                    required_failures.append("restore_archived_labs")
+            elif restore_mode == "skip" and lab_archive is not None:
+                print("lab archive retained; deploy again with --restore-labs to restore it")
 
     final_status = "ok" if not required_failures else "failed"
     if cancelled:

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.blueprint.command import (
+    _run_lab_restore,
+    _select_lab_restore_mode,
+)
+
+
+def _namespace(**overrides):
+    values = {
+        "restore_labs": False,
+        "skip_lab_restore": False,
+        "overwrite_labs": False,
+        "yes": True,
+        "json": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _payload():
+    return {
+        "archive_before_destroy": {
+            "module_ref": "platform/linux/eve-ng-lab-archive",
+            "state_instance": "lab_archive",
+            "inputs": {
+                "inventory_state_ref": "platform/test/vm#lab_vm",
+                "eveng_lab_archive_action": "export",
+            },
+        }
+    }
+
+
+class BlueprintLabRestoreTest(TestCase):
+    def test_explicit_restore_uses_verified_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "labs.tar.gz"
+            archive.write_bytes(b"portable labs")
+            checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+            paths = SimpleNamespace(state_dir=Path(tmp) / "state")
+            state = {
+                "outputs": {
+                    "eveng_lab_archive_path": str(archive),
+                    "eveng_lab_archive_sha256": checksum,
+                }
+            }
+            with patch(
+                "hyops.blueprint.command.read_module_state",
+                return_value=state,
+            ):
+                mode, selected = _select_lab_restore_mode(
+                    _namespace(restore_labs=True),
+                    _payload(),
+                    paths,
+                )
+
+        self.assertEqual(mode, "restore")
+        self.assertEqual(selected, (archive.resolve(), checksum))
+
+    def test_explicit_restore_requires_an_archive(self):
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+        with patch(
+            "hyops.blueprint.command.read_module_state",
+            side_effect=FileNotFoundError,
+        ), self.assertRaisesRegex(ValueError, "no verified lab archive"):
+            _select_lab_restore_mode(
+                _namespace(restore_labs=True),
+                _payload(),
+                paths,
+            )
+
+    def test_checksum_mismatch_stops_restore(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "labs.tar.gz"
+            archive.write_bytes(b"changed")
+            paths = SimpleNamespace(state_dir=Path(tmp) / "state")
+            state = {
+                "outputs": {
+                    "eveng_lab_archive_path": str(archive),
+                    "eveng_lab_archive_sha256": "a" * 64,
+                }
+            }
+            with patch(
+                "hyops.blueprint.command.read_module_state",
+                return_value=state,
+            ), self.assertRaisesRegex(ValueError, "checksum verification failed"):
+                _select_lab_restore_mode(
+                    _namespace(restore_labs=True),
+                    _payload(),
+                    paths,
+                )
+
+    def test_restore_reuses_target_contract_and_protects_existing_labs(self):
+        archive = (Path("/tmp/labs.tar.gz"), "b" * 64)
+        with patch(
+            "hyops.blueprint.command.run_step_module_command",
+            return_value=0,
+        ) as command:
+            rc = _run_lab_restore(
+                _namespace(restore_labs=True),
+                _payload(),
+                SimpleNamespace(),
+                archive,
+            )
+
+        self.assertEqual(rc, 0)
+        step = command.call_args.args[0]
+        self.assertEqual(step["id"], "restore_archived_labs")
+        self.assertEqual(
+            step["inputs"]["inventory_state_ref"],
+            "platform/test/vm#lab_vm",
+        )
+        self.assertEqual(step["inputs"]["eveng_lab_archive_action"], "restore")
+        self.assertEqual(
+            step["inputs"]["eveng_lab_archive_expected_sha256"],
+            "b" * 64,
+        )
+        self.assertFalse(step["inputs"]["eveng_lab_archive_overwrite"])
+

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -15,3 +15,6 @@ artifacts/eveng/labs/eve-ng-labs.tar.gz
 Restore requires the archive path and its recorded SHA-256 checksum. Existing
 lab content is protected unless `eveng_lab_archive_overwrite` is enabled.
 
+EVE-NG blueprints use this contract directly. After a protected teardown, run
+the same blueprint deployment with `--restore-labs` to restore the latest
+verified archive for that environment.


### PR DESCRIPTION
Closes #190

## Summary

- detect the latest environment-scoped EVE-NG lab archive after deployment
- verify the recorded checksum before restoration
- add guarded interactive and non-interactive restore paths
- protect existing lab definitions unless overwrite is explicit
- document the portable archive boundary

## Validation

- `python3 -m unittest discover -s hyops -p 'test_*.py'` (177 tests)\n- `bash tools/ci/check-install.sh`\n- `python3 -m hyops.cli blueprint validate --ref gcp/eve-ng@v1`\n- `python3 -m hyops.cli blueprint validate --ref onprem/eve-ng@v1`\n- `git diff --check`