### PR TITLE
Restore archived EVE-NG node state

### DIFF
--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -44,6 +44,7 @@ archive_before_destroy:
     ssh_private_key_file: "~/.ssh/id_ed25519"
     ssh_access_mode: "gcp-iap"
     eveng_lab_archive_action: "export"
+    eveng_lab_archive_include_node_state: true
 
 steps:
   - id: gcp_eve_ng_network

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -46,6 +46,7 @@ archive_before_destroy:
     become: true
     become_user: "root"
     eveng_lab_archive_action: "export"
+    eveng_lab_archive_include_node_state: true
 
 steps:
   - id: template_image_jammy

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1066,7 +1066,7 @@ def run_access(ns) -> int:
 def _verified_lab_archive(
     payload: dict[str, Any],
     paths,
-) -> tuple[Path, str] | None:
+) -> tuple[Path, str, Path | None, str] | None:
     lifecycle = payload.get("archive_before_destroy")
     if not isinstance(lifecycle, dict) or not lifecycle:
         return None
@@ -1093,14 +1093,38 @@ def _verified_lab_archive(
             digest.update(chunk)
     if digest.hexdigest() != expected:
         raise ValueError(f"lab archive checksum verification failed: {archive_path}")
-    return archive_path.resolve(), expected
+
+    node_archive: Path | None = None
+    node_checksum = ""
+    if bool(outputs.get("eveng_lab_archive_node_state_included", False)):
+        candidate = Path(
+            str(outputs.get("eveng_lab_archive_node_state_archive_path") or "")
+        ).expanduser()
+        candidate_checksum = str(
+            outputs.get("eveng_lab_archive_node_state_sha256") or ""
+        ).strip().lower()
+        if not candidate.is_file() or not re.fullmatch(
+            r"[0-9a-f]{64}", candidate_checksum
+        ):
+            raise ValueError("node-state archive is missing or unverifiable")
+        node_digest = hashlib.sha256()
+        with candidate.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                node_digest.update(chunk)
+        if node_digest.hexdigest() != candidate_checksum:
+            raise ValueError(
+                f"node-state archive checksum verification failed: {candidate}"
+            )
+        node_archive = candidate.resolve()
+        node_checksum = candidate_checksum
+    return archive_path.resolve(), expected, node_archive, node_checksum
 
 
 def _select_lab_restore_mode(
     ns,
     payload: dict[str, Any],
     paths,
-) -> tuple[str, tuple[Path, str] | None]:
+) -> tuple[str, tuple[Path, str, Path | None, str] | None]:
     lifecycle = payload.get("archive_before_destroy")
     requested = bool(getattr(ns, "restore_labs", False))
     skipped = bool(getattr(ns, "skip_lab_restore", False))
@@ -1126,6 +1150,8 @@ def _select_lab_restore_mode(
         return "skip", archive
 
     print(f"lab archive available: {archive[0]}")
+    if archive[2] is not None:
+        print(f"stopped node state available: {archive[2]}")
     try:
         answer = input("Restore archived labs? [y/N]: ").strip().lower()
     except (EOFError, KeyboardInterrupt):
@@ -1138,10 +1164,10 @@ def _run_lab_restore(
     ns,
     payload: dict[str, Any],
     paths,
-    archive: tuple[Path, str],
+    archive: tuple[Path, str, Path | None, str],
 ) -> int:
     lifecycle = payload["archive_before_destroy"]
-    archive_path, checksum = archive
+    archive_path, checksum, node_archive_path, node_checksum = archive
     restore_inputs = dict(lifecycle.get("inputs") or {})
     restore_inputs.update(
         {
@@ -1153,6 +1179,14 @@ def _run_lab_restore(
             ),
         }
     )
+    if node_archive_path is not None:
+        restore_inputs.update(
+            {
+                "eveng_lab_archive_restore_node_state": True,
+                "eveng_lab_archive_node_state_path": str(node_archive_path),
+                "eveng_lab_archive_node_state_expected_sha256": node_checksum,
+            }
+        )
     restore_step = {
         "id": "restore_archived_labs",
         "module_ref": lifecycle["module_ref"],
@@ -1681,6 +1715,31 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         return OPERATOR_ERROR
     print(f"lab archive: {archive_path}")
     print(f"sha256: {actual}")
+    if bool(outputs.get("eveng_lab_archive_node_state_included", False)):
+        node_archive_path = Path(
+            str(outputs.get("eveng_lab_archive_node_state_archive_path") or "")
+        ).expanduser()
+        node_expected = str(
+            outputs.get("eveng_lab_archive_node_state_sha256") or ""
+        ).strip().lower()
+        if not node_archive_path.is_file() or not re.fullmatch(
+            r"[0-9a-f]{64}", node_expected
+        ):
+            print("ERR: node-state archive is missing; no resources were destroyed")
+            return OPERATOR_ERROR
+        node_digest = hashlib.sha256()
+        with node_archive_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                node_digest.update(chunk)
+        node_actual = node_digest.hexdigest()
+        if node_actual != node_expected:
+            print(
+                "ERR: node-state archive checksum verification failed; "
+                "no resources were destroyed"
+            )
+            return OPERATOR_ERROR
+        print(f"stopped node state: {node_archive_path}")
+        print(f"sha256: {node_actual}")
     return 0
 
 

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -62,7 +62,7 @@ class BlueprintLabRestoreTest(TestCase):
                 )
 
         self.assertEqual(mode, "restore")
-        self.assertEqual(selected, (archive.resolve(), checksum))
+        self.assertEqual(selected, (archive.resolve(), checksum, None, ""))
 
     def test_explicit_restore_requires_an_archive(self):
         paths = SimpleNamespace(state_dir=Path("/tmp/state"))
@@ -98,7 +98,7 @@ class BlueprintLabRestoreTest(TestCase):
                 )
 
     def test_restore_reuses_target_contract_and_protects_existing_labs(self):
