### PR TITLE
Use environment placeholders in blueprint examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ for the complete operating sequence.
 Initialise a target environment:
 
 ```bash
-hyops init proxmox --env dev
-hyops init gcp --env dev
+hyops init proxmox --env <env>
+hyops init gcp --env <env>
 ```
 
 After initialization, preflight resolves the environment, runtime, contracts,
@@ -89,20 +89,20 @@ credential requirements, state, and driver checks. Some module paths may inspect
 live state, but preflight does not deploy resources:
 
 ```bash
-hyops blueprint preflight --env dev --ref onprem/authoritative-foundation@v1
+hyops blueprint preflight --env <env> --ref onprem/authoritative-foundation@v1
 ```
 
 Run a module:
 
 ```bash
-hyops apply --env dev --module platform/onprem/rke2-cluster
-hyops apply --env dev --module org/gcp/project-factory
+hyops apply --env <env> --module platform/onprem/rke2-cluster
+hyops apply --env <env> --module org/gcp/project-factory
 ```
 
 Run a full blueprint (ordered multi-step deployment):
 
 ```bash
-hyops blueprint deploy --env dev --ref onprem/authoritative-foundation@v1 --execute
+hyops blueprint deploy --env <env> --ref onprem/authoritative-foundation@v1 --execute
 ```
 
 The runtime root defaults to `~/.hybridops`. Override with `--root <path>` or `$HYOPS_RUNTIME_ROOT`.

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -1,5 +1,8 @@
 # Blueprints
 
+In the command examples, replace `<env>` with the environment name used during
+initialization.
+
 Blueprints are product orchestration manifests for supported module chains.
 
 They package repeatable outcomes, not implementation details.
@@ -90,7 +93,7 @@ credential requirements, state, and driver checks. Some paths may inspect live
 state, but preflight does not deploy resources:
 
 ```bash
-hyops blueprint preflight --env dev \
+hyops blueprint preflight --env <env> \
   --ref gcp/eve-ng@v1 \
   --blueprints-root blueprints
 ```
@@ -98,7 +101,7 @@ hyops blueprint preflight --env dev \
 Execution begins only when `deploy` is given `--execute`:
 
 ```bash
-hyops blueprint deploy --env dev \
+hyops blueprint deploy --env <env> \
   --ref gcp/eve-ng@v1 \
   --blueprints-root blueprints \
   --execute

--- a/blueprints/dr/postgresql-cloudsql-failback-onprem@v1/README.md
+++ b/blueprints/dr/postgresql-cloudsql-failback-onprem@v1/README.md
@@ -18,6 +18,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref dr/postgresql-cloudsql-failback-onprem@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref dr/postgresql-cloudsql-failback-onprem@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref dr/postgresql-cloudsql-failback-onprem@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref dr/postgresql-cloudsql-failback-onprem@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref dr/postgresql-cloudsql-failback-onprem@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/dr/postgresql-cloudsql-promote-gcp@v1/README.md
+++ b/blueprints/dr/postgresql-cloudsql-promote-gcp@v1/README.md
@@ -19,6 +19,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref dr/postgresql-cloudsql-promote-gcp@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref dr/postgresql-cloudsql-promote-gcp@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref dr/postgresql-cloudsql-promote-gcp@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref dr/postgresql-cloudsql-promote-gcp@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref dr/postgresql-cloudsql-promote-gcp@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/dr/postgresql-cloudsql-standby-gcp@v1/README.md
+++ b/blueprints/dr/postgresql-cloudsql-standby-gcp@v1/README.md
@@ -18,6 +18,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref dr/postgresql-cloudsql-standby-gcp@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref dr/postgresql-cloudsql-standby-gcp@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref dr/postgresql-cloudsql-standby-gcp@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref dr/postgresql-cloudsql-standby-gcp@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref dr/postgresql-cloudsql-standby-gcp@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/dr/postgresql-ha-backup-gcp@v1/README.md
+++ b/blueprints/dr/postgresql-ha-backup-gcp@v1/README.md
@@ -17,6 +17,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref dr/postgresql-ha-backup-gcp@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref dr/postgresql-ha-backup-gcp@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref dr/postgresql-ha-backup-gcp@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref dr/postgresql-ha-backup-gcp@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref dr/postgresql-ha-backup-gcp@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/dr/postgresql-ha-failback-onprem@v1/README.md
+++ b/blueprints/dr/postgresql-ha-failback-onprem@v1/README.md
@@ -21,6 +21,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref dr/postgresql-ha-failback-onprem@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref dr/postgresql-ha-failback-onprem@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref dr/postgresql-ha-failback-onprem@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref dr/postgresql-ha-failback-onprem@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref dr/postgresql-ha-failback-onprem@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/dr/postgresql-ha-failover-gcp@v1/README.md
+++ b/blueprints/dr/postgresql-ha-failover-gcp@v1/README.md
@@ -21,6 +21,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref dr/postgresql-ha-failover-gcp@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref dr/postgresql-ha-failover-gcp@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref dr/postgresql-ha-failover-gcp@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref dr/postgresql-ha-failover-gcp@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref dr/postgresql-ha-failover-gcp@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -57,7 +57,7 @@ target environment are ready:
 Seed the EVE-NG secrets before deployment:
 
 ```bash
