### PR TITLE
Keep setup progress moving during long phases

### DIFF
--- a/hyops/runtime/progress.py
+++ b/hyops/runtime/progress.py
@@ -40,11 +40,36 @@ class ProgressDisplay:
     _labels: dict[str, str] = field(default_factory=dict)
     _stops: dict[str, threading.Event] = field(default_factory=dict)
     _threads: dict[str, threading.Thread] = field(default_factory=dict)
+    _percent_tracks: dict[str, dict[str, float | int | str]] = field(
+        default_factory=dict
+    )
+
+    def _advance_tracked_percent(
+        self,
+        key: str,
+        *,
+        now: float | None = None,
+    ) -> None:
+        tracked = self._percent_tracks.get(key)
+        if tracked is None:
+            return
+        current_time = time.monotonic() if now is None else now
+        last_advance = float(tracked["last_advance"])
+        interval_s = float(tracked["interval_s"])
+        current = int(tracked["current"])
+        ceiling = int(tracked["ceiling"])
+        if current >= ceiling or current_time - last_advance < interval_s:
+            return
+        current += 1
+        tracked["current"] = current
+        tracked["last_advance"] = current_time
+        self._labels[key] = f"{tracked['label']}  {current}%"
 
     def _animate(self, key: str, label: str, stopped: threading.Event) -> None:
         frames = ("|", "/", "-", "\\")
         frame = 0
         while not stopped.wait(0.2):
+            self._advance_tracked_percent(key)
             started = self._started.get(key, time.monotonic())
             current_label = self._labels.get(key, label)
             elapsed = f"  {_elapsed(started)}" if self.show_elapsed else ""
@@ -80,6 +105,29 @@ class ProgressDisplay:
         if self.enabled and key in self._started:
             self._labels[key] = label
 
+    def track_percent(
+        self,
+        key: str,
+        label: str,
+        *,
+        current: int,
+        ceiling: int,
+        interval_s: float = 5.0,
+    ) -> None:
+        """Advance an active percentage slowly without crossing its next boundary."""
+        if not self.enabled or key not in self._started:
+            return
+        bounded_current = max(0, min(99, int(current)))
+        bounded_ceiling = max(bounded_current, min(99, int(ceiling)))
+        self._percent_tracks[key] = {
+            "label": label,
+            "current": bounded_current,
+            "ceiling": bounded_ceiling,
+            "interval_s": max(0.1, float(interval_s)),
+            "last_advance": time.monotonic(),
+        }
+        self._labels[key] = f"{label}  {bounded_current}%"
+
     def finish(
         self,
         key: str,
@@ -91,6 +139,7 @@ class ProgressDisplay:
     ) -> None:
         started = self._started.pop(key, None)
         self._labels.pop(key, None)
+        self._percent_tracks.pop(key, None)
         if started is None:
             started = time.monotonic()
         if not self.enabled:

--- a/hyops/runtime/tests/test_progress.py
+++ b/hyops/runtime/tests/test_progress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import os
+import time
 import unittest
 from contextlib import redirect_stdout
 from unittest.mock import patch
@@ -87,6 +88,26 @@ class ProgressDisplayTests(unittest.TestCase):
                 "Base tools: Preparing system packages",
             )
             display.finish("base", "Base tools", "ok", plain="ignored")
+
+    def test_tracked_percentage_advances_without_crossing_boundary(self) -> None:
+        display = ProgressDisplay(enabled=True, show_elapsed=False)
+        display._started["galaxy"] = time.monotonic()
+        display._labels["galaxy"] = "Galaxy dependencies  43%"
+        display.track_percent(
+            "galaxy",
+            "Galaxy dependencies",
+            current=43,
+            ceiling=45,
+            interval_s=1,
+        )
+        tracked = display._percent_tracks["galaxy"]
+        first_tick = float(tracked["last_advance"]) + 1.1
+
+        display._advance_tracked_percent("galaxy", now=first_tick)
+        display._advance_tracked_percent("galaxy", now=first_tick + 1.1)
+        display._advance_tracked_percent("galaxy", now=first_tick + 2.2)
+
+        self.assertEqual(display._labels["galaxy"], "Galaxy dependencies  45%")
 
 
 if __name__ == "__main__":

--- a/hyops/setup/command.py
+++ b/hyops/setup/command.py
@@ -124,7 +124,26 @@ def _update_setup_progress(
                 phase_positions[step] = position
             started = completed_phases + max(0.5, position - 0.5)
             percent = min(99, int((started * 100) / max(1, total_phases)))
-            progress.update(step, f"{base_label}: {phase}  {percent}%")
+            label = f"{base_label}: {phase}"
+            progress.update(step, f"{label}  {percent}%")
+            next_boundary = min(
+                99,
+                max(
+                    percent,
+                    int(
+                        (completed_phases + max(1, position))
+                        * 100
+                        / max(1, total_phases)
+                    )
+                    - 1,
+                ),
+            )
+            progress.track_percent(
+                step,
+                label,
+                current=percent,
+                ceiling=next_boundary,
+            )
 
 
 def add_setup_subparser(sp: argparse._SubParsersAction) -> None:


### PR DESCRIPTION
## Summary

- advance interactive setup percentages gradually during long phases
- cap movement at the next confirmed phase boundary
- preserve deterministic verbose and non-interactive output

Closes #204

## Verification

- `bash tools/ci/check-python.sh` (187 tests)
- `bash tools/ci/check-ruff.sh`
- `git diff --check`