-        archive = (Path("/tmp/labs.tar.gz"), "b" * 64)
+        archive = (Path("/tmp/labs.tar.gz"), "b" * 64, None, "")
         with patch(
             "hyops.blueprint.command.run_step_module_command",
             return_value=0,
@@ -124,3 +124,32 @@ class BlueprintLabRestoreTest(TestCase):
         )
         self.assertFalse(step["inputs"]["eveng_lab_archive_overwrite"])
 
+    def test_restore_includes_verified_node_state(self):
+        archive = (
+            Path("/tmp/labs.tar.gz"),
+            "b" * 64,
+            Path("/tmp/labs.tar.gz.node-state.tar.gz"),
+            "c" * 64,
+        )
+        with patch(
+            "hyops.blueprint.command.run_step_module_command",
+            return_value=0,
+        ) as command:
+            rc = _run_lab_restore(
+                _namespace(restore_labs=True),
+                _payload(),
+                SimpleNamespace(),
+                archive,
+            )
+
+        self.assertEqual(rc, 0)
+        inputs = command.call_args.args[0]["inputs"]
+        self.assertTrue(inputs["eveng_lab_archive_restore_node_state"])
+        self.assertEqual(
+            inputs["eveng_lab_archive_node_state_path"],
+            "/tmp/labs.tar.gz.node-state.tar.gz",
+        )
+        self.assertEqual(
+            inputs["eveng_lab_archive_node_state_expected_sha256"],
+            "c" * 64,
+        )

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -82,6 +82,52 @@ def validate(inputs: dict[str, Any]) -> None:
             )
     if not isinstance(data.get("eveng_lab_archive_overwrite"), bool):
         raise ValueError("inputs.eveng_lab_archive_overwrite must be a boolean")
+    include_node_state = data.get("eveng_lab_archive_include_node_state")
+    restore_node_state = data.get("eveng_lab_archive_restore_node_state")
+    if not isinstance(include_node_state, bool):
+        raise ValueError(
+            "inputs.eveng_lab_archive_include_node_state must be a boolean"
+        )
+    if not isinstance(restore_node_state, bool):
+        raise ValueError(
+            "inputs.eveng_lab_archive_restore_node_state must be a boolean"
+        )
+    node_state_root = require_non_empty_str(
+        data.get("eveng_lab_archive_node_state_root"),
+        "inputs.eveng_lab_archive_node_state_root",
+    )
+    if not node_state_root.startswith("/"):
+        raise ValueError(
+            "inputs.eveng_lab_archive_node_state_root must be an absolute path"
+        )
+    require_non_empty_str(
+        data.get("eveng_lab_archive_qemu_img"),
+        "inputs.eveng_lab_archive_qemu_img",
+    )
+    if action == "export" and include_node_state and data.get(
+        "eveng_lab_archive_folders"
+    ):
+        raise ValueError(
+            "inputs.eveng_lab_archive_folders must be empty when node state is included"
+        )
+    if action == "restore" and restore_node_state:
+        node_state_path = require_non_empty_str(
+            data.get("eveng_lab_archive_node_state_path"),
+            "inputs.eveng_lab_archive_node_state_path",
+        )
+        if not node_state_path.startswith("/"):
+            raise ValueError(
+                "inputs.eveng_lab_archive_node_state_path must be an absolute path"
+            )
+        node_state_checksum = require_non_empty_str(
+            data.get("eveng_lab_archive_node_state_expected_sha256"),
+            "inputs.eveng_lab_archive_node_state_expected_sha256",
+        )
+        if not _SHA256_RE.fullmatch(node_state_checksum):
+            raise ValueError(
+                "inputs.eveng_lab_archive_node_state_expected_sha256 must contain "
+                "64 hexadecimal characters"
+            )
     if data.get("required_env_destroy") is not None:
         require_str_list(data.get("required_env_destroy"), "inputs.required_env_destroy")
     normalize_required_env(data.get("required_env"), "inputs.required_env")

