### PR TITLE
Explain GCP zonal capacity failures

### DIFF
--- a/hyops/drivers/iac/terragrunt/_internal/execution.py
+++ b/hyops/drivers/iac/terragrunt/_internal/execution.py
@@ -4,11 +4,64 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 from pathlib import Path
 from typing import Any
 
 from hyops.runtime.coerce import as_argv
 from .proc import run_capture_with_policy
+
+
+_GCP_CAPACITY_MARKERS = (
+    "does not have enough resources available",
+    "zone_resource_pool_exhausted",
+    "resource pool exhausted",
+)
+
+
+def translate_gcp_capacity_error(
+    *,
+    command_name: str,
+    stdout: str,
+    stderr: str,
+    env: dict[str, str],
+) -> str:
+    """Return operator guidance for a GCP zonal capacity failure."""
+    if command_name != "apply":
+        return ""
+
+    combined = f"{stderr}\n{stdout}"
+    lowered = combined.lower()
+    if not any(marker in lowered for marker in _GCP_CAPACITY_MARKERS):
+        return ""
+
+    zone_match = re.search(r"/zones/([a-z0-9-]+)", combined, flags=re.IGNORECASE)
+    if zone_match is None:
+        zone_match = re.search(
+            r"\b(?:in|the)\s+(?:the\s+)?([a-z]+-[a-z0-9]+-[a-z])\s+zone\b",
+            combined,
+            flags=re.IGNORECASE,
+        )
+    zone = str(zone_match.group(1) if zone_match else "").strip()
+
+    machine_match = re.search(
+        r"\b([a-z][a-z0-9-]+)\s+VM instance is currently unavailable\b",
+        combined,
+        flags=re.IGNORECASE,
+    )
+    machine_type = str(machine_match.group(1) if machine_match else "").strip()
+
+    location = f" in {zone}" if zone else ""
+    request = f" for {machine_type}" if machine_type else ""
+    env_name = str(env.get("HYOPS_ENV") or "").strip() or "<env>"
+    init_command = f"hyops init gcp --env {shlex.quote(env_name)} --force"
+
+    return (
+        f"GCP compute capacity is temporarily unavailable{location}{request}. "
+        "The requested VM was not created.\n"
+        f"hint: run `{init_command}`, choose a different compute location, "
+        "then run the blueprint deploy command again."
+    )
 
 
 def resolve_terragrunt_config(profile: dict[str, Any]) -> dict[str, Any]:
@@ -120,6 +173,14 @@ def run_terragrunt_operation(
         stream=True,
     )
     if r_exec.rc != 0:
+        capacity_error = translate_gcp_capacity_error(
+            command_name=command_name,
+            stdout=str(r_exec.stdout or ""),
+            stderr=str(r_exec.stderr or ""),
+            env=env,
+        )
+        if capacity_error:
+            return {}, capacity_error
         return {}, exec_error
 
     outputs: dict[str, Any] = {}

--- a/hyops/drivers/iac/terragrunt/tests/test_execution.py
+++ b/hyops/drivers/iac/terragrunt/tests/test_execution.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+from hyops.drivers.iac.terragrunt._internal.execution import translate_gcp_capacity_error
+
+
+class GcpCapacityErrorTest(TestCase):
+    def test_translates_zonal_capacity_failure(self):
+        stderr = (
+            "The zone 'projects/student-project/zones/europe-west2-a' does not "
+            "have enough resources available to fulfill the request.\n"
+            "A n2-standard-8 VM instance is currently unavailable in the "
+            "europe-west2-a zone."
+        )
+
+        message = translate_gcp_capacity_error(
+            command_name="apply",
+            stdout="",
+            stderr=stderr,
+            env={"HYOPS_ENV": "demo-lab"},
+        )
+
+        self.assertIn("temporarily unavailable in europe-west2-a", message)
+        self.assertIn("for n2-standard-8", message)
+        self.assertIn("The requested VM was not created.", message)
+        self.assertIn("hyops init gcp --env demo-lab --force", message)
+        self.assertIn("choose a different compute location", message)
+
+    def test_ignores_unrelated_provider_failure(self):
+        message = translate_gcp_capacity_error(
+            command_name="apply",
+            stdout="",
+            stderr="Permission denied while creating the instance.",
+            env={"HYOPS_ENV": "demo-lab"},
+        )
+
+        self.assertEqual(message, "")
+
+    def test_ignores_capacity_text_during_destroy(self):
+        message = translate_gcp_capacity_error(
+            command_name="destroy",
+            stdout="",
+            stderr="ZONE_RESOURCE_POOL_EXHAUSTED",
+            env={"HYOPS_ENV": "demo-lab"},
+        )
+
+        self.assertEqual(message, "")


### PR DESCRIPTION
## Summary

- recognise GCP zonal capacity exhaustion during apply
- report the affected zone and machine type when available
- provide an environment-specific command for choosing another compute location
- preserve the existing provider run record and avoid automatic placement changes

Closes #198

## Verification

- `bash tools/ci/check-python.sh`
- `bash tools/ci/check-ruff.sh`
- `git diff --check`