### PR TITLE
fix(cli): reduce blueprint output noise

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -27,7 +27,7 @@ from hyops.runtime.gcp import diagnose_project_billing
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import read_module_state, split_module_state_ref
 from hyops.runtime.paths import resolve_runtime_paths
-from hyops.runtime.progress import ProgressDisplay
+from hyops.runtime.progress import ProgressDisplay, verbose_enabled
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.source_roots import resolve_blueprints_root
 from hyops.runtime.storage import format_runtime_storage_error, require_runtime_writable
@@ -315,7 +315,7 @@ def _collect_deploy_risk_signals(payload: dict[str, Any], paths) -> list[dict[st
             )
             continue
 
-        if not status:
+        if not status or status in {"absent", "destroyed", "missing"}:
             continue
         if bool(step.get("skip_if_state_ok", False)) and status == "ok":
             # This step should self-skip and does not need confirmation noise.
@@ -344,16 +344,22 @@ def _confirm_deploy_if_needed(ns, payload: dict[str, Any], paths) -> int:
         return 0
 
     env_name = str(getattr(ns, "env", None) or getattr(paths.root, "name", "") or "").strip() or "default"
-    print(
-        f"WARN: blueprint deploy may update or replace existing resources in env={env_name}."
-    )
-    print("impact_signals:")
+    count = len(signals)
+    noun = "step" if count == 1 else "steps"
+    print(f"WARN: deploy may change {count} active blueprint {noun} in env={env_name}.")
+    print("steps:")
     for item in signals:
-        print(
-            "  - "
-            f"{item['id']}: {item['action']} {item['module_ref']} "
-            f"(state={item['state_status']} ref={item['state_ref']})"
+        step = next(
+            candidate
+            for candidate in payload.get("steps", [])
+            if str(candidate.get("id") or "") == item["id"]
         )
+        print(f"  - {_step_display_label(step)} (state={item['state_status']})")
+        if verbose_enabled():
+            print(
+                f"    id={item['id']} action={item['action']} "
+                f"module={item['module_ref']} ref={item['state_ref']}"
+            )
 
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         print("WARN: non-interactive session detected; proceeding without prompt (use --yes to silence).")
@@ -2205,14 +2211,16 @@ def run_rebuild(ns) -> int:
         f"blueprint={payload['blueprint_ref']} mode={payload['mode']} "
         f"rebuild_steps={len(payload['order'])}"
     )
-    print("destroy_order:")
-    for step_id in destroy_order:
-        step = next(s for s in payload["steps"] if s["id"] == step_id)
-        suffix = " (retained)" if bool(step.get("retain_on_destroy", False)) else ""
-        print(f"  - {step_id}{suffix}")
-    print("deploy_order:")
-    for step_id in payload["order"]:
-        print(f"  - {step_id}")
+    if not bool(getattr(ns, "execute", False)) or verbose_enabled():
+        print("destroy_order:")
+        for step_id in destroy_order:
+            step = next(s for s in payload["steps"] if s["id"] == step_id)
+            suffix = " (retained)" if bool(step.get("retain_on_destroy", False)) else ""
+            print(f"  - {_step_display_label(step)}{suffix}")
+        print("deploy_order:")
+        for step_id in payload["order"]:
+            step = next(s for s in payload["steps"] if s["id"] == step_id)
+            print(f"  - {_step_display_label(step)}")
 
     if not bool(getattr(ns, "execute", False)):
         return 0

--- a/hyops/blueprint/tests/test_presentation.py
+++ b/hyops/blueprint/tests/test_presentation.py
@@ -1,10 +1,14 @@
 """Tests for concise blueprint step presentation."""
 
+import io
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import patch
 
 from hyops.blueprint.command import (
+    _collect_deploy_risk_signals,
+    _confirm_deploy_if_needed,
     _destroy_preview_label,
     _step_display_label,
     _step_presentation,
@@ -13,6 +17,58 @@ from hyops.runtime.module_state import write_module_state
 
 
 class BlueprintPresentationTest(TestCase):
+    def test_destroyed_steps_do_not_trigger_deploy_risk_warning(self):
+        step = {
+            "id": "network",
+            "module_ref": "platform/gcp/lab-network",
+            "state_instance": "network",
+            "action": "deploy",
+        }
+        payload = {"steps": [step]}
+        paths = type("Paths", (), {"state_dir": Path("/tmp/state")})()
+
+        with patch(
+            "hyops.blueprint.command.module_state_status",
+            return_value="destroyed",
+        ):
+            self.assertEqual(_collect_deploy_risk_signals(payload, paths), [])
+
+    def test_active_deploy_warning_is_concise_by_default(self):
+        step = {
+            "id": "gcp_eve_ng_network",
+            "module_ref": "platform/gcp/lab-network",
+            "state_instance": "gcp_eve_ng_network",
+            "action": "deploy",
+            "presentation": {"label": "Private lab network"},
+        }
+        payload = {"steps": [step]}
+        paths = type(
+            "Paths",
+            (),
+            {"state_dir": Path("/tmp/state"), "root": Path("/tmp/demo-lab")},
+        )()
+        ns = type("Namespace", (), {"yes": False, "json": False, "env": "demo-lab"})()
+        output = io.StringIO()
+
+        with (
+            patch(
+                "hyops.blueprint.command.module_state_status",
+                return_value="ok",
+            ),
+            patch("hyops.blueprint.command.sys.stdin", io.StringIO()),
+            patch("hyops.blueprint.command.sys.stdout", output),
+        ):
+            self.assertEqual(_confirm_deploy_if_needed(ns, payload, paths), 0)
+
+        rendered = output.getvalue()
+        self.assertIn(
+            "WARN: deploy may change 1 active blueprint step in env=demo-lab.",
+            rendered,
+        )
+        self.assertIn("  - Private lab network (state=ok)", rendered)
+        self.assertNotIn("platform/gcp/lab-network", rendered)
+        self.assertNotIn("gcp_eve_ng_network", rendered)
+
     def test_destroy_preview_uses_readable_label(self):
         step = {
             "id": "gcp_eve_ng_healthcheck",

--- a/hyops/blueprint/tests/test_rebuild.py
+++ b/hyops/blueprint/tests/test_rebuild.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import tempfile
 import unittest
 from pathlib import Path
@@ -50,7 +51,7 @@ class BlueprintRebuildTests(unittest.TestCase):
             "hyops.blueprint.command._resolve_and_validate", return_value=_payload()
         ), patch("builtins.print") as output:
             self.assertEqual(run_rebuild(_namespace(tmp, execute=False)), 0)
-            output.assert_any_call("  - network (retained)")
+            output.assert_any_call("  - Network (retained)")
 
     def test_plan_only_does_not_execute(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, patch(
@@ -88,6 +89,21 @@ class BlueprintRebuildTests(unittest.TestCase):
         ) as deploy:
             self.assertEqual(run_rebuild(_namespace(tmp, execute=True)), 0)
             deploy.assert_called_once()
+
+    def test_execute_omits_order_lists_in_default_output(self) -> None:
+        output = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.blueprint.command._resolve_and_validate", return_value=_payload()
+        ), patch(
+            "hyops.blueprint.command.new_run_id", return_value="rebuild-test"
+        ), patch("hyops.blueprint.command.run_destroy", return_value=0), patch(
+            "hyops.blueprint.command.run_deploy", return_value=0
+        ), patch("sys.stdout", output):
+            self.assertEqual(run_rebuild(_namespace(tmp, execute=True)), 0)
+
+        rendered = output.getvalue()
+        self.assertNotIn("destroy_order:", rendered)
+        self.assertNotIn("deploy_order:", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #206.

## Summary

- treat destroyed or absent blueprint state as a normal deployment path
- keep active-resource confirmation concise in default mode
- retain module references and state bindings under verbose output
- avoid repeating full rebuild orders during execution
- use readable step labels in rebuild previews

## Validation

- `bash tools/ci/check-python.sh` (190 tests)
- `bash tools/ci/check-ruff.sh`
- release bundle build and verification
- `git diff --check`