--- a/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
@@ -53,6 +53,27 @@ class EveNgLabArchiveValidatorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate(inputs)
 
+    def test_node_state_export_requires_complete_lab_tree(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_include_node_state"] = True
+        inputs["eveng_lab_archive_folders"] = ["student"]
+        with self.assertRaisesRegex(ValueError, "must be empty"):
+            validate(inputs)
+
+    def test_node_state_restore_requires_companion_checksum(self) -> None:
+        inputs = valid_inputs()
+        inputs.update(
+            {
+                "eveng_lab_archive_action": "restore",
+                "eveng_lab_archive_path": "/tmp/labs.tar.gz",
+                "eveng_lab_archive_expected_sha256": "a" * 64,
+                "eveng_lab_archive_restore_node_state": True,
+                "eveng_lab_archive_node_state_path": "/tmp/nodes.tar.gz",
+            }
+        )
+        with self.assertRaises(ValueError):
+            validate(inputs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -50,6 +50,12 @@ inputs:
     eveng_lab_archive_expected_sha256: ""
     eveng_lab_archive_overwrite: false
     eveng_lab_archive_remote_dir: "/tmp/hyops-eveng-lab-archive"
+    eveng_lab_archive_include_node_state: false
+    eveng_lab_archive_restore_node_state: false
+    eveng_lab_archive_node_state_root: "/opt/unetlab/tmp"
+    eveng_lab_archive_node_state_path: ""
+    eveng_lab_archive_node_state_expected_sha256: ""
+    eveng_lab_archive_qemu_img: "/opt/qemu/bin/qemu-img"
 
 execution:
   driver: "config/ansible"
@@ -66,6 +72,10 @@ outputs:
     - eveng_lab_archive_sha256
     - eveng_lab_archive_created_at
     - eveng_lab_archive_folders
+    - eveng_lab_archive_node_state_included
+    - eveng_lab_archive_node_state_archive_path
+    - eveng_lab_archive_node_state_sha256
+    - eveng_lab_archive_node_state_files
 
 probes: []
 constraints: []

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -51,5 +51,13 @@
             'eveng_lab_archive_manifest_path': eveng_lab_archive_results.manifest_path | default(''),
             'eveng_lab_archive_sha256': eveng_lab_archive_results.sha256,
             'eveng_lab_archive_created_at': eveng_lab_archive_results.created_at | default(''),
-            'eveng_lab_archive_folders': eveng_lab_archive_results.folders
+            'eveng_lab_archive_folders': eveng_lab_archive_results.folders,
+            'eveng_lab_archive_node_state_included':
+              eveng_lab_archive_results.node_state_included | default(false),
+            'eveng_lab_archive_node_state_archive_path':
+              eveng_lab_archive_results.node_state_archive_path | default(''),
+            'eveng_lab_archive_node_state_sha256':
+              eveng_lab_archive_results.node_state_sha256 | default(''),
+            'eveng_lab_archive_node_state_files':
+              eveng_lab_archive_results.node_state_files | default(0)
           } | to_json }}


### PR DESCRIPTION
Closes #192.

Carries the helper node-state companion archive through the EVE-NG module contract and both teaching blueprints. Core verifies topology and node-state checksums before teardown, and passes verified companion data into guarded restore. The helper dependency remains pinned to 0.1.8.

Checks:
- 178 Python tests
- GCP EVE-NG blueprint validation
- Proxmox EVE-NG blueprint validation
