### PR TITLE
Add readable stage summaries to blueprint output

### DIFF
--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -8,6 +8,7 @@ metadata:
   title: "GCP EVE-NG Host"
   description: "Provision a single nested-virtualization-capable GCP VM and configure EVE-NG over IAP."
   outcome: "A private EVE-NG host exists in GCP and is configured for governed training and network simulation use."
+  ready_message: "EVE-NG network emulation lab ready"
 
 policy:
   fail_fast: true
@@ -49,6 +50,9 @@ archive_before_destroy:
 steps:
   - id: gcp_eve_ng_network
     module_ref: "platform/gcp/lab-network"
+    presentation:
+      label: "Private network"
+      success: "ready"
     execution_profile: "gcp-local@v1.0"
     state_instance: "gcp_eve_ng_network"
     action: "deploy"
@@ -65,6 +69,9 @@ steps:
 
   - id: gcp_eve_ng_vm
     module_ref: "platform/gcp/platform-vm"
+    presentation:
+      label: "EVE-NG host"
+      success: "ready"
     execution_profile: "gcp-local@v1.0"
     state_instance: "gcp_eve_ng_vm"
     action: "deploy"
@@ -112,6 +119,9 @@ steps:
 
   - id: gcp_eve_ng_config
     module_ref: "platform/linux/eve-ng"
+    presentation:
+      label: "Guest networking"
+      success: "configured"
     state_instance: "gcp_eve_ng_config"
     action: "deploy"
     phase: "operations"
@@ -136,6 +146,15 @@ steps:
 
   - id: gcp_eve_ng_images
     module_ref: "platform/linux/eve-ng-images"
+    presentation:
+      label: "Lab images"
+      success: "ready"
+      items_label: "images"
+      items:
+        - "Alpine Linux"
+        - "NETem"
+        - "Tiny Core Linux"
+        - "Ubuntu Server"
     state_instance: "gcp_eve_ng_images"
     action: "deploy"
     phase: "operations"
@@ -202,6 +221,14 @@ steps:
 
   - id: gcp_eve_ng_healthcheck
     module_ref: "platform/linux/eve-ng-healthcheck"
+    presentation:
+      label: "EVE-NG health checks"
+      items_label: "checks"
+      items:
+        - "services"
+        - "database"
+        - "API"
+        - "KVM"
     state_instance: "gcp_eve_ng_healthcheck"
     action: "deploy"
     phase: "operations"

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -8,6 +8,7 @@ metadata:
   title: "On-Prem EVE-NG Platform Stack"
   description: "Build a Jammy template image (if needed), provision a standalone EVE-NG VM on the Proxmox uplink, then configure EVE-NG."
   outcome: "EVE-NG is installed and reachable."
+  ready_message: "EVE-NG network emulation lab ready"
 
 policy:
   fail_fast: true
@@ -51,6 +52,9 @@ archive_before_destroy:
 steps:
   - id: template_image_jammy
     module_ref: "core/onprem/template-image"
+    presentation:
+      label: "Ubuntu template"
+      success: "ready"
     state_instance: "template_image_ubuntu_22_04"
     action: "deploy"
     phase: "bootstrap"
@@ -66,6 +70,9 @@ steps:
 
   - id: eve_ng_vm
     module_ref: "platform/onprem/platform-vm"
+    presentation:
+      label: "EVE-NG host"
+      success: "ready"
     state_instance: "eve_ng_vm"
     action: "deploy"
     phase: "bootstrap"
@@ -92,6 +99,9 @@ steps:
 
   - id: eve_ng_config
     module_ref: "platform/linux/eve-ng"
+    presentation:
+      label: "Guest networking"
+      success: "configured"
     action: "deploy"
     phase: "operations"
     with_deps: false
@@ -114,6 +124,15 @@ steps:
 
   - id: eve_ng_images
     module_ref: "platform/linux/eve-ng-images"
+    presentation:
+      label: "Lab images"
+      success: "ready"
+      items_label: "images"
+      items:
+        - "Alpine Linux"
+        - "NETem"
+        - "Tiny Core Linux"
+        - "Ubuntu Server"
     state_instance: "eve_ng_images"
     action: "deploy"
     phase: "operations"
@@ -153,6 +172,14 @@ steps:
 
   - id: eve_ng_healthcheck
     module_ref: "platform/linux/eve-ng-healthcheck"
