### PR TITLE
Add GCP blueprint cost estimates

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -887,16 +887,16 @@ def _print_cost_estimate(
     access_seconds: int | None = None,
 ) -> None:
     if not estimate.available:
-        print("estimated active cost: unavailable")
+        print("estimated fixed cost: unavailable")
         return
     print(
-        "estimated active cost: "
+        "estimated fixed cost: "
         f"{format_money(estimate.hourly, estimate.currency)}/hour"
     )
     state_seconds = _state_age_seconds(state.get("updated_at"))
     if state_seconds:
         print(
-            "estimated cost since resource update: "
+            "estimated maximum since resource update: "
             f"{format_money(estimate.amount_for_seconds(state_seconds), estimate.currency)}"
         )
     if access_seconds is not None:
@@ -963,6 +963,18 @@ def _offer_access_close_destroy(
     destroy_ns.archive_before_destroy = False
     destroy_ns.skip_archive = False
     return run_destroy(destroy_ns)
+
+
+def _destroyed_blueprint_cost_cleared(payload: dict[str, Any], paths) -> bool:
+    """Return true only when every declared step has terminal resource state."""
+
+    for step in payload.get("steps") or []:
+        if bool(step.get("retain_on_destroy", False)):
+            return False
+        status = module_state_status(paths.state_dir, step_state_ref(step))
+        if status not in {"destroyed", "absent"}:
+            return False
+    return True
 
 
 def _access_known_hosts_file(paths, state_ref: str, state: dict[str, Any]) -> Path:
@@ -1151,7 +1163,12 @@ def run_access(ns) -> int:
         if not match:
             raise ValueError("GCP VM state does not contain a usable instance id")
         project, zone, instance = match.groups()
-        print("checking cloud cost estimate", flush=True)
+        cost_progress = ProgressDisplay(show_elapsed=True)
+        cost_progress.start(
+            "cloud-cost",
+            "Cloud cost estimate",
+            plain="cloud cost estimate: checking",
+        )
         try:
             cost_estimate = estimate_gcp_vm_cost(
                 project_id=project,
@@ -1164,6 +1181,24 @@ def run_access(ns) -> int:
                 False,
                 detail="cloud pricing could not be resolved",
             )
+        except KeyboardInterrupt:
+            cost_progress.finish(
+                "cloud-cost",
+                "Cloud cost estimate",
+                "cancelled",
+                plain="cloud cost estimate: cancelled",
+            )
+            raise
+        cost_progress.finish(
+            "cloud-cost",
+            "Cloud cost estimate",
+            "ok" if cost_estimate.available else "skipped",
+            plain=(
+                "cloud cost estimate: ready"
+                if cost_estimate.available
+                else "cloud cost estimate: unavailable"
+            ),
+        )
         port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
         url = f"http://127.0.0.1:{port}{path}"
         gcloud = shutil.which("gcloud")
@@ -2321,12 +2356,22 @@ def run_destroy(ns) -> int:
         "optional_failures": optional_failures,
         "steps": step_results,
     }
+    cost_cleared = False
     if final_status == "ok" and str(payload["blueprint_ref"]).startswith("gcp/"):
-        output["cost"] = {
-            "estimated_ongoing_hourly": "0.00",
-            "currency": "USD",
-            "scope": "destroyed blueprint resources",
-        }
+        cost_cleared = _destroyed_blueprint_cost_cleared(payload, paths)
+        output["cost"] = (
+            {
+                "status": "cleared",
+                "estimated_ongoing_hourly": "0.00",
+                "currency": "USD",
+                "scope": "declared blueprint resources",
+            }
+            if cost_cleared
+            else {
+                "status": "unverified",
+                "scope": "declared blueprint resources",
+            }
+        )
 
     if json_mode:
         print(json.dumps(output, indent=2, sort_keys=True))
@@ -2340,7 +2385,10 @@ def run_destroy(ns) -> int:
         if optional_failures:
             print(f"optional_failures: {', '.join(optional_failures)}")
         if final_status == "ok" and str(payload["blueprint_ref"]).startswith("gcp/"):
