### PR TITLE
Keep archive restore inputs action-specific

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1302,6 +1302,8 @@ def _run_lab_restore(
             "eveng_lab_archive_action": "restore",
             "eveng_lab_archive_path": str(archive_path),
             "eveng_lab_archive_expected_sha256": checksum,
+            "eveng_lab_archive_include_node_state": False,
+            "eveng_lab_archive_stop_running_nodes": False,
             "eveng_lab_archive_overwrite": bool(
                 getattr(ns, "overwrite_labs", False)
             ),

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -33,6 +33,8 @@ def _payload():
             "inputs": {
                 "inventory_state_ref": "platform/test/vm#lab_vm",
                 "eveng_lab_archive_action": "export",
+                "eveng_lab_archive_include_node_state": True,
+                "eveng_lab_archive_stop_running_nodes": True,
             },
         }
     }
@@ -123,6 +125,8 @@ class BlueprintLabRestoreTest(TestCase):
             "b" * 64,
         )
         self.assertFalse(step["inputs"]["eveng_lab_archive_overwrite"])
+        self.assertFalse(step["inputs"]["eveng_lab_archive_include_node_state"])
+        self.assertFalse(step["inputs"]["eveng_lab_archive_stop_running_nodes"])
 
     def test_restore_includes_verified_node_state(self):
         archive = (


### PR DESCRIPTION
## Summary
- clear export-only node-state settings when constructing a restore invocation
- retain the verified node-state companion through the dedicated restore inputs
- cover lifecycle inputs that enable node stopping during export

## Validation
- archive restore tests
- archive input validator tests
- Python compilation

Closes #216