+    presentation:
+      label: "EVE-NG health checks"
+      items_label: "checks"
+      items:
+        - "services"
+        - "database"
+        - "API"
+        - "KVM"
     state_instance: "eve_ng_healthcheck"
     action: "deploy"
     phase: "operations"

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -104,6 +104,119 @@ def _cancelled_deploy_actions(ns, payload: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def _step_presentation(
+    step: dict[str, Any],
+    *,
+    state_dir: Path,
+    progress_after: int,
+) -> tuple[str, str, str]:
+    presentation = step.get("presentation")
+    if not isinstance(presentation, dict):
+        presentation = {}
+
+    label = str(presentation.get("label") or step["id"]).strip()
+    details: list[str] = []
+    success = str(presentation.get("success") or "").strip()
+    if success:
+        details.append(success)
+
+    try:
+        state = read_module_state(state_dir, step_state_ref(step))
+    except (FileNotFoundError, OSError, ValueError):
+        state = {}
+    outputs = state.get("outputs")
+    if not isinstance(outputs, dict):
+        outputs = {}
+
+    image_count = outputs.get("eveng_images_requested_count")
+    if isinstance(image_count, int) and image_count >= 0:
+        details.append(f"{image_count} images")
+
+    health_status = str(outputs.get("eveng_health_status") or "").strip().lower()
+    if health_status and health_status not in details:
+        details.append(health_status)
+
+    details.append(f"overall {progress_after}%")
+
+    items = presentation.get("items")
+    item_line = ""
+    if isinstance(items, list) and items:
+        item_values = [str(item).strip() for item in items if str(item).strip()]
+        if item_values:
+            items_label = str(presentation.get("items_label") or "includes").strip()
+            item_line = f"  {items_label}: {', '.join(item_values)}"
+
+    return label, ", ".join(details), item_line
+
+
+def _step_display_label(step: dict[str, Any]) -> str:
+    presentation = step.get("presentation")
+    if isinstance(presentation, dict):
+        label = str(presentation.get("label") or "").strip()
+        if label:
+            return label
+
+    step_id = str(step.get("id") or "").strip()
+    words = [word for word in re.split(r"[_-]+", step_id) if word]
+    names = {
+        "api": "API",
+        "cloudsql": "Cloud SQL",
+        "config": "configuration",
+        "day2": "Day 2",
+        "dns": "DNS",
+        "dr": "DR",
+        "gcp": "GCP",
+        "gke": "GKE",
+        "gitops": "GitOps",
+        "gns3": "GNS3",
+        "gsm": "GSM",
+        "ha": "HA",
+        "healthcheck": "health checks",
+        "iap": "IAP",
+        "ip": "IP",
+        "ipam": "IPAM",
+        "kvm": "KVM",
+        "netbox": "NetBox",
+        "onprem": "on-premises",
+        "ops": "operations",
+        "pg": "PostgreSQL",
+        "pgcore": "PostgreSQL core",
+        "postgres": "PostgreSQL",
+        "postgresql": "PostgreSQL",
+        "powerdns": "PowerDNS",
+        "repo": "repository",
+        "rke2": "RKE2",
+        "rocky9": "Rocky Linux 9",
+        "sdn": "SDN",
+        "sql": "SQL",
+        "vm": "VM",
+        "vms": "VMs",
+        "vpn": "VPN",
+        "vyos": "VyOS",
+        "wan": "WAN",
+    }
+    rendered = [names.get(word.lower(), word.capitalize()) for word in words]
+
+    for index in range(len(rendered) - 1):
+        if rendered[index] == "Eve" and rendered[index + 1] == "Ng":
+            rendered[index : index + 2] = ["EVE-NG"]
+            break
+    for index in range(len(rendered) - 2):
+        if rendered[index : index + 3] == ["Ubuntu", "22", "04"]:
+            rendered[index : index + 3] = ["Ubuntu 22.04"]
+            break
+    return " ".join(rendered) or step_id
+
+
+def _destroy_preview_label(step: dict[str, Any], state_status: str) -> str:
+    label = _step_display_label(step)
+    if bool(step.get("retain_on_destroy", False)):
+        return f"{label} (retained)"
+    if state_status in {"absent", "destroyed", "missing"}:
+        return f"{label} (already absent)"
+    return label
+
+
 def _emit_plan(payload: dict[str, Any], *, json_mode: bool) -> None:
     if json_mode:
         print(
@@ -1337,8 +1450,11 @@ def run_deploy(ns) -> int:
         step = by_id[step_id]
         progress_before = int(((step_position - 1) * 100) / total_steps) if total_steps else 0
         progress_after = int((step_position * 100) / total_steps) if total_steps else 100
-        running_label = f"{step_id}  stage {step_position}/{total_steps}"
+        display_label = _step_display_label(step)
+        running_label = f"{display_label}  stage {step_position}/{total_steps}"
+        completed_label = display_label
         completed_detail = f"overall {progress_after}%"
+        item_line = ""
         base = {
             "id": step_id,
             "module_ref": step["module_ref"],
@@ -1372,16 +1488,23 @@ def run_deploy(ns) -> int:
             else:
                 verify_state_on_skip = bool(step.get("verify_state_on_skip", False))
                 if not verify_state_on_skip:
+                    skip_label, skip_detail, skip_item_line = _step_presentation(
+                        step,
+                        state_dir=paths.state_dir,
+                        progress_after=progress_after,
+                    )
                     result = dict(base)
                     result.update({"status": "skipped", "reason": "state-ok", "rc": 0})
                     step_results.append(result)
                     progress.finish(
                         step_id,
-                        step_id,
+                        skip_label,
                         "skipped",
                         plain=f"step={step_id} status=skipped reason=state-ok",
-                        detail=f"state-ok, {completed_detail}",
+                        detail=f"existing, {skip_detail}",
                     )
+                    if skip_item_line and progress.enabled:
+                        print(skip_item_line)
                     continue
 
                 try:
@@ -1394,16 +1517,25 @@ def run_deploy(ns) -> int:
                     detail = "state-ok"
                     if skip_detail:
                         detail = f"state-ok ({skip_detail})"
+                    presentation_label, presentation_detail, skip_item_line = (
+                        _step_presentation(
+                            step,
+                            state_dir=paths.state_dir,
+                            progress_after=progress_after,
+                        )
+                    )
                     result = dict(base)
                     result.update({"status": "skipped", "reason": detail, "rc": 0})
                     step_results.append(result)
                     progress.finish(
                         step_id,
-                        step_id,
+                        presentation_label,
                         "skipped",
                         plain=f"step={step_id} status=skipped reason={detail}",
-                        detail=f"{detail}, {completed_detail}",
+                        detail=f"existing, {presentation_detail}",
                     )
+                    if skip_item_line and progress.enabled:
+                        print(skip_item_line)
                     continue
 
                 if skip_status == "error":
@@ -1481,16 +1613,23 @@ def run_deploy(ns) -> int:
                 os.environ["HYOPS_PROGRESS_CHILD"] = previous_child
 
         if rc == 0:
+            completed_label, completed_detail, item_line = _step_presentation(
+                step,
+                state_dir=paths.state_dir,
+                progress_after=progress_after,
+            )
             result = dict(base)
             result.update({"status": "ok", "rc": 0})
             step_results.append(result)
             progress.finish(
                 step_id,
-                step_id,
+                completed_label,
                 "ok",
                 plain=f"step={step_id} status=ok progress={progress_after}%",
                 detail=completed_detail,
             )
+            if item_line and progress.enabled:
+                print(item_line)
             continue
 
         result = dict(base)
@@ -1601,6 +1740,17 @@ def run_deploy(ns) -> int:
     if json_mode:
         print(json.dumps(output, indent=2, sort_keys=True))
     else:
+        ready_message = str(
+            (payload.get("metadata") or {}).get("ready_message") or ""
+        ).strip()
+        if final_status == "ok" and ready_message and progress.enabled:
+            print()
+            progress.finish(
+                "blueprint-ready",
+                ready_message,
+                "ok",
+                plain=f"blueprint={payload['blueprint_ref']} status=ready",
+            )
         print(
             f"blueprint={payload['blueprint_ref']} mode={payload['mode']} "
             f"status={final_status} steps={len(step_results)}"
@@ -1775,7 +1925,12 @@ def run_destroy(ns) -> int:
             for step_id in destroy_order:
                 step = next(s for s in payload["steps"] if s["id"] == step_id)
                 action = "retain" if bool(step.get("retain_on_destroy", False)) else "destroy"
-                print(f"  - {step_id}: {action} {step['module_ref']}")
+                print(f"  - {_step_display_label(step)}: {action}")
+                if os.getenv("HYOPS_VERBOSE"):
+                    print(
+                        f"    id={step_id} module={step['module_ref']} "
+                        f"ref={step_state_ref(step)}"
+                    )
         return 0
 
     json_mode = bool(getattr(ns, "json", False))
@@ -1804,17 +1959,18 @@ def run_destroy(ns) -> int:
     )
 
     if not bool(getattr(ns, "yes", False)) and not json_mode:
-        print(f"WARN: blueprint destroy will tear down resources in env={env_name}.")
-        print("steps (reverse order):")
+        print(f"WARN: destroy resources in env={env_name}.")
+        print("resources:")
         for step_id in destroy_order:
             step = by_id[step_id]
             state_ref = step_state_ref(step)
             status = module_state_status(paths.state_dir, state_ref) or "missing"
-            action = "retain" if bool(step.get("retain_on_destroy", False)) else "destroy"
-            print(
-                f"  - {step_id}: {action} {step['module_ref']} "
-                f"(state={status} ref={state_ref})"
-            )
+            print(f"  - {_destroy_preview_label(step, status)}")
+            if os.getenv("HYOPS_VERBOSE"):
+                print(
+                    f"    id={step_id} module={step['module_ref']} "
+                    f"state={status} ref={state_ref}"
+                )
 
     try:
         archive_mode = _select_archive_destroy_mode(ns, payload, env_name)

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -343,6 +343,44 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             norm_token = normalize_state_instance(token)
             state_instance = norm_token or ""
 
+        presentation: dict[str, Any] = {}
+        raw_presentation = step.get("presentation")
+        if raw_presentation is not None:
+            presentation_map = as_mapping(
+                raw_presentation,
+                f"steps[{idx}].presentation",
+            )
+            allowed = {"label", "success", "items_label", "items"}
+            unknown = sorted(
+                str(key)
+                for key in presentation_map.keys()
+                if str(key) not in allowed
+            )
+            if unknown:
+                raise ValueError(
+                    f"steps[{idx}].presentation has unknown keys: "
+                    f"{', '.join(unknown)}"
+                )
+            for key in ("label", "success", "items_label"):
+                if presentation_map.get(key) is not None:
+                    presentation[key] = as_non_empty_string(
+                        presentation_map.get(key),
+                        f"steps[{idx}].presentation.{key}",
+                    )
+            raw_items = presentation_map.get("items")
+            if raw_items is not None:
+                if not isinstance(raw_items, list):
+                    raise ValueError(
+                        f"steps[{idx}].presentation.items must be a list"
+                    )
+                presentation["items"] = [
+                    as_non_empty_string(
+                        item,
+                        f"steps[{idx}].presentation.items[{item_idx}]",
+                    )
+                    for item_idx, item in enumerate(raw_items, start=1)
+                ]
+
         contracts: dict[str, Any] = {
             "addressing_mode": "static",
             "requires_module_state_ok": [],
@@ -421,6 +459,7 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 "inputs": inputs if isinstance(inputs, dict) else None,
                 "inputs_file": str(inputs_file).strip() if isinstance(inputs_file, str) else "",
                 "state_instance": state_instance,
+                "presentation": presentation,
                 "contracts": contracts,
             }
         )

--- a/hyops/blueprint/tests/test_gcp_eve_ng.py
+++ b/hyops/blueprint/tests/test_gcp_eve_ng.py
@@ -13,6 +13,10 @@ class GcpEveNgBlueprintTest(TestCase):
         validated = validate_blueprint(load_blueprint(path), path)
 
         self.assertTrue(validated["access"]["offer_destroy_on_close"])
+        self.assertEqual(
+            validated["metadata"]["ready_message"],
+            "EVE-NG network emulation lab ready",
+        )
 
         self.assertEqual(
             validated["order"],
@@ -41,5 +45,13 @@ class GcpEveNgBlueprintTest(TestCase):
             len(by_id["gcp_eve_ng_images"]["inputs"]["eveng_images_list"]), 4
         )
         self.assertEqual(
+            by_id["gcp_eve_ng_images"]["presentation"]["items"],
+            ["Alpine Linux", "NETem", "Tiny Core Linux", "Ubuntu Server"],
+        )
+        self.assertEqual(
             by_id["gcp_eve_ng_healthcheck"]["requires"], ["gcp_eve_ng_images"]
+        )
+        self.assertEqual(
+            by_id["gcp_eve_ng_healthcheck"]["presentation"]["label"],
+            "EVE-NG health checks",
         )

--- a/hyops/blueprint/tests/test_presentation.py
+++ b/hyops/blueprint/tests/test_presentation.py
@@ -1,0 +1,129 @@
+"""Tests for concise blueprint step presentation."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from hyops.blueprint.command import (
+    _destroy_preview_label,
+    _step_display_label,
+    _step_presentation,
+)
+from hyops.runtime.module_state import write_module_state
+
+
+class BlueprintPresentationTest(TestCase):
+    def test_destroy_preview_uses_readable_label(self):
+        step = {
+            "id": "gcp_eve_ng_healthcheck",
+            "presentation": {"label": "EVE-NG health checks"},
+        }
+
+        self.assertEqual(_step_display_label(step), "EVE-NG health checks")
+        self.assertEqual(
+            _destroy_preview_label(step, "ok"),
+            "EVE-NG health checks",
+        )
+
+    def test_undeclared_step_label_is_humanised(self):
+        self.assertEqual(
+            _step_display_label({"id": "gcp_wan_vpn_to_edge"}),
+            "GCP WAN VPN To Edge",
+        )
+        self.assertEqual(
+            _step_display_label({"id": "postgres_ha_vms"}),
+            "PostgreSQL HA VMs",
+        )
+        self.assertEqual(
+            _step_display_label({"id": "gns3_healthcheck"}),
+            "GNS3 health checks",
+        )
+        self.assertEqual(
+            _step_display_label({"id": "template_image_ubuntu_22_04"}),
+            "Template Image Ubuntu 22.04",
+        )
+
+    def test_destroy_preview_marks_retained_or_absent_resources(self):
+        retained = {
+            "id": "template",
+            "presentation": {"label": "Ubuntu template"},
+            "retain_on_destroy": True,
+        }
+        absent = {
+            "id": "network",
+            "presentation": {"label": "Private network"},
+        }
+
+        self.assertEqual(
+            _destroy_preview_label(retained, "ok"),
+            "Ubuntu template (retained)",
+        )
+        self.assertEqual(
+            _destroy_preview_label(absent, "destroyed"),
+            "Private network (already absent)",
+        )
+
+    def test_uses_published_image_count_and_declared_items(self):
+        step = {
+            "id": "images",
+            "module_ref": "platform/linux/eve-ng-images",
+            "state_instance": "images",
+            "presentation": {
+                "label": "Lab images",
+                "success": "ready",
+                "items_label": "images",
+                "items": ["Alpine Linux", "NETem"],
+            },
+        }
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp)
+            write_module_state(
+                state_dir,
+                step["module_ref"],
+                {
+                    "status": "ok",
+                    "outputs": {"eveng_images_requested_count": 2},
+                },
+                state_instance=step["state_instance"],
+            )
+
+            label, detail, item_line = _step_presentation(
+                step,
+                state_dir=state_dir,
+                progress_after=80,
+            )
+
+        self.assertEqual(label, "Lab images")
+        self.assertEqual(detail, "ready, 2 images, overall 80%")
+        self.assertEqual(item_line, "  images: Alpine Linux, NETem")
+
+    def test_uses_published_health_status(self):
+        step = {
+            "id": "health",
+            "module_ref": "platform/linux/eve-ng-healthcheck",
+            "state_instance": "health",
+            "presentation": {"label": "EVE-NG health checks"},
+        }
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp)
+            write_module_state(
+                state_dir,
+                step["module_ref"],
+                {
+                    "status": "ok",
+                    "outputs": {"eveng_health_status": "healthy"},
+                },
+                state_instance=step["state_instance"],
+            )
+
+            label, detail, item_line = _step_presentation(
+                step,
+                state_dir=state_dir,
+                progress_after=100,
+            )
+
+        self.assertEqual(label, "EVE-NG health checks")
+        self.assertEqual(detail, "healthy, overall 100%")
+        self.assertEqual(item_line, "")


### PR DESCRIPTION
## Summary

- add validated presentation metadata for blueprint steps
- provide readable fallback labels across all shipped and future blueprints
- show concise EVE-NG image and health summaries from published module state
- simplify destroy previews while keeping technical references behind `--verbose`
- retain stable identifiers in plain and structured output

Closes #202

## Verification

- validated 28 blueprints and 115 step labels
- `bash tools/ci/check-python.sh` (186 tests)
- `bash tools/ci/check-ruff.sh`
- `git diff --check`