### PR TITLE
Keep private access host trust state-scoped

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -921,6 +921,21 @@ def _access_known_hosts_file(paths, state_ref: str, state: dict[str, Any]) -> Pa
     return directory / f"{scope}.known_hosts"
 
 
+def _ssh_access_trust_options(
+    known_hosts_file: Path,
+    *,
+    host_key_alias: str = "",
+) -> list[str]:
+    options = [
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", f"UserKnownHostsFile={known_hosts_file}",
+        "-o", "LogLevel=ERROR",
+    ]
+    if host_key_alias:
+        options.extend(["-o", f"HostKeyAlias={host_key_alias}"])
+    return options
+
+
 def _ssh_access_error(stderr: str, known_hosts_file: Path) -> str:
     detail = str(stderr or "").strip()
     if (
@@ -994,8 +1009,7 @@ def run_access(ns) -> int:
                 ssh,
                 "-o", "BatchMode=yes",
                 "-o", "IdentitiesOnly=yes",
-                "-o", "StrictHostKeyChecking=accept-new",
-                "-o", f"UserKnownHostsFile={known_hosts_file}",
+                *_ssh_access_trust_options(known_hosts_file),
                 "-i", str(ssh_key),
             ]
             identity_check = subprocess.run(
@@ -1105,11 +1119,15 @@ def run_access(ns) -> int:
             ]
             iap_proc = subprocess.Popen(iap_argv, cwd=str(Path.home()))
             _wait_for_local_port(iap_port, iap_proc)
+            known_hosts_file = _access_known_hosts_file(paths, state_ref, state)
             ssh_base = [
                 ssh,
                 "-o", "BatchMode=yes",
                 "-o", "IdentitiesOnly=yes",
-                "-o", "StrictHostKeyChecking=accept-new",
+                *_ssh_access_trust_options(
+                    known_hosts_file,
+                    host_key_alias=f"hyops-{known_hosts_file.stem}",
+                ),
                 "-i", ssh_key,
                 "-p", str(iap_port),
             ]
@@ -1130,7 +1148,7 @@ def run_access(ns) -> int:
                 if probe.returncode != 0:
                     raise ValueError(
                         "failed to discover native EVE-NG consoles: "
-                        + (probe.stderr.strip() or f"ssh rc={probe.returncode}")
+                        + _ssh_access_error(probe.stderr, known_hosts_file)
                     )
                 console_ports = _parse_eve_qemu_console_ports(probe.stdout)
                 if console_ports:

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -19,6 +19,7 @@ from hyops.blueprint.command import (
     _print_native_console_client_guidance,
     _require_local_ports_available,
     _ssh_access_error,
+    _ssh_access_trust_options,
     _wait_for_local_port,
 )
 
@@ -49,6 +50,18 @@ class BlueprintAccessTests(unittest.TestCase):
             self.assertEqual(path.parent.name, "access_known_hosts")
             self.assertIn("eve_ng_vm-apply-20260712T120000Z-abcd1234", path.name)
             self.assertTrue(path.parent.is_dir())
+
+    def test_private_access_trust_is_quiet_and_keeps_verification(self) -> None:
+        options = _ssh_access_trust_options(
+            Path("/tmp/access.known_hosts"),
+            host_key_alias="hyops-eve-ng-01",
+        )
+
+        self.assertIn("StrictHostKeyChecking=accept-new", options)
+        self.assertIn("UserKnownHostsFile=/tmp/access.known_hosts", options)
+        self.assertIn("LogLevel=ERROR", options)
+        self.assertIn("HostKeyAlias=hyops-eve-ng-01", options)
+        self.assertNotIn("StrictHostKeyChecking=no", options)
 
     def test_extracts_direct_host_from_proxmox_vm_outputs(self) -> None:
         outputs = {


### PR DESCRIPTION
## Summary
- store private access host trust in the environment-scoped record
- use a stable VM-state alias for forwarded GCP SSH sessions
- suppress routine first-use SSH output without disabling verification
- retain changed-key protection and operator guidance

## Validation
- blueprint access tests
- Python compilation

Closes #218