-            print("estimated ongoing cost from destroyed resources: USD 0.00/hour")
+            if cost_cleared:
+                print("estimated ongoing blueprint cost: USD 0.00/hour")
+            else:
+                print("ongoing blueprint cost: verify remaining resources")
 
     if cancelled:
         return CANCELLED

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -908,6 +908,93 @@ def _print_cost_estimate(
         print(f"pricing basis: {estimate.basis}")
 
 
+def _gcp_cost_estimate_with_progress(
+    *,
+    project_id: str,
+    zone: str,
+    state: dict[str, Any],
+    paths,
+) -> CostEstimate:
+    progress = ProgressDisplay(show_elapsed=True)
+    progress.start(
+        "cloud-cost",
+        "Cloud cost estimate",
+        plain="cloud cost estimate: checking",
+    )
+    try:
+        estimate = estimate_gcp_vm_cost(
+            project_id=project_id,
+            zone=zone,
+            state=state,
+            cache_dir=paths.meta_dir / "pricing",
+        )
+    except Exception:
+        estimate = CostEstimate(
+            False,
+            detail="cloud pricing could not be resolved",
+        )
+    except KeyboardInterrupt:
+        progress.finish(
+            "cloud-cost",
+            "Cloud cost estimate",
+            "cancelled",
+            plain="cloud cost estimate: cancelled",
+        )
+        raise
+    progress.finish(
+        "cloud-cost",
+        "Cloud cost estimate",
+        "ok" if estimate.available else "skipped",
+        plain=(
+            "cloud cost estimate: ready"
+            if estimate.available
+            else "cloud cost estimate: unavailable"
+        ),
+    )
+    return estimate
+
+
+def _gcp_blueprint_cost_estimate(
+    payload: dict[str, Any],
+    paths,
+) -> CostEstimate | None:
+    if not str(payload.get("blueprint_ref") or "").startswith("gcp/"):
+        return None
+    access = payload.get("access")
+    if not isinstance(access, dict):
+        return None
+    state_ref = str(access.get("state_ref") or "").strip()
+    if not state_ref:
+        return None
+    try:
+        module_ref, state_instance = split_module_state_ref(state_ref)
+        state = read_module_state(
+            paths.state_dir,
+            module_ref,
+            state_instance=state_instance,
+        )
+    except (OSError, ValueError):
+        return None
+    outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
+    vms = outputs.get("vms") if isinstance(outputs.get("vms"), dict) else {}
+    if not vms:
+        return None
+    first_vm = next(iter(vms.values()))
+    if not isinstance(first_vm, dict):
+        return None
+    vm_id = str(first_vm.get("vm_id") or "").strip()
+    match = re.fullmatch(r"projects/([^/]+)/zones/([^/]+)/instances/([^/]+)", vm_id)
+    if not match:
+        return None
+    project_id, zone, _instance = match.groups()
+    return _gcp_cost_estimate_with_progress(
+        project_id=project_id,
+        zone=zone,
+        state=state,
+        paths=paths,
+    )
+
+
 def _offer_access_close_destroy(
     ns,
     payload: dict[str, Any],
@@ -962,6 +1049,7 @@ def _offer_access_close_destroy(
     destroy_ns.yes = False
     destroy_ns.archive_before_destroy = False
     destroy_ns.skip_archive = False
+    destroy_ns._cost_estimate = cost_estimate
     return run_destroy(destroy_ns)
 
 
@@ -1163,41 +1251,11 @@ def run_access(ns) -> int:
         if not match:
             raise ValueError("GCP VM state does not contain a usable instance id")
         project, zone, instance = match.groups()
-        cost_progress = ProgressDisplay(show_elapsed=True)
-        cost_progress.start(
-            "cloud-cost",
-            "Cloud cost estimate",
-            plain="cloud cost estimate: checking",
-        )
-        try:
-            cost_estimate = estimate_gcp_vm_cost(
-                project_id=project,
-                zone=zone,
-                state=state,
-                cache_dir=paths.meta_dir / "pricing",
-            )
-        except Exception:
-            cost_estimate = CostEstimate(
-                False,
-                detail="cloud pricing could not be resolved",
-            )
-        except KeyboardInterrupt:
-            cost_progress.finish(
-                "cloud-cost",
-                "Cloud cost estimate",
-                "cancelled",
-                plain="cloud cost estimate: cancelled",
-            )
-            raise
-        cost_progress.finish(
-            "cloud-cost",
-            "Cloud cost estimate",
-            "ok" if cost_estimate.available else "skipped",
-            plain=(
-                "cloud cost estimate: ready"
-                if cost_estimate.available
-                else "cloud cost estimate: unavailable"
-            ),
+        cost_estimate = _gcp_cost_estimate_with_progress(
+            project_id=project,
+            zone=zone,
+            state=state,
+            paths=paths,
         )
         port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
         url = f"http://127.0.0.1:{port}{path}"
@@ -2152,6 +2210,14 @@ def run_destroy(ns) -> int:
                     f"    id={step_id} module={step['module_ref']} "
                     f"state={status} ref={state_ref}"
                 )
+        cost_estimate = getattr(ns, "_cost_estimate", None)
+        if cost_estimate is None:
+            cost_estimate = _gcp_blueprint_cost_estimate(payload, paths)
+        if isinstance(cost_estimate, CostEstimate) and cost_estimate.available:
+            print(
+                "estimated fixed cost while retained: "
+                f"{format_money(cost_estimate.hourly, cost_estimate.currency)}/hour"
+            )
 
     try:
         archive_mode = _select_archive_destroy_mode(ns, payload, env_name)

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -21,9 +21,11 @@ from typing import Any
 
 from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.browser import is_windows_wsl, open_operator_url
+from hyops.runtime.cost import CostEstimate, format_money
 from hyops.runtime.evidence import new_run_id
 from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
 from hyops.runtime.gcp import diagnose_project_billing
+from hyops.runtime.gcp_cost import estimate_gcp_vm_cost
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import read_module_state, split_module_state_ref
 from hyops.runtime.paths import resolve_runtime_paths
@@ -865,12 +867,55 @@ def _state_age(updated_at: Any) -> str:
     return f"{minutes}m"
 
 
+def _state_age_seconds(updated_at: Any) -> int:
+    raw = str(updated_at or "").strip()
+    if not raw:
+        return 0
+    try:
+        recorded = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if recorded.tzinfo is None:
+            recorded = recorded.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return 0
+    return max(0, int((datetime.now(timezone.utc) - recorded).total_seconds()))
+
+
+def _print_cost_estimate(
+    estimate: CostEstimate,
+    *,
+    state: dict[str, Any],
+    access_seconds: int | None = None,
+) -> None:
+    if not estimate.available:
+        print("estimated active cost: unavailable")
+        return
+    print(
+        "estimated active cost: "
+        f"{format_money(estimate.hourly, estimate.currency)}/hour"
+    )
+    state_seconds = _state_age_seconds(state.get("updated_at"))
+    if state_seconds:
+        print(
+            "estimated cost since resource update: "
+            f"{format_money(estimate.amount_for_seconds(state_seconds), estimate.currency)}"
+        )
+    if access_seconds is not None:
+        print(
+            "estimated access-session cost: "
+            f"{format_money(estimate.amount_for_seconds(access_seconds), estimate.currency)}"
+        )
+    if estimate.basis:
+        print(f"pricing basis: {estimate.basis}")
+
+
 def _offer_access_close_destroy(
     ns,
     payload: dict[str, Any],
     state: dict[str, Any],
     *,
     project_id: str = "",
+    cost_estimate: CostEstimate | None = None,
+    access_started_at: float | None = None,
 ) -> int:
     access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
     if not bool(access.get("offer_destroy_on_close", False)):
@@ -891,6 +936,17 @@ def _offer_access_close_destroy(
             f"https://console.cloud.google.com/billing?project={project_id}"
         )
     print(f"resource state age: {_state_age(state.get('updated_at'))}")
+    if cost_estimate is not None:
+        access_seconds = (
+            max(0, int(time.monotonic() - access_started_at))
+            if access_started_at is not None
+            else None
+        )
+        _print_cost_estimate(
+            cost_estimate,
+            state=state,
+            access_seconds=access_seconds,
+        )
     print("billable resources may remain active after access closes")
 
     destroy_command = (
@@ -1095,6 +1151,19 @@ def run_access(ns) -> int:
         if not match:
             raise ValueError("GCP VM state does not contain a usable instance id")
         project, zone, instance = match.groups()
+        print("checking cloud cost estimate", flush=True)
+        try:
+            cost_estimate = estimate_gcp_vm_cost(
+                project_id=project,
+                zone=zone,
+                state=state,
+                cache_dir=paths.meta_dir / "pricing",
+            )
+        except Exception:
+            cost_estimate = CostEstimate(
+                False,
+                detail="cloud pricing could not be resolved",
+            )
         port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
         url = f"http://127.0.0.1:{port}{path}"
         gcloud = shutil.which("gcloud")
@@ -1175,12 +1244,16 @@ def run_access(ns) -> int:
         else:
             print(f"local endpoint: 127.0.0.1:{port}")
         _print_guest_network_guidance(access)
+        validated, enabled, _detail = diagnose_project_billing(project)
+        print(f"billing: {'enabled' if enabled else 'disabled'}" if validated else "billing: unable to verify")
+        _print_cost_estimate(cost_estimate, state=state)
         if bool(getattr(ns, "native_consoles", False)):
             _print_native_console_client_guidance()
             print(_native_console_status(console_ports))
             if not console_ports:
                 print("native console setup: start a QEMU node, then rerun access with --native-consoles")
         print("press Ctrl-C to close access")
+        access_started_at = time.monotonic()
         proc = subprocess.Popen(argv, cwd=str(Path.home()))
         time.sleep(2)
         if proc.poll() is not None:
@@ -1201,6 +1274,8 @@ def run_access(ns) -> int:
                 payload,
                 state,
                 project_id=project,
+                cost_estimate=cost_estimate,
+                access_started_at=access_started_at,
             )
     except Exception as exc:
         if "iap_proc" in locals():
@@ -2246,6 +2321,12 @@ def run_destroy(ns) -> int:
         "optional_failures": optional_failures,
         "steps": step_results,
     }
+    if final_status == "ok" and str(payload["blueprint_ref"]).startswith("gcp/"):
+        output["cost"] = {
+            "estimated_ongoing_hourly": "0.00",
+            "currency": "USD",
+            "scope": "destroyed blueprint resources",
+        }
 
     if json_mode:
         print(json.dumps(output, indent=2, sort_keys=True))
@@ -2258,6 +2339,8 @@ def run_destroy(ns) -> int:
             print(f"required_failures: {', '.join(required_failures)}")
         if optional_failures:
             print(f"optional_failures: {', '.join(optional_failures)}")
+        if final_status == "ok" and str(payload["blueprint_ref"]).startswith("gcp/"):
+            print("estimated ongoing cost from destroyed resources: USD 0.00/hour")
 
     if cancelled:
         return CANCELLED

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -6,6 +6,7 @@ import io
 import socket
 import tempfile
 import unittest
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -22,6 +23,7 @@ from hyops.blueprint.command import (
     _ssh_access_trust_options,
     _wait_for_local_port,
 )
+from hyops.runtime.cost import CostEstimate
 
 
 class _TTY(io.StringIO):
@@ -180,6 +182,13 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
                 payload,
                 {"updated_at": "2026-07-14T08:00:00Z"},
                 project_id="student-project",
+                cost_estimate=CostEstimate(
+                    True,
+                    hourly=Decimal("0.50"),
+                    currency="USD",
+                    basis="public list price",
+                ),
+                access_started_at=0,
             )
 
         self.assertEqual(rc, 0)
@@ -193,6 +202,8 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
             "https://console.cloud.google.com/billing?project=student-project",
             stdout.getvalue(),
         )
