### PR TITLE
Fix deletion-only Proxmox VM-set shrink

### DIFF
--- a/hyops/drivers/iac/terragrunt/contracts/proxmox_vm.py
+++ b/hyops/drivers/iac/terragrunt/contracts/proxmox_vm.py
@@ -1172,6 +1172,62 @@ class ProxmoxVmContract(TerragruntModuleContract):
             return out, warnings, "runtime.state_dir is required"
 
         state_dir = Path(state_dir_raw).expanduser().resolve()
+
+        # Evaluate the managed VM-set safety rail before probing the clone
+        # template. A confirmed strict subset is a deletion-only lifecycle
+        # operation: it can safely render a plan even when the historical
+        # source template has since been retired.
+        requested_vm_names = _collect_requested_vm_names(out)
+        confirmed_deletion_only_vm_set = False
+        if requested_vm_names:
+            raw_state_instance = str(runtime.get("state_instance") or "").strip().lower()
+            current_slot = f"instance:{raw_state_instance}" if raw_state_instance else "latest"
+
+            existing_by_slot, existing_err = _collect_existing_managed_vm_names_by_slot(
+                state_dir, module_ref
+            )
+            if existing_err:
+                return out, warnings, existing_err
+
+            existing_vm_names = existing_by_slot.get(current_slot, set())
+            if existing_vm_names and existing_vm_names != requested_vm_names:
+                allow_replace = as_bool(out.get("allow_vm_set_replace"), default=False)
+                diff = _format_vm_set_diff(existing_vm_names, requested_vm_names)
+                if not allow_replace:
+                    return (
+                        out,
+                        warnings,
+                        "vm set collision detected: requested VM names differ from existing managed VM names "
+                        f"for module_ref={module_ref}; {diff}. "
+                        "This run would replace active VMs. Use a separate env/module scope, or explicitly set "
+                        "inputs.allow_vm_set_replace=true when replacement is intentional.",
+                    )
+                confirmed_deletion_only_vm_set = requested_vm_names < existing_vm_names
+                warnings.append(
+                    "allow_vm_set_replace=true: proceeding despite VM set collision "
+                    f"for module_ref={module_ref}; {diff}"
+                )
+
+            # Guard against duplicated VM names across different state slots
+            # (for example latest vs instance), which can silently create
+            # duplicate Proxmox VMs with clashing IP/name intent.
+            cross_slot_conflicts: list[str] = []
+            for slot, names in existing_by_slot.items():
+                if slot == current_slot:
+                    continue
+                overlap = sorted(names & requested_vm_names)
+                if overlap:
+                    cross_slot_conflicts.append(f"{slot} overlap={overlap}")
+            if cross_slot_conflicts:
+                detail = "; ".join(cross_slot_conflicts)
+                return (
+                    out,
+                    warnings,
+                    "vm name collision detected across module state slots "
+                    f"for module_ref={module_ref}: requested={sorted(requested_vm_names)}; {detail}. "
+                    "Use one slot consistently (latest or a single state_instance), or destroy the stale slot first.",
+                )
+
         if template_state_ref and as_positive_int(out.get("template_vm_id")) is None:
             try:
                 state_payload = read_module_state(state_dir, template_state_ref)
@@ -1251,19 +1307,25 @@ class ProxmoxVmContract(TerragruntModuleContract):
                 if probe_err:
                     warnings.append(f"template vm probe skipped: {probe_err}")
                 elif not exists:
