### PR TITLE
fix(blueprint): clarify lab archive duration

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1848,7 +1848,8 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         "with_deps": False,
         "inputs": archive.get("inputs") or {},
     }
-    print("exporting lab data before teardown")
+    print("preparing lab archive; active nodes will be stopped and saved state verified")
+    print("this may take several minutes, depending on lab size")
     progress = ProgressDisplay(
         enabled=bool(
             sys.stdout


### PR DESCRIPTION
Closes #212

## Summary

- explain that confirmed archive preparation stops active nodes and verifies saved state
- set a clear duration expectation based on lab size
- retain one concise lifecycle progress item without simulated stages

## Verification

- blueprint destroy tests
- repository diff check