### PR TITLE
Align helper checkpoint source

### DIFF
--- a/tools/setup/requirements/ansible.hybridops.git.json
+++ b/tools/setup/requirements/ansible.hybridops.git.json
@@ -8,7 +8,7 @@
     {
       "name": "hybridops.helper",
       "repo": "git@github.com:hybridops-tech/ansible-collection-helper.git",
-      "ref": "1d28487f2f420f83896f5fdea6870d8f1800361f"
+      "ref": "85dbfddceecab888850b72dc2918e55a54c9793e"
     },
     {
       "name": "hybridops.app",


### PR DESCRIPTION
## Summary
- keep the published helper dependency on 0.1.8
- align the source fallback with the consolidated release commit

## Validation
- helper 0.1.8 installs from the public collection index
- the installed artifact contains the writable-overlay checkpoint fix
- the source fallback resolves to the tagged release

Closes #214
