### PR TITLE
Remove percentages from verbose setup output

### DIFF
--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -593,20 +593,25 @@ def run(ns) -> int:
     ensure_layout(evidence_paths)
     evidence_dir = command_evidence_dir(evidence_paths.logs_dir, "setup", canonical_action)
     label = SETUP_LABELS.get(canonical_action, canonical_action)
+    stream_verbose = verbose_enabled()
     progress = ProgressDisplay(show_elapsed=False)
     total_phases = _setup_phase_count(canonical_action)
     phase_positions: dict[str, int] = {}
     progress.start(
         canonical_action,
         f"{label}  0%",
-        plain=f"setup={canonical_action} status=running progress=0%",
+        plain=(
+            f"setup={canonical_action} status=running"
+            if stream_verbose
+            else f"setup={canonical_action} status=running progress=0%"
+        ),
     )
     rc = run_streamed(
         argv,
         env=env,
         evidence_dir=evidence_dir,
         command=f"setup {canonical_action}",
-        stream_output=verbose_enabled(),
+        stream_output=stream_verbose,
         announce=False,
         line_callback=lambda line: _update_setup_progress(
             progress,
@@ -622,7 +627,11 @@ def run(ns) -> int:
             canonical_action,
             f"{label}  100%",
             "ok",
-            plain=f"setup={canonical_action} status=ok progress=100%",
+            plain=(
+                f"setup={canonical_action} status=ok"
+                if stream_verbose
+                else f"setup={canonical_action} status=ok progress=100%"
+            ),
         )
     else:
         completed = max(0, phase_positions.get(canonical_action, 1) - 1)
@@ -632,9 +641,16 @@ def run(ns) -> int:
             f"{label}  {failed_percent}%",
             "cancelled" if rc == CANCELLED else "failed",
             plain=(
-                f"setup={canonical_action} "
-                f"status={'cancelled' if rc == CANCELLED else 'failed'} "
-                f"progress={failed_percent}%"
+                (
+                    f"setup={canonical_action} "
+                    f"status={'cancelled' if rc == CANCELLED else 'failed'}"
+                )
+                if stream_verbose
+                else (
+                    f"setup={canonical_action} "
+                    f"status={'cancelled' if rc == CANCELLED else 'failed'} "
+                    f"progress={failed_percent}%"
+                )
             ),
         )
     print(f"run record: {evidence_dir}")

--- a/hyops/setup/tests/test_command.py
+++ b/hyops/setup/tests/test_command.py
@@ -260,6 +260,32 @@ class SetupCommandTests(unittest.TestCase):
             )
         self.assertEqual(rc, 0)
 
+    def test_verbose_setup_omits_percentage_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as runtime, patch(
+            "hyops.setup.command.run_streamed", return_value=0
+        ), patch(
+            "hyops.setup.command.command_evidence_dir",
+            return_value=Path(runtime) / "run-record",
+        ):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                rc = main(
+                    [
+                        "setup",
+                        "galaxy",
+                        "--root",
+                        str(REPO_ROOT),
+                        "--runtime-root",
+                        runtime,
+                        "--verbose",
+                    ]
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertIn("setup=galaxy status=running", output.getvalue())
+        self.assertIn("setup=galaxy status=ok", output.getvalue())
+        self.assertNotIn("progress=", output.getvalue())
+
     def test_individual_base_setup_elevates_automatically_on_linux(self) -> None:
         with tempfile.TemporaryDirectory() as runtime, patch(
             "hyops.setup.command.run_streamed", return_value=0


### PR DESCRIPTION
Closes #196.

Verbose setup now reports running, streamed phase output, and the final status without the concise mode percentage. Normal interactive setup retains its spinner and percentage display.

Checks:
- 15 setup command tests
- Python compile check