-                    if template_state_ref:
-                        source_hint = (
-                            f"template_vm_id={resolved_template_vm_id} resolved from template_state_ref={template_state_ref}"
+                    if confirmed_deletion_only_vm_set:
+                        warnings.append(
+                            f"template_vm_id={resolved_template_vm_id} is unavailable; allowing confirmed "
+                            "deletion-only VM-set shrink because allow_vm_set_replace=true"
                         )
                     else:
-                        source_hint = f"configured template_vm_id={resolved_template_vm_id}"
-                    return (
-                        out,
-                        warnings,
-                        f"{source_hint}, but no VM/template with that ID exists on the Proxmox host. "
-                        "Rebuild or reseed the template first "
-                        "(for example: core/onprem/template-image or core/onprem/vyos-template-seed).",
-                    )
+                        if template_state_ref:
+                            source_hint = (
+                                f"template_vm_id={resolved_template_vm_id} resolved from template_state_ref={template_state_ref}"
+                            )
+                        else:
+                            source_hint = f"configured template_vm_id={resolved_template_vm_id}"
+                        return (
+                            out,
+                            warnings,
+                            f"{source_hint}, but no VM/template with that ID exists on the Proxmox host. "
+                            "Rebuild or reseed the template first "
+                            "(for example: core/onprem/template-image or core/onprem/vyos-template-seed).",
+                        )
                 elif not is_template:
                     return (
                         out,
@@ -1274,57 +1336,6 @@ class ProxmoxVmContract(TerragruntModuleContract):
             else:
                 warnings.append(
                     "template vm probe skipped: proxmox API or SSH runtime credentials are not available"
-                )
-
-        # Hard safety rail: prevent accidental destructive replacement of an
-        # already-managed VM set under the same module_ref in the same env.
-        requested_vm_names = _collect_requested_vm_names(out)
-        if requested_vm_names:
-            raw_state_instance = str(runtime.get("state_instance") or "").strip().lower()
-            current_slot = f"instance:{raw_state_instance}" if raw_state_instance else "latest"
-
-            existing_by_slot, existing_err = _collect_existing_managed_vm_names_by_slot(
-                state_dir, module_ref
-            )
-            if existing_err:
-                return out, warnings, existing_err
-
-            existing_vm_names = existing_by_slot.get(current_slot, set())
-            if existing_vm_names and existing_vm_names != requested_vm_names:
-                allow_replace = as_bool(out.get("allow_vm_set_replace"), default=False)
-                diff = _format_vm_set_diff(existing_vm_names, requested_vm_names)
-                if not allow_replace:
-                    return (
-                        out,
-                        warnings,
-                        "vm set collision detected: requested VM names differ from existing managed VM names "
-                        f"for module_ref={module_ref}; {diff}. "
-                        "This run would replace active VMs. Use a separate env/module scope, or explicitly set "
-                        "inputs.allow_vm_set_replace=true when replacement is intentional.",
-                    )
-                warnings.append(
-                    "allow_vm_set_replace=true: proceeding despite VM set collision "
-                    f"for module_ref={module_ref}; {diff}"
-                )
-
-            # Guard against duplicated VM names across different state slots
-            # (for example latest vs instance), which can silently create
-            # duplicate Proxmox VMs with clashing IP/name intent.
-            cross_slot_conflicts: list[str] = []
-            for slot, names in existing_by_slot.items():
-                if slot == current_slot:
-                    continue
-                overlap = sorted(names & requested_vm_names)
-                if overlap:
-                    cross_slot_conflicts.append(f"{slot} overlap={overlap}")
-            if cross_slot_conflicts:
-                detail = "; ".join(cross_slot_conflicts)
-                return (
-                    out,
-                    warnings,
-                    "vm name collision detected across module state slots "
-                    f"for module_ref={module_ref}: requested={sorted(requested_vm_names)}; {detail}. "
-                    "Use one slot consistently (latest or a single state_instance), or destroy the stale slot first.",
                 )
 
         # Fail fast when a VM consumer targets HybridOps SDN bridges (vnet*) but the shared SDN

--- a/hyops/drivers/iac/terragrunt/tests/test_proxmox_vm_contract.py
+++ b/hyops/drivers/iac/terragrunt/tests/test_proxmox_vm_contract.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from hyops.drivers.iac.terragrunt.contracts.proxmox_vm import ProxmoxVmContract
+
+
+class ProxmoxVmContractDeletionOnlyTests(unittest.TestCase):
+    def _run_contract(
+        self,
+        *,
+        existing: set[str],
+        requested: set[str],
+        allow_replace: bool,
+    ) -> tuple[dict, list[str], str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            module_dir = (
+                state_dir
+                / "modules"
+                / "platform__onprem__platform-vm"
+                / "instances"
+            )
+            module_dir.mkdir(parents=True)
+            (module_dir / "platform_vms.json").write_text(
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "outputs": {
+                            "vms": {name: {"vm_id": index + 100} for index, name in enumerate(sorted(existing))}
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            inputs = {
+                "template_vm_id": 107,
+                "allow_vm_set_replace": allow_replace,
+                "vms": {name: {} for name in sorted(requested)},
+            }
+            credentials = {
+                "proxmox_url": "https://proxmox.invalid:8006/api2/json",
+                "proxmox_token_id": "automation@pam!infra-token",
+                "proxmox_token_secret": "test-only",
+                "proxmox_node": "pve",
+            }
+            with patch(
+                "hyops.drivers.iac.terragrunt.contracts.proxmox_vm._probe_proxmox_vm_exists",
+                return_value=(False, False, ""),
+            ):
+                return ProxmoxVmContract().preprocess_inputs(
+                    command_name="plan",
+                    module_ref="platform/onprem/platform-vm",
+                    inputs=inputs,
+                    profile_policy={},
+                    runtime={
+                        "state_dir": str(state_dir),
+                        "state_instance": "platform_vms",
+                        "env": "shared",
+                    },
+                    env={"HYOPS_ENV": "shared"},
+                    credential_env=credentials,
+                )
+
+    def test_missing_template_is_allowed_for_confirmed_strict_subset(self) -> None:
+        _, warnings, error = self._run_contract(
+            existing={"netbox-01", "pgcore-01"},
+            requested={"netbox-01"},
+            allow_replace=True,
+        )
+
+        self.assertEqual(error, "")
+        self.assertTrue(any("deletion-only VM-set shrink" in warning for warning in warnings))
+
+    def test_missing_template_still_blocks_mixed_replacement(self) -> None:
+        _, _, error = self._run_contract(
+            existing={"netbox-01", "pgcore-01"},
+            requested={"netbox-01", "replacement-01"},
+            allow_replace=True,
+        )
+
+        self.assertIn("no VM/template with that ID exists", error)
+
+    def test_vm_set_shrink_still_requires_explicit_confirmation(self) -> None:
+        _, _, error = self._run_contract(
+            existing={"netbox-01", "pgcore-01"},
+            requested={"netbox-01"},
+            allow_replace=False,
+        )
+
+        self.assertIn("allow_vm_set_replace=true", error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

HybridOps probes the historical clone template before it decides whether a managed VM-set change only removes VMs. If that template has already been retired, a deletion-only change is blocked even though cloning is not part of the plan.

Closes #234.

## Change

- evaluate the existing VM-set safety rail before probing the clone template;
- recognize only an explicitly confirmed strict-subset change as deletion-only;
- allow that narrow path to continue when the historical template is absent;
- continue blocking mixed replacement, additions, and unconfirmed shrink operations;
- preserve cross-state-slot collision checks;
- add focused regression coverage for all three paths.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /home/user/.hybridops/core/venv/bin/python -m unittest hyops.drivers.iac.terragrunt.tests.test_proxmox_vm_contract -v`
- `pipx run --spec 'ruff==0.13.2' ruff check --config tools/ci/ruff.toml hyops/drivers/iac/terragrunt/contracts/proxmox_vm.py hyops/drivers/iac/terragrunt/tests/test_proxmox_vm_contract.py`
- `git diff --cached --check`

## Assumptions and scope

This does not weaken normal template validation. The exception applies only when the requested VM names are a strict subset of the names already recorded in the same state slot and `allow_vm_set_replace=true` explicitly confirms the change.
