### PR TITLE
Keep archive success output concise

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1928,8 +1928,11 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
     if actual != expected:
         print("ERR: lab archive checksum verification failed; no resources were destroyed")
         return OPERATOR_ERROR
-    print(f"lab archive: {archive_path}")
-    print(f"sha256: {actual}")
+    archive_contents = ["lab definitions"]
+    verbose = bool(os.getenv("HYOPS_VERBOSE"))
+    if verbose:
+        print(f"lab archive: {archive_path}")
+        print(f"sha256: {actual}")
     if bool(outputs.get("eveng_lab_archive_node_state_included", False)):
         node_archive_path = Path(
             str(outputs.get("eveng_lab_archive_node_state_archive_path") or "")
@@ -1953,8 +1956,11 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
                 "no resources were destroyed"
             )
             return OPERATOR_ERROR
-        print(f"stopped node state: {node_archive_path}")
-        print(f"sha256: {node_actual}")
+        archive_contents.append("stopped node state")
+        if verbose:
+            print(f"stopped node state: {node_archive_path}")
+            print(f"sha256: {node_actual}")
+    print(f"archive saved: {', '.join(archive_contents)}")
     return 0
 
 

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -193,6 +193,41 @@ class ResumableBlueprintDestroyTest(TestCase):
 
         self.assertEqual(rc, 0)
 
+    def test_normal_archive_success_hides_paths_and_checksums(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive_path = Path(tmp) / "labs.tar.gz"
+            archive_path.write_bytes(b"portable labs")
+            checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+            payload = {
+                "archive_before_destroy": {
+                    "module_ref": "platform/test/archive",
+                    "state_instance": "lab_archive",
+                    "inputs": {},
+                }
+            }
+            paths = SimpleNamespace(state_dir=Path(tmp) / "state")
+            state = {
+                "outputs": {
+                    "eveng_lab_archive_path": str(archive_path),
+                    "eveng_lab_archive_sha256": checksum,
+                }
+            }
+            stdout = io.StringIO()
+
+            with (
+                patch("hyops.blueprint.command.run_step_module_command", return_value=0),
+                patch("hyops.blueprint.command.read_module_state", return_value=state),
+                patch("hyops.blueprint.command.sys.stdout", stdout),
+                patch.dict(os.environ, {}, clear=True),
+            ):
+                rc = _run_archive_before_destroy(_namespace(), payload, paths)
+
+        self.assertEqual(rc, 0)
+        output = stdout.getvalue()
+        self.assertIn("archive saved: lab definitions", output)
+        self.assertNotIn(str(archive_path), output)
+        self.assertNotIn(checksum, output)
+
     def test_failed_archive_stops_before_resource_destroy(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
         payload = _payload()


### PR DESCRIPTION
## Summary
- replace full artifact paths and raw checksums in normal output with one archive-content summary
- retain exact paths and checksums in verbose output and module state
- cover normal-mode output with a regression test

## Validation
- resumable destroy tests
- Python compilation

Closes #220