+        self.assertIn("estimated active cost: USD 0.50/hour", stdout.getvalue())
+        self.assertIn("estimated access-session cost:", stdout.getvalue())
 
     def test_access_close_destroy_delegates_confirmation(self) -> None:
         ns = SimpleNamespace(env="student-lab")

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -202,7 +202,7 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
             "https://console.cloud.google.com/billing?project=student-project",
             stdout.getvalue(),
         )
-        self.assertIn("estimated active cost: USD 0.50/hour", stdout.getvalue())
+        self.assertIn("estimated fixed cost: USD 0.50/hour", stdout.getvalue())
         self.assertIn("estimated access-session cost:", stdout.getvalue())
 
     def test_access_close_destroy_delegates_confirmation(self) -> None:

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from hyops.blueprint.command import (
+    _destroyed_blueprint_cost_cleared,
     _run_archive_before_destroy,
     _select_archive_destroy_mode,
     run_destroy,
@@ -51,6 +52,31 @@ def _namespace():
 
 
 class ResumableBlueprintDestroyTest(TestCase):
+    def test_cost_is_cleared_only_when_every_step_is_terminal(self):
+        payload = _payload()
+        paths = SimpleNamespace(state_dir="/tmp/state")
+
+        with patch(
+            "hyops.blueprint.command.module_state_status",
+            side_effect=("destroyed", "absent", "destroyed"),
+        ):
+            self.assertTrue(_destroyed_blueprint_cost_cleared(payload, paths))
+
+        with patch(
+            "hyops.blueprint.command.module_state_status",
+            side_effect=("destroyed", "ok", "destroyed"),
+        ):
+            self.assertFalse(_destroyed_blueprint_cost_cleared(payload, paths))
+
+    def test_retained_step_prevents_zero_cost_claim(self):
+        payload = _payload()
+        payload["steps"][0]["retain_on_destroy"] = True
+        paths = SimpleNamespace(state_dir="/tmp/state")
+
+        with patch("hyops.blueprint.command.module_state_status") as status:
+            self.assertFalse(_destroyed_blueprint_cost_cleared(payload, paths))
+        status.assert_not_called()
+
     def _run(self, statuses, run_step, *, retained=()):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
         payload = _payload()

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -9,10 +9,12 @@ from unittest.mock import patch
 
 from hyops.blueprint.command import (
     _destroyed_blueprint_cost_cleared,
+    _gcp_blueprint_cost_estimate,
     _run_archive_before_destroy,
     _select_archive_destroy_mode,
     run_destroy,
 )
+from hyops.runtime.cost import CostEstimate
 
 
 def _payload():
@@ -52,6 +54,45 @@ def _namespace():
 
 
 class ResumableBlueprintDestroyTest(TestCase):
+    def test_standalone_destroy_resolves_cost_from_access_state(self):
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {
+                "state_ref": "platform/gcp/platform-vm#gcp_eve_ng_vm",
+            },
+        }
+        paths = SimpleNamespace(state_dir="/tmp/state", meta_dir=Path("/tmp/meta"))
+        state = {
+            "outputs": {
+                "vms": {
+                    "eve-ng-01": {
+                        "vm_id": (
+                            "projects/student-project/zones/europe-west2-b/"
+                            "instances/eve-ng-01"
+                        )
+                    }
+                }
+            }
+        }
+        expected = CostEstimate(True)
+
+        with (
+            patch("hyops.blueprint.command.read_module_state", return_value=state),
+            patch(
+                "hyops.blueprint.command._gcp_cost_estimate_with_progress",
+                return_value=expected,
+            ) as estimate,
+        ):
+            result = _gcp_blueprint_cost_estimate(payload, paths)
+
+        self.assertIs(result, expected)
+        estimate.assert_called_once_with(
+            project_id="student-project",
+            zone="europe-west2-b",
+            state=state,
+            paths=paths,
+        )
+
     def test_cost_is_cleared_only_when_every_step_is_terminal(self):
         payload = _payload()
         paths = SimpleNamespace(state_dir="/tmp/state")