-hyops secrets ensure --env dev EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
+hyops secrets ensure --env <env> EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
 ```
 
 ## Usage
@@ -74,7 +74,7 @@ Run preflight:
 
 ```bash
 hyops blueprint preflight \
-  --env dev \
+  --env <env> \
   --ref gcp/eve-ng@v1 \
   --blueprints-root blueprints
 ```
@@ -82,7 +82,7 @@ hyops blueprint preflight \
 Open the private EVE-NG UI after deployment:
 
 ```bash
-hyops blueprint access --env dev --ref gcp/eve-ng@v1
+hyops blueprint access --env <env> --ref gcp/eve-ng@v1
 ```
 
 HybridOps resolves the VM, project, and zone from module state, forwards HTTP
@@ -99,7 +99,7 @@ Destruction requires the operator to type `destroy <environment>`.
 Automation must state the intended archive behaviour:
 
 ```bash
-hyops blueprint destroy --env dev --ref gcp/eve-ng@v1 --execute --yes \
+hyops blueprint destroy --env <env> --ref gcp/eve-ng@v1 --execute --yes \
   --archive-before-destroy
 ```
 
@@ -109,7 +109,7 @@ Deploy:
 
 ```bash
 hyops blueprint deploy \
-  --env dev \
+  --env <env> \
   --ref gcp/eve-ng@v1 \
   --blueprints-root blueprints \
   --execute
@@ -120,7 +120,7 @@ offers to restore it after the host is ready. For non-interactive recovery:
 
 ```bash
 hyops blueprint deploy \
-  --env dev \
+  --env <env> \
   --ref gcp/eve-ng@v1 \
   --execute \
   --restore-labs
@@ -134,7 +134,7 @@ Rebuild the blueprint-managed resources:
 
 ```bash
 hyops blueprint rebuild \
-  --env dev \
+  --env <env> \
   --ref gcp/eve-ng@v1 \
   --execute
 ```

--- a/blueprints/gcp/gke-burst@v1/README.md
+++ b/blueprints/gcp/gke-burst@v1/README.md
@@ -19,6 +19,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref gcp/gke-burst@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref gcp/gke-burst@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref gcp/gke-burst@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref gcp/gke-burst@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref gcp/gke-burst@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/gcp/linux-desktop@v1/README.md
+++ b/blueprints/gcp/linux-desktop@v1/README.md
@@ -18,6 +18,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref gcp/linux-desktop@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref gcp/linux-desktop@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref gcp/linux-desktop@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref gcp/linux-desktop@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref gcp/linux-desktop@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/gcp/windows-desktop@v1/README.md
+++ b/blueprints/gcp/windows-desktop@v1/README.md
@@ -17,6 +17,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref gcp/windows-desktop@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref gcp/windows-desktop@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref gcp/windows-desktop@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref gcp/windows-desktop@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref gcp/windows-desktop@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/edge-control-plane@v1/README.md
+++ b/blueprints/networking/edge-control-plane@v1/README.md
@@ -31,6 +31,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/edge-control-plane@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/edge-control-plane@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/edge-control-plane@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/edge-control-plane@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/edge-control-plane@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/gcp-ops-runner@v1/README.md
+++ b/blueprints/networking/gcp-ops-runner@v1/README.md
@@ -18,6 +18,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/gcp-ops-runner@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/gcp-ops-runner@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/gcp-ops-runner@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/gcp-ops-runner@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/gcp-ops-runner@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/hetzner-vyos-edge@v1/README.md
+++ b/blueprints/networking/hetzner-vyos-edge@v1/README.md
@@ -19,6 +19,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/hetzner-vyos-edge@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/hetzner-vyos-edge@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/hetzner-vyos-edge@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/hetzner-vyos-edge@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/hetzner-vyos-edge@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/onprem-ops-runner@v1/README.md
+++ b/blueprints/networking/onprem-ops-runner@v1/README.md
@@ -18,6 +18,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/onprem-ops-runner@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/onprem-ops-runner@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/onprem-ops-runner@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/onprem-ops-runner@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/onprem-ops-runner@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/onprem-site-extension@v1/README.md
+++ b/blueprints/networking/onprem-site-extension@v1/README.md
@@ -17,6 +17,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/onprem-site-extension@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/onprem-site-extension@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/onprem-site-extension@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/onprem-site-extension@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/onprem-site-extension@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/onprem-vyos-edge@v1/README.md
+++ b/blueprints/networking/onprem-vyos-edge@v1/README.md
@@ -17,6 +17,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/onprem-vyos-edge@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/onprem-vyos-edge@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/onprem-vyos-edge@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/onprem-vyos-edge@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/onprem-vyos-edge@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/powerdns-onprem-secondary@v1/README.md
+++ b/blueprints/networking/powerdns-onprem-secondary@v1/README.md
@@ -16,6 +16,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/powerdns-onprem-secondary@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/powerdns-onprem-secondary@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/powerdns-onprem-secondary@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/powerdns-onprem-secondary@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/powerdns-onprem-secondary@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/powerdns-shared-primary@v1/README.md
+++ b/blueprints/networking/powerdns-shared-primary@v1/README.md
@@ -16,6 +16,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/powerdns-shared-primary@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/powerdns-shared-primary@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/powerdns-shared-primary@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/powerdns-shared-primary@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/powerdns-shared-primary@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/networking/wan-hub-edge@v1/README.md
+++ b/blueprints/networking/wan-hub-edge@v1/README.md
@@ -21,6 +21,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref networking/wan-hub-edge@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref networking/wan-hub-edge@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref networking/wan-hub-edge@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref networking/wan-hub-edge@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref networking/wan-hub-edge@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/onprem/authoritative-foundation@v1/README.md
+++ b/blueprints/onprem/authoritative-foundation@v1/README.md
@@ -20,6 +20,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref onprem/authoritative-foundation@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/onprem/bootstrap-netbox@v1/README.md
+++ b/blueprints/onprem/bootstrap-netbox@v1/README.md
@@ -20,6 +20,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref onprem/bootstrap-netbox@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref onprem/bootstrap-netbox@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref onprem/bootstrap-netbox@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref onprem/bootstrap-netbox@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref onprem/bootstrap-netbox@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -48,7 +48,7 @@ NetBox and shared Proxmox SDN remain available for managed platform deployments,
 Seed the EVE-NG secrets before deployment:
 
 ```bash
-hyops secrets ensure --env dev EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
+hyops secrets ensure --env <env> EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
 ```
 
 ## Usage
@@ -65,7 +65,7 @@ Run preflight:
 
 ```bash
 hyops blueprint preflight \
-  --env dev \
+  --env <env> \
   --ref onprem/eve-ng@v1 \
   --blueprints-root blueprints
 ```
@@ -74,7 +74,7 @@ Deploy:
 
 ```bash
 hyops blueprint deploy \
-  --env dev \
+  --env <env> \
   --ref onprem/eve-ng@v1 \
   --blueprints-root blueprints \
   --execute
@@ -83,7 +83,7 @@ hyops blueprint deploy \
 Open the private UI:
 
 ```bash
-hyops blueprint access --env dev --ref onprem/eve-ng@v1
+hyops blueprint access --env <env> --ref onprem/eve-ng@v1
 ```
 
 When access closes, HybridOps offers to keep the environment, export its lab
@@ -96,7 +96,7 @@ For non-interactive recovery:
 
 ```bash
 hyops blueprint deploy \
-  --env dev \
+  --env <env> \
   --ref onprem/eve-ng@v1 \
   --execute \
   --restore-labs

--- a/blueprints/onprem/netbox-ha-cutover@v1/README.md
+++ b/blueprints/onprem/netbox-ha-cutover@v1/README.md
@@ -16,6 +16,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref onprem/netbox-ha-cutover@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref onprem/netbox-ha-cutover@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref onprem/netbox-ha-cutover@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref onprem/netbox-ha-cutover@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref onprem/netbox-ha-cutover@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/onprem/postgresql-ha@v1/README.md
+++ b/blueprints/onprem/postgresql-ha@v1/README.md
@@ -18,6 +18,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref onprem/postgresql-ha@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref onprem/postgresql-ha@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref onprem/postgresql-ha@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref onprem/postgresql-ha@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref onprem/postgresql-ha@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/onprem/rke2-workloads@v1/README.md
+++ b/blueprints/onprem/rke2-workloads@v1/README.md
@@ -20,6 +20,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref onprem/rke2-workloads@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref onprem/rke2-workloads@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref onprem/rke2-workloads@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref onprem/rke2-workloads@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref onprem/rke2-workloads@v1 --blueprints-root blueprints --execute
 ```

--- a/blueprints/onprem/rke2@v1/README.md
+++ b/blueprints/onprem/rke2@v1/README.md
@@ -18,6 +18,6 @@ See [blueprint.yml](blueprint.yml) for the full contract.
 
 ```bash
 hyops blueprint validate --ref onprem/rke2@v1 --blueprints-root blueprints
-hyops blueprint preflight --env dev --ref onprem/rke2@v1 --blueprints-root blueprints
-hyops blueprint deploy --env dev --ref onprem/rke2@v1 --blueprints-root blueprints --execute
+hyops blueprint preflight --env <env> --ref onprem/rke2@v1 --blueprints-root blueprints
+hyops blueprint deploy --env <env> --ref onprem/rke2@v1 --blueprints-root blueprints --execute
 ```


### PR DESCRIPTION
Closes #224.

## Summary

- replace the example `dev` environment with `<env>` across Core and blueprint READMEs
- state once that `<env>` means the name used during initialization
- keep command behaviour unchanged

## Checks

- `git diff --check`
- confirmed no `--env dev` examples remain in the affected README set