--- a/hyops/runtime/cost.py
+++ b/hyops/runtime/cost.py
@@ -1,0 +1,27 @@
+"""Provider-neutral cloud cost summaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """A point-in-time estimate for active blueprint resources."""
+
+    available: bool
+    hourly: Decimal = Decimal("0")
+    currency: str = "USD"
+    basis: str = ""
+    detail: str = ""
+
+    def amount_for_seconds(self, seconds: int) -> Decimal:
+        duration = Decimal(max(0, int(seconds))) / Decimal(3600)
+        return (self.hourly * duration).quantize(Decimal("0.01"))
+
+
+def format_money(amount: Decimal, currency: str) -> str:
+    """Format a monetary amount without implying accounting precision."""
+
+    return f"{str(currency or 'USD').upper()} {amount.quantize(Decimal('0.01'))}"

--- a/hyops/runtime/gcp_cost.py
+++ b/hyops/runtime/gcp_cost.py
@@ -1,0 +1,263 @@
+"""GCP public-price estimation for deployed Compute Engine VMs."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from hyops.runtime.cost import CostEstimate
+
+_COMPUTE_SERVICE = "services/6F81-5844-456A"
+_HOURS_PER_MONTH = Decimal("730")
+
+
+def _capture(argv: list[str]) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(argv, text=True, capture_output=True, check=False)
+    except OSError as exc:
+        return 127, "", str(exc)
+    return proc.returncode, str(proc.stdout or "").strip(), str(proc.stderr or "").strip()
+
+
+def _read_inputs(state: dict[str, Any]) -> dict[str, Any]:
+    raw = str(state.get("rerun_inputs_file") or "").strip()
+    if not raw:
+        return {}
+    path = Path(raw).expanduser()
+    if not path.is_file():
+        return {}
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _access_token() -> tuple[str, str]:
+    rc, stdout, stderr = _capture(
+        ["gcloud", "auth", "application-default", "print-access-token"]
+    )
+    if rc != 0 or not stdout:
+        return "", stderr or "application credentials are unavailable"
+    return stdout, ""
+
+
+def _public_compute_skus(
+    token: str,
+    currency: str,
+    *,
+    region: str = "",
+    cache_file: Path | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    if cache_file and cache_file.is_file():
+        try:
+            if time.time() - cache_file.stat().st_mtime < 86400:
+                cached = json.loads(cache_file.read_text(encoding="utf-8"))
+                if isinstance(cached, list):
+                    return [item for item in cached if isinstance(item, dict)], ""
+        except (OSError, json.JSONDecodeError):
+            pass
+    all_skus: list[dict[str, Any]] = []
+    page_token = ""
+    while True:
+        params = {"pageSize": 5000, "currencyCode": currency}
+        if page_token:
+            params["pageToken"] = page_token
+        query = urllib.parse.urlencode(params)
+        url = f"https://cloudbilling.googleapis.com/v1/{_COMPUTE_SERVICE}/skus?{query}"
+        req = urllib.request.Request(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as response:
+                payload = json.loads(response.read().decode("utf-8") or "{}")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace").strip()
+            return [], f"pricing service returned HTTP {exc.code}: {detail or exc.reason}"
+        except Exception as exc:
+            return [], str(exc)
+        skus = payload.get("skus")
+        if not isinstance(skus, list):
+            return [], "pricing service returned no Compute Engine SKUs"
+        all_skus.extend(item for item in skus if isinstance(item, dict))
+        page_token = str(payload.get("nextPageToken") or "").strip()
+        if not page_token:
+            if region:
+                all_skus = [
+                    sku
+                    for sku in all_skus
+                    if region in (sku.get("serviceRegions") or [])
+                    and (sku.get("category") or {}).get("usageType") == "OnDemand"
+                ]
+            if cache_file:
+                try:
+                    cache_file.parent.mkdir(parents=True, exist_ok=True)
+                    cache_file.write_text(json.dumps(all_skus), encoding="utf-8")
+                except OSError:
+                    pass
+            return all_skus, ""
+
+
+def _unit_price(sku: dict[str, Any]) -> tuple[Decimal, str]:
+    pricing = sku.get("pricingInfo")
+    if not isinstance(pricing, list) or not pricing:
+        return Decimal("0"), ""
+    expression = pricing[0].get("pricingExpression")
+    if not isinstance(expression, dict):
+        return Decimal("0"), ""
+    rates = expression.get("tieredRates")
+    if not isinstance(rates, list) or not rates:
+        return Decimal("0"), ""
+    unit = rates[0].get("unitPrice")
+    if not isinstance(unit, dict):
+        return Decimal("0"), ""
+    amount = Decimal(str(unit.get("units") or 0))
+    amount += Decimal(str(unit.get("nanos") or 0)) / Decimal(1_000_000_000)
+    return amount, str(expression.get("usageUnit") or "")
+
+
+def _matching_price(
+    skus: list[dict[str, Any]],
+    *,
+    region: str,
+    resource_group: str,
+    description_terms: tuple[str, ...],
+    excluded_terms: tuple[str, ...] = (),
+) -> tuple[Decimal, str]:
+    for sku in skus:
+        category = sku.get("category")
+        if not isinstance(category, dict):
+            continue
+        regions = sku.get("serviceRegions")
+        description = str(sku.get("description") or "").lower()
+        if (
+            str(category.get("usageType") or "") != "OnDemand"
+            or str(category.get("resourceGroup") or "") != resource_group
+            or any(term.lower() not in description for term in description_terms)
+            or any(term.lower() in description for term in excluded_terms)
+            or not isinstance(regions, list)
+            or region not in regions
+        ):
+            continue
+        price, unit = _unit_price(sku)
+        if price:
+            return price, unit
+    return Decimal("0"), ""
+
+
+def _machine_shape(project_id: str, zone: str, machine_type: str) -> tuple[int, Decimal, str]:
+    rc, stdout, stderr = _capture(
+        [
+            "gcloud",
+            "compute",
+            "machine-types",
+            "describe",
+            machine_type,
+            "--project",
+            project_id,
+            "--zone",
+            zone,
+            "--format=json",
+        ]
+    )
+    if rc != 0:
+        return 0, Decimal("0"), stderr or "machine shape could not be resolved"
+    try:
+        payload = json.loads(stdout)
+        cpus = int(payload["guestCpus"])
+        memory_gib = Decimal(str(payload["memoryMb"])) / Decimal(1024)
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return 0, Decimal("0"), "machine shape response was invalid"
+    return cpus, memory_gib, ""
+
+
+def estimate_gcp_vm_cost(
+    *,
+    project_id: str,
+    zone: str,
+    state: dict[str, Any],
+    currency: str = "USD",
+    cache_dir: Path | None = None,
+) -> CostEstimate:
+    """Estimate fixed hourly VM and persistent-disk charges from deployed state."""
+
+    inputs = _read_inputs(state)
+    machine_type = str(inputs.get("machine_type") or "").strip()
+    disk_type = str(inputs.get("boot_disk_type") or "").strip()
+    try:
+        disk_gib = Decimal(str(inputs.get("boot_disk_size_gb") or 0))
+    except Exception:
+        disk_gib = Decimal("0")
+    if not machine_type or not disk_type or disk_gib <= 0:
+        return CostEstimate(False, detail="deployed VM pricing inputs are unavailable")
+
+    cpus, memory_gib, detail = _machine_shape(project_id, zone, machine_type)
+    if detail:
+        return CostEstimate(False, detail=detail)
+    token, detail = _access_token()
+    if detail:
+        return CostEstimate(False, detail=detail)
+    region = zone.rsplit("-", 1)[0]
+    cache_file = (
+        cache_dir / f"gcp-compute-prices-{region}-{currency.lower()}.json"
+        if cache_dir
+        else None
+    )
+    skus, detail = _public_compute_skus(
+        token,
+        currency,
+        region=region,
+        cache_file=cache_file,
+    )
+    if detail:
+        return CostEstimate(False, detail=detail)
+
+    family = machine_type.split("-", 1)[0].upper()
+    core_price, core_unit = _matching_price(
+        skus,
+        region=region,
+        resource_group="CPU",
+        description_terms=(f"{family} instance", "core"),
+    )
+    ram_price, ram_unit = _matching_price(
+        skus,
+        region=region,
+        resource_group="RAM",
+        description_terms=(f"{family} instance", "ram"),
+    )
+    disk_groups = {
+        "pd-standard": "PDStandard",
+        "pd-balanced": "PDBalanced",
+        "pd-ssd": "SSD",
+    }
+    disk_price, disk_unit = _matching_price(
+        skus,
+        region=region,
+        resource_group=disk_groups.get(disk_type, ""),
+        description_terms=("storage",),
+        excluded_terms=("regional",),
+    )
+    if not core_price or not ram_price or not disk_price:
+        return CostEstimate(False, detail="a public price was not found for the deployed VM shape")
+
+    compute_hourly = core_price * cpus + ram_price * memory_gib
+    disk_hourly = disk_price * disk_gib
+    if "mo" in disk_unit.lower():
+        disk_hourly /= _HOURS_PER_MONTH
+    if "h" not in core_unit.lower() or "h" not in ram_unit.lower():
+        return CostEstimate(False, detail="the public compute price used an unsupported unit")
+    hourly = (compute_hourly + disk_hourly).quantize(Decimal("0.0001"))
+    return CostEstimate(
+        True,
+        hourly=hourly,
+        currency=currency,
+        basis="public list price; usage-based network charges excluded",
+    )

--- a/hyops/runtime/gcp_cost.py
+++ b/hyops/runtime/gcp_cost.py
@@ -198,6 +198,11 @@ def estimate_gcp_vm_cost(
         disk_gib = Decimal("0")
     if not machine_type or not disk_type or disk_gib <= 0:
         return CostEstimate(False, detail="deployed VM pricing inputs are unavailable")
+    outputs = state.get("outputs")
+    vms = outputs.get("vms") if isinstance(outputs, dict) else None
+    vm_count = len(vms) if isinstance(vms, dict) else 1
+    if vm_count < 1:
+        return CostEstimate(False, detail="deployed VM outputs are unavailable")
 
     cpus, memory_gib, detail = _machine_shape(project_id, zone, machine_type)
     if detail:
@@ -248,8 +253,8 @@ def estimate_gcp_vm_cost(
     if not core_price or not ram_price or not disk_price:
         return CostEstimate(False, detail="a public price was not found for the deployed VM shape")
 
-    compute_hourly = core_price * cpus + ram_price * memory_gib
-    disk_hourly = disk_price * disk_gib
+    compute_hourly = (core_price * cpus + ram_price * memory_gib) * vm_count
+    disk_hourly = disk_price * disk_gib * vm_count
     if "mo" in disk_unit.lower():
         disk_hourly /= _HOURS_PER_MONTH
     if "h" not in core_unit.lower() or "h" not in ram_unit.lower():
@@ -259,5 +264,9 @@ def estimate_gcp_vm_cost(
         True,
         hourly=hourly,
         currency=currency,
-        basis="public list price; usage-based network charges excluded",
+        basis=(
+            f"public list price for {vm_count} VM"
+            f"{'s' if vm_count != 1 else ''} and boot disk"
+            f"{'s' if vm_count != 1 else ''}; usage-based network charges excluded"
+        ),
     )

--- a/hyops/runtime/tests/test_gcp_cost.py
+++ b/hyops/runtime/tests/test_gcp_cost.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+from hyops.runtime.cost import CostEstimate, format_money
+from hyops.runtime.gcp_cost import estimate_gcp_vm_cost
+
+
+def _sku(
+    description: str,
+    resource_group: str,
+    units: str,
+    nanos: int,
+    usage_unit: str,
+) -> dict:
+    return {
+        "description": description,
+        "serviceRegions": ["europe-west2"],
+        "category": {
+            "usageType": "OnDemand",
+            "resourceGroup": resource_group,
+        },
+        "pricingInfo": [
+            {
+                "pricingExpression": {
+                    "usageUnit": usage_unit,
+                    "tieredRates": [
+                        {
+                            "unitPrice": {
+                                "units": units,
+                                "nanos": nanos,
+                            }
+                        }
+                    ],
+                }
+            }
+        ],
+    }
+
+
+class GcpCostTests(unittest.TestCase):
+    def test_formats_estimated_amount(self) -> None:
+        estimate = CostEstimate(True, hourly=Decimal("0.5"), currency="USD")
+        self.assertEqual(estimate.amount_for_seconds(5400), Decimal("0.75"))
+        self.assertEqual(format_money(estimate.hourly, estimate.currency), "USD 0.50")
+
+    def test_estimates_compute_and_disk_from_deployed_inputs(self) -> None:
+        skus = [
+            _sku("N2 Instance Core running in London", "CPU", "0", 50_000_000, "h"),
+            _sku("N2 Instance Ram running in London", "RAM", "0", 10_000_000, "GiBy.h"),
+            _sku("Storage PD Capacity in London", "PDStandard", "0", 40_000_000, "GiBy.mo"),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs = Path(tmp) / "inputs.yml"
+            inputs.write_text(
+                "machine_type: n2-standard-8\n"
+                "boot_disk_type: pd-standard\n"
+                "boot_disk_size_gb: 100\n",
+                encoding="utf-8",
+            )
+            with (
+                patch(
+                    "hyops.runtime.gcp_cost._machine_shape",
+                    return_value=(8, Decimal("32"), ""),
+                ),
+                patch("hyops.runtime.gcp_cost._access_token", return_value=("token", "")),
+                patch(
+                    "hyops.runtime.gcp_cost._public_compute_skus",
+                    return_value=(skus, ""),
+                ),
+            ):
+                estimate = estimate_gcp_vm_cost(
+                    project_id="student-project",
+                    zone="europe-west2-b",
+                    state={"rerun_inputs_file": str(inputs)},
+                )
+
+        self.assertTrue(estimate.available)
+        self.assertEqual(estimate.hourly, Decimal("0.7255"))
+        self.assertIn("network charges excluded", estimate.basis)
+
+    def test_returns_unavailable_when_pricing_inputs_are_absent(self) -> None:
+        estimate = estimate_gcp_vm_cost(
+            project_id="student-project",
+            zone="europe-west2-b",
+            state={},
+        )
+        self.assertFalse(estimate.available)
+        self.assertIn("inputs", estimate.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hyops/runtime/tests/test_gcp_cost.py
+++ b/hyops/runtime/tests/test_gcp_cost.py
@@ -92,6 +92,44 @@ class GcpCostTests(unittest.TestCase):
         self.assertFalse(estimate.available)
         self.assertIn("inputs", estimate.detail)
 
+    def test_multiplies_shared_shape_by_deployed_vm_count(self) -> None:
+        skus = [
+            _sku("N2 Instance Core running in London", "CPU", "0", 50_000_000, "h"),
+            _sku("N2 Instance Ram running in London", "RAM", "0", 10_000_000, "GiBy.h"),
+            _sku("Storage PD Capacity in London", "PDStandard", "0", 40_000_000, "GiBy.mo"),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs = Path(tmp) / "inputs.yml"
+            inputs.write_text(
+                "machine_type: n2-standard-8\n"
+                "boot_disk_type: pd-standard\n"
+                "boot_disk_size_gb: 100\n",
+                encoding="utf-8",
+            )
+            with (
+                patch(
+                    "hyops.runtime.gcp_cost._machine_shape",
+                    return_value=(8, Decimal("32"), ""),
+                ),
+                patch("hyops.runtime.gcp_cost._access_token", return_value=("token", "")),
+                patch(
+                    "hyops.runtime.gcp_cost._public_compute_skus",
+                    return_value=(skus, ""),
+                ),
+            ):
+                estimate = estimate_gcp_vm_cost(
+                    project_id="student-project",
+                    zone="europe-west2-b",
+                    state={
+                        "rerun_inputs_file": str(inputs),
+                        "outputs": {"vms": {"vm-1": {}, "vm-2": {}}},
+                    },
+                )
+
+        self.assertTrue(estimate.available)
+        self.assertEqual(estimate.hourly, Decimal("1.4510"))
+        self.assertIn("2 VMs", estimate.basis)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #230

## Summary

- estimate fixed Compute Engine and persistent-disk cost from deployed state and current public pricing
- account for every VM published by the access state
- show billing state, hourly estimate, cautious resource-age maximum and access-session estimate
- report zero ongoing cost only after all declared GCP blueprint states are terminal
- keep access and destroy available when pricing cannot be resolved
- show live progress while the first price catalogue is resolved

## Validation

- `bash tools/ci/check-python.sh` (206 tests)
- live public-price lookup for `n2-standard-8`, `pd-standard`, `europe-west2`
- full pull-request quality and package matrix
- checksum and installer work remain unchanged