### PR TITLE
Clean up DMS resources on external replica destroy

### DIFF
--- a/hyops/runtime/module_state_contracts.py
+++ b/hyops/runtime/module_state_contracts.py
@@ -2062,6 +2062,12 @@ def resolve_postgresql_dr_source_contract_from_state(
     assumed_state_ok: set[str] | None = None,
 ) -> None:
     """Resolve PostgreSQL DR source assessment outputs from upstream state."""
+    lifecycle_command = str(inputs.get("_hyops_lifecycle_command") or "").strip().lower()
+    if lifecycle_command == "destroy":
+        # Destroy owns the downstream resources named in its inputs. It must
+        # remain possible after the source database has already been retired.
+        return
+
     apply_mode = str(inputs.get("apply_mode") or "").strip().lower()
     if apply_mode == "status" and str(inputs.get("replica_state_ref") or "").strip():
         return

--- a/hyops/runtime/tests/test_postgresql_dr_source_contract.py
+++ b/hyops/runtime/tests/test_postgresql_dr_source_contract.py
@@ -1,0 +1,28 @@
+import unittest
+
+from hyops.runtime.module_state_contracts import (
+    resolve_postgresql_dr_source_contract_from_state,
+)
+
+
+class PostgreSqlDrSourceContractTests(unittest.TestCase):
+    def test_destroy_does_not_require_live_source_state(self) -> None:
+        inputs = {
+            "_hyops_lifecycle_command": "destroy",
+            "source_state_ref": "platform/onprem/postgresql-dr-source#retired-source",
+        }
+
+        resolve_postgresql_dr_source_contract_from_state(inputs, state_root=None)
+
+    def test_apply_still_requires_source_state(self) -> None:
+        inputs = {
+            "_hyops_lifecycle_command": "apply",
+            "source_state_ref": "platform/onprem/postgresql-dr-source#missing-source",
+        }
+
+        with self.assertRaisesRegex(ValueError, "requires runtime state_dir"):
+            resolve_postgresql_dr_source_contract_from_state(inputs, state_root=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/org/gcp/cloudsql-external-replica/README.md
+++ b/modules/org/gcp/cloudsql-external-replica/README.md
@@ -31,6 +31,7 @@ This keeps replication secrets out of Terraform state and aligns the managed DR 
 - assess an existing Cloud SQL target
 - create DMS source and destination connection profiles
 - create and optionally start a DMS migration job
+- remove the module-owned DMS migration job and connection profiles on destroy
 - publish normalized readiness, establishment, and endpoint outputs
 
 ## Not in scope yet
@@ -102,6 +103,35 @@ when no upstream bastion state exists.
 
 `gcloud` must already be authenticated for the current operator. The module copies the current `~/.config/gcloud` into the runtime cache on first use so long-running or packaged runs do not depend on write access to the default config directory.
 
+## Destroy behavior
+
+`hyops destroy` removes the DMS migration job first, waits for the asynchronous
+deletion to finish, and then removes any remaining source or destination
+connection profiles. Missing objects are treated as already destroyed, so the
+operation can be rerun safely.
+
+The destroy path never passes `--force` to `gcloud`. This is deliberate:
+Google's force-delete options can also delete the destination Cloud SQL
+database. A promoted or otherwise independent Cloud SQL database remains
+outside this module's destroy boundary and must be retired separately through
+its owning lifecycle.
+
+Before deleting anything, the module verifies access to the target project.
+When the default HybridOps runtime gcloud cache has expired and
+`gcloud_copy_default_config=true`, destroy refreshes that cache from the
+current operator gcloud configuration and checks project access again.
+Explicit `gcloud_runtime_config_dir` values are never replaced automatically.
+
+For an established lane, the destroy inputs must resolve:
+
+- `project_id` or `target_project_id`
+- `region` or `target_region`
+- `migration_job_name`
+- `source_connection_profile_name`
+- `destination_connection_profile_name`
+
+Assessment-only state with no DMS object names remains a state-only destroy.
+
 State resolution rule:
 
 - same-env is the default
@@ -143,6 +173,7 @@ Project service requirement:
 - `managed_replication_prereqs_ready`
 - `managed_replication_established`
 - `cap.db.managed_external_replica = assessed|established`
+- `dms_cleanup` (destroy evidence: project, region, removed object names, and the Cloud SQL safety boundary)
 
 `managed_replication_ready_for_cutover=true` means the DMS job is currently `RUNNING`.
 
@@ -157,7 +188,8 @@ Operator rule:
 
 After promote or failback, the establish state can remain `ok` as historical
 evidence while the status instance correctly flips to `error` because the live
-migration job is no longer `RUNNING`.
+migration job is no longer `RUNNING`. Run `hyops destroy` for that establish
+state when the DMS control-plane objects should also be retired.
 
 The endpoint outputs intentionally match the client-facing contract already used by `platform/postgresql-ha`:
 

--- a/modules/org/gcp/cloudsql-external-replica/spec.yml
+++ b/modules/org/gcp/cloudsql-external-replica/spec.yml
@@ -123,6 +123,7 @@ outputs:
     - managed_replication_prereqs_ready
     - managed_replication_established
     - cap.db.managed_external_replica
+    - dms_cleanup
 
 probes: []
 constraints: []

--- a/modules/org/gcp/cloudsql-external-replica/tests/test_destroy_contract.py
+++ b/modules/org/gcp/cloudsql-external-replica/tests/test_destroy_contract.py
@@ -1,0 +1,188 @@
+from pathlib import Path
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+
+class CloudSqlExternalReplicaDestroyContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        core_root = Path(__file__).resolve().parents[5]
+        cls.playbook_path = (
+            core_root
+            / "packs"
+            / "config"
+            / "ansible"
+            / "gcp"
+            / "org"
+            / "12-cloudsql-external-replica@v1.0"
+            / "stack"
+            / "destroy.playbook.yml"
+        )
+        cls.play = yaml.safe_load(cls.playbook_path.read_text(encoding="utf-8"))[0]
+        cls.tasks = {task["name"]: task for task in cls.play["tasks"]}
+
+    def test_destroy_uses_input_driven_gcloud_identifiers(self) -> None:
+        rendered = self.playbook_path.read_text(encoding="utf-8")
+
+        self.assertIn("{{ migration_job_name }}", rendered)
+        self.assertIn("{{ item }}", rendered)
+        self.assertIn("--project={{ project_id }}", rendered)
+        self.assertIn("--region={{ region }}", rendered)
+
+    def test_destroy_never_force_deletes_cloud_sql(self) -> None:
+        delete_tasks = [
+            self.tasks["Delete DMS migration job without deleting its Cloud SQL database"],
+            self.tasks["Delete remaining DMS connection profiles without deleting Cloud SQL"],
+        ]
+
+        for task in delete_tasks:
+            argv = task["ansible.builtin.command"]["argv"]
+            self.assertNotIn("--force", argv)
+            self.assertIn("--quiet", argv)
+
+        outputs = self.tasks["Write HyOps outputs"]["ansible.builtin.copy"]["content"]
+        self.assertIn("'cloudsql_database_deleted': false", outputs)
+
+    def test_destroy_orders_job_before_connection_profiles_and_verifies_absence(self) -> None:
+        names = [task["name"] for task in self.play["tasks"]]
+
+        self.assertLess(
+            names.index("Delete DMS migration job without deleting its Cloud SQL database"),
+            names.index("Delete remaining DMS connection profiles without deleting Cloud SQL"),
+        )
+        self.assertIn("Wait for DMS migration job deletion", names)
+        self.assertIn("Verify DMS connection profiles are absent", names)
+
+    def test_missing_objects_are_idempotent(self) -> None:
+        delete_tasks = [
+            self.tasks["Delete DMS migration job without deleting its Cloud SQL database"],
+            self.tasks["Delete remaining DMS connection profiles without deleting Cloud SQL"],
+        ]
+
+        for task in delete_tasks:
+            conditions = "\n".join(task["failed_when"]).lower()
+            self.assertIn("not_found", conditions)
+            self.assertIn("does not exist", conditions)
+
+    def test_destroy_executes_and_can_be_rerun_when_objects_are_absent(self) -> None:
+        ansible_playbook = shutil.which("ansible-playbook")
+        if not ansible_playbook:
+            self.skipTest("ansible-playbook is not installed")
+
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = Path(raw_tmp)
+            state_dir = tmp / "fake-dms"
+            state_dir.mkdir()
+            for name in ("job-1", "destination-1", "source-1"):
+                (state_dir / name).touch()
+
+            fake_gcloud = tmp / "gcloud"
+            fake_gcloud.write_text(
+                """#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+state_dir = Path(os.environ["FAKE_DMS_STATE_DIR"])
+
+if args[:1] == ["version"]:
+    print("Google Cloud SDK test")
+    raise SystemExit(0)
+if args[:2] == ["auth", "list"]:
+    print("operator@example.com")
+    raise SystemExit(0)
+if args[:2] == ["projects", "describe"]:
+    print(args[2])
+    raise SystemExit(0)
+
+kind = ""
+action = ""
+if args[:3] == ["database-migration", "migration-jobs", "delete"]:
+    kind, action = "job", "delete"
+elif args[:3] == ["database-migration", "migration-jobs", "describe"]:
+    kind, action = "job", "describe"
+elif args[:3] == ["database-migration", "connection-profiles", "delete"]:
+    kind, action = "profile", "delete"
+elif args[:3] == ["database-migration", "connection-profiles", "describe"]:
+    kind, action = "profile", "describe"
+else:
+    print(f"unsupported fake gcloud invocation: {args}", file=sys.stderr)
+    raise SystemExit(2)
+
+name = args[3]
+resource = state_dir / name
+if action == "describe":
+    if resource.exists():
+        print("{}")
+        raise SystemExit(0)
+    print("ERROR: NOT_FOUND: resource does not exist", file=sys.stderr)
+    raise SystemExit(1)
+
+if resource.exists():
+    resource.unlink()
+    if kind == "job":
+        destination = state_dir / os.environ["FAKE_DMS_DEST_PROFILE"]
+        if destination.exists():
+            destination.unlink()
+    raise SystemExit(0)
+
+print("ERROR: NOT_FOUND: resource does not exist", file=sys.stderr)
+raise SystemExit(1)
+""",
+                encoding="utf-8",
+            )
+            fake_gcloud.chmod(0o755)
+
+            outputs_file = tmp / "outputs.json"
+            runtime_root = tmp / "runtime"
+            runtime_root.mkdir()
+            home = tmp / "home"
+            home.mkdir()
+
+            extra_vars = {
+                "hyops_runtime_root": str(runtime_root),
+                "hyops_outputs_file": str(outputs_file),
+                "project_id": "test-project",
+                "region": "test-region",
+                "migration_job_name": "job-1",
+                "destination_connection_profile_name": "destination-1",
+                "source_connection_profile_name": "source-1",
+                "gcloud_bin": str(fake_gcloud),
+                "gcloud_copy_default_config": False,
+                "gcloud_runtime_config_dir": str(tmp / "gcloud-config"),
+                "gcloud_active_account": "operator@example.com",
+            }
+            argv = [
+                ansible_playbook,
+                "-i",
+                "localhost,",
+                str(self.playbook_path),
+                "--extra-vars",
+                json.dumps(extra_vars),
+            ]
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            env["FAKE_DMS_STATE_DIR"] = str(state_dir)
+            env["FAKE_DMS_DEST_PROFILE"] = "destination-1"
+
+            first = subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
+            self.assertEqual(first.returncode, 0, msg=f"{first.stdout}\n{first.stderr}")
+            self.assertEqual(list(state_dir.iterdir()), [])
+            outputs = json.loads(outputs_file.read_text(encoding="utf-8"))
+            self.assertEqual(outputs["cap.db.managed_external_replica"], "destroyed")
+            self.assertFalse(outputs["dms_cleanup"]["cloudsql_database_deleted"])
+
+            second = subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
+            self.assertEqual(second.returncode, 0, msg=f"{second.stdout}\n{second.stderr}")
+            self.assertEqual(list(state_dir.iterdir()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packs/config/ansible/gcp/org/12-cloudsql-external-replica@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/gcp/org/12-cloudsql-external-replica@v1.0/stack/destroy.playbook.yml
@@ -1,12 +1,381 @@
 ---
 - name: Destroy org/gcp/cloudsql-external-replica
   hosts: localhost
+  connection: local
   gather_facts: false
 
+  vars:
+    _hyops_input_project_id: >-
+      {{
+        (vars.get('project_id', '') | default('', true) | string)
+        or (vars.get('target_project_id', '') | default('', true) | string)
+      }}
+    _hyops_input_region: >-
+      {{
+        (vars.get('region', '') | default('', true) | string)
+        or (vars.get('target_region', '') | default('', true) | string)
+      }}
+    _hyops_input_migration_job_name: >-
+      {{ vars.get('migration_job_name', '') | default('', true) | string }}
+    _hyops_input_source_connection_profile_name: >-
+      {{ vars.get('source_connection_profile_name', '') | default('', true) | string }}
+    _hyops_input_destination_connection_profile_name: >-
+      {{ vars.get('destination_connection_profile_name', '') | default('', true) | string }}
+    _hyops_input_gcloud_bin: "{{ vars.get('gcloud_bin', 'gcloud') | string }}"
+    _hyops_input_gcloud_copy_default_config: >-
+      {{ vars.get('gcloud_copy_default_config', true) | bool }}
+    _hyops_input_gcloud_runtime_config_dir: >-
+      {{ vars.get('gcloud_runtime_config_dir', '') | default('', true) | string }}
+    _hyops_input_gcloud_active_account: >-
+      {{ vars.get('gcloud_active_account', '') | default('', true) | string }}
+    _hyops_gcloud_config_dir: >-
+      {{
+        (_hyops_input_gcloud_runtime_config_dir | string)
+        if (_hyops_input_gcloud_runtime_config_dir | length) > 0
+        else (hyops_runtime_root ~ '/cache/gcloud')
+      }}
+    _hyops_gcloud_uses_default_runtime_cache: >-
+      {{ (_hyops_input_gcloud_runtime_config_dir | length) == 0 }}
+    _hyops_default_gcloud_config_dir: "{{ lookup('env', 'HOME') ~ '/.config/gcloud' }}"
+
+  pre_tasks:
+    - name: Normalize DMS destroy inputs
+      ansible.builtin.set_fact:
+        project_id: "{{ _hyops_input_project_id }}"
+        region: "{{ _hyops_input_region }}"
+        migration_job_name: "{{ _hyops_input_migration_job_name }}"
+        source_connection_profile_name: "{{ _hyops_input_source_connection_profile_name }}"
+        destination_connection_profile_name: "{{ _hyops_input_destination_connection_profile_name }}"
+        gcloud_bin: "{{ _hyops_input_gcloud_bin }}"
+        gcloud_copy_default_config: "{{ _hyops_input_gcloud_copy_default_config }}"
+        gcloud_active_account: "{{ _hyops_input_gcloud_active_account }}"
+        _hyops_dms_object_names: >-
+          {{
+            [
+              _hyops_input_migration_job_name,
+              _hyops_input_destination_connection_profile_name,
+              _hyops_input_source_connection_profile_name
+            ]
+            | reject('equalto', '')
+            | unique
+            | list
+          }}
+        _hyops_dms_connection_profile_names: >-
+          {{
+            [
+              _hyops_input_destination_connection_profile_name,
+              _hyops_input_source_connection_profile_name
+            ]
+            | reject('equalto', '')
+            | unique
+            | list
+          }}
+      changed_when: false
+
+    - name: Require project and region when DMS objects are declared
+      ansible.builtin.assert:
+        that:
+          - (project_id | length) > 0
+          - (region | length) > 0
+        fail_msg: >-
+          inputs.project_id/target_project_id and inputs.region/target_region
+          are required to destroy declared DMS objects.
+      when: (_hyops_dms_object_names | length) > 0
+
+    - name: Ensure runtime gcloud config directory exists
+      ansible.builtin.file:
+        path: "{{ _hyops_gcloud_config_dir }}"
+        state: directory
+        mode: "0700"
+      when: (_hyops_dms_object_names | length) > 0
+
+    - name: Check default gcloud config sentinel
+      ansible.builtin.stat:
+        path: "{{ _hyops_default_gcloud_config_dir }}/config_sentinel"
+      register: _hyops_default_gcloud_cfg
+      when: (_hyops_dms_object_names | length) > 0
+
+    - name: Check runtime gcloud config sentinel
+      ansible.builtin.stat:
+        path: "{{ _hyops_gcloud_config_dir }}/config_sentinel"
+      register: _hyops_runtime_gcloud_cfg
+      when: (_hyops_dms_object_names | length) > 0
+
+    - name: Copy default gcloud config into runtime cache
+      ansible.builtin.command:
+        argv:
+          - cp
+          - -a
+          - "{{ _hyops_default_gcloud_config_dir }}/."
+          - "{{ _hyops_gcloud_config_dir }}/"
+      changed_when: true
+      when:
+        - (_hyops_dms_object_names | length) > 0
+        - gcloud_copy_default_config | bool
+        - _hyops_default_gcloud_cfg.stat.exists
+        - not _hyops_runtime_gcloud_cfg.stat.exists
+
+    - name: Require gcloud binary
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - version
+      changed_when: false
+      when: (_hyops_dms_object_names | length) > 0
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
+    - name: Check cached gcloud project access
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - projects
+          - describe
+          - "{{ project_id }}"
+          - --format=value(projectId)
+      register: _hyops_gcloud_project_access
+      changed_when: false
+      failed_when: false
+      when: (_hyops_dms_object_names | length) > 0
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
+    - name: Remove stale default runtime gcloud cache
+      ansible.builtin.file:
+        path: "{{ _hyops_gcloud_config_dir }}"
+        state: absent
+      when:
+        - (_hyops_dms_object_names | length) > 0
+        - (_hyops_gcloud_project_access.rc | int) != 0
+        - _hyops_gcloud_uses_default_runtime_cache | bool
+        - gcloud_copy_default_config | bool
+        - _hyops_default_gcloud_cfg.stat.exists
+
+    - name: Recreate runtime gcloud cache after stale credentials
+      ansible.builtin.file:
+        path: "{{ _hyops_gcloud_config_dir }}"
+        state: directory
+        mode: "0700"
+      when:
+        - (_hyops_dms_object_names | length) > 0
+        - (_hyops_gcloud_project_access.rc | int) != 0
+        - _hyops_gcloud_uses_default_runtime_cache | bool
+        - gcloud_copy_default_config | bool
+        - _hyops_default_gcloud_cfg.stat.exists
+
+    - name: Refresh stale runtime gcloud cache from current operator config
+      ansible.builtin.command:
+        argv:
+          - cp
+          - -a
+          - "{{ _hyops_default_gcloud_config_dir }}/."
+          - "{{ _hyops_gcloud_config_dir }}/"
+      changed_when: true
+      when:
+        - (_hyops_dms_object_names | length) > 0
+        - (_hyops_gcloud_project_access.rc | int) != 0
+        - _hyops_gcloud_uses_default_runtime_cache | bool
+        - gcloud_copy_default_config | bool
+        - _hyops_default_gcloud_cfg.stat.exists
+
+    - name: Recheck gcloud project access after credential refresh
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - projects
+          - describe
+          - "{{ project_id }}"
+          - --format=value(projectId)
+      register: _hyops_gcloud_project_access_refreshed
+      changed_when: false
+      failed_when: false
+      when:
+        - (_hyops_dms_object_names | length) > 0
+        - (_hyops_gcloud_project_access.rc | int) != 0
+        - _hyops_gcloud_uses_default_runtime_cache | bool
+        - gcloud_copy_default_config | bool
+        - _hyops_default_gcloud_cfg.stat.exists
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
+    - name: Normalize effective gcloud project access result
+      ansible.builtin.set_fact:
+        _hyops_gcloud_project_access_effective: >-
+          {{
+            _hyops_gcloud_project_access_refreshed
+            if (
+              _hyops_gcloud_project_access_refreshed is defined
+              and not (_hyops_gcloud_project_access_refreshed.skipped | default(false) | bool)
+            )
+            else _hyops_gcloud_project_access
+          }}
+      changed_when: false
+      when: (_hyops_dms_object_names | length) > 0
+
+    - name: Require authenticated access to the target GCP project
+      ansible.builtin.assert:
+        that:
+          - (_hyops_gcloud_project_access_effective.rc | int) == 0
+          - (_hyops_gcloud_project_access_effective.stdout | trim) == (project_id | trim)
+        fail_msg: >-
+          The selected gcloud configuration cannot access project {{ project_id }}.
+          Refresh authentication with hyops init gcp or gcloud auth login before retrying.
+      when: (_hyops_dms_object_names | length) > 0
+
+    - name: Resolve active gcloud account
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - auth
+          - list
+          - --filter=status:ACTIVE
+          - --format=value(account)
+      register: _hyops_gcloud_account
+      changed_when: false
+      when: (_hyops_dms_object_names | length) > 0
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
+    - name: Require an active gcloud account
+      ansible.builtin.assert:
+        that:
+          - (_hyops_gcloud_account.stdout | default('') | trim | length) > 0
+        fail_msg: "No active gcloud account is available for DMS cleanup."
+      when: (_hyops_dms_object_names | length) > 0
+
+    - name: Reject an unexpected gcloud account
+      ansible.builtin.assert:
+        that:
+          - (_hyops_gcloud_account.stdout | trim) == (gcloud_active_account | trim)
+        fail_msg: >-
+          The active gcloud account does not match inputs.gcloud_active_account.
+          Observed={{ _hyops_gcloud_account.stdout | trim }}
+          expected={{ gcloud_active_account | trim }}.
+      when:
+        - (_hyops_dms_object_names | length) > 0
+        - (gcloud_active_account | length) > 0
+
   tasks:
+    - name: Delete DMS migration job without deleting its Cloud SQL database
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - database-migration
+          - migration-jobs
+          - delete
+          - "{{ migration_job_name }}"
+          - --project={{ project_id }}
+          - --region={{ region }}
+          - --quiet
+      register: _hyops_dms_job_delete
+      changed_when: (_hyops_dms_job_delete.rc | int) == 0
+      failed_when:
+        - (_hyops_dms_job_delete.rc | int) != 0
+        - "'not_found' not in ((_hyops_dms_job_delete.stdout | default('') ~ ' ' ~ _hyops_dms_job_delete.stderr | default('')) | lower)"
+        - "'does not exist' not in ((_hyops_dms_job_delete.stdout | default('') ~ ' ' ~ _hyops_dms_job_delete.stderr | default('')) | lower)"
+      when: (migration_job_name | length) > 0
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
+    - name: Wait for DMS migration job deletion
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - database-migration
+          - migration-jobs
+          - describe
+          - "{{ migration_job_name }}"
+          - --project={{ project_id }}
+          - --region={{ region }}
+          - --format=json
+      register: _hyops_dms_job_absent
+      changed_when: false
+      failed_when: false
+      until: >-
+        (_hyops_dms_job_absent.rc | int) != 0
+        and (
+          'not_found' in ((_hyops_dms_job_absent.stdout | default('') ~ ' ' ~ _hyops_dms_job_absent.stderr | default('')) | lower)
+          or 'does not exist' in ((_hyops_dms_job_absent.stdout | default('') ~ ' ' ~ _hyops_dms_job_absent.stderr | default('')) | lower)
+        )
+      retries: 30
+      delay: 5
+      when:
+        - (migration_job_name | length) > 0
+        - (_hyops_dms_job_delete.rc | default(1) | int) == 0
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
+    - name: Delete remaining DMS connection profiles without deleting Cloud SQL
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - database-migration
+          - connection-profiles
+          - delete
+          - "{{ item }}"
+          - --project={{ project_id }}
+          - --region={{ region }}
+          - --quiet
+      loop: "{{ _hyops_dms_connection_profile_names }}"
+      loop_control:
+        label: "{{ item }}"
+      register: _hyops_dms_profile_delete
+      changed_when: (_hyops_dms_profile_delete.rc | int) == 0
+      failed_when:
+        - (_hyops_dms_profile_delete.rc | int) != 0
+        - "'not_found' not in ((_hyops_dms_profile_delete.stdout | default('') ~ ' ' ~ _hyops_dms_profile_delete.stderr | default('')) | lower)"
+        - "'does not exist' not in ((_hyops_dms_profile_delete.stdout | default('') ~ ' ' ~ _hyops_dms_profile_delete.stderr | default('')) | lower)"
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
+    - name: Verify DMS connection profiles are absent
+      ansible.builtin.command:
+        argv:
+          - "{{ gcloud_bin }}"
+          - database-migration
+          - connection-profiles
+          - describe
+          - "{{ item }}"
+          - --project={{ project_id }}
+          - --region={{ region }}
+          - --format=json
+      loop: "{{ _hyops_dms_connection_profile_names }}"
+      loop_control:
+        label: "{{ item }}"
+      register: _hyops_dms_profiles_absent
+      changed_when: false
+      failed_when: false
+      until: >-
+        (_hyops_dms_profiles_absent.rc | int) != 0
+        and (
+          'not_found' in ((_hyops_dms_profiles_absent.stdout | default('') ~ ' ' ~ _hyops_dms_profiles_absent.stderr | default('')) | lower)
+          or 'does not exist' in ((_hyops_dms_profiles_absent.stdout | default('') ~ ' ' ~ _hyops_dms_profiles_absent.stderr | default('')) | lower)
+        )
+      retries: 30
+      delay: 5
+      environment:
+        CLOUDSDK_CONFIG: "{{ _hyops_gcloud_config_dir }}"
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+
     - name: Write HyOps outputs
       ansible.builtin.copy:
         dest: "{{ hyops_outputs_file }}"
         mode: "0600"
         content: |
-          {{ {'cap.db.managed_external_replica': 'destroyed'} | to_json }}
+          {{ {
+            'cap.db.managed_external_replica': 'destroyed',
+            'dms_cleanup': {
+              'project_id': (project_id | string),
+              'region': (region | string),
+              'migration_job_name': (migration_job_name | string),
+              'connection_profile_names': (_hyops_dms_connection_profile_names | list),
+              'cloudsql_database_deleted': false
+            }
+          } | to_json }}


### PR DESCRIPTION
## Problem

Destroying `org/gcp/cloudsql-external-replica` retires HybridOps state but leaves the module-owned Database Migration Service job and connection profiles behind. Cleanup can also become impossible after the upstream source state has already been retired.

Closes #235.

## Change

- resolve DMS cleanup identifiers from module inputs;
- verify project access before destructive operations;
- refresh a stale default HybridOps gcloud cache from the current operator session, while preserving explicit runtime config directories;
- delete the migration job first, wait for asynchronous removal, then delete any remaining connection profiles;
- treat missing objects as an idempotent success;
- never pass `--force`, preserving the destination Cloud SQL database outside this module's destroy boundary;
- allow downstream destroy without requiring a live upstream source state;
- expose `dms_cleanup` evidence and document the destroy contract;
- add lifecycle unit tests and an executable fake-gcloud Ansible test covering deletion and rerun.

## Validation

- source-state lifecycle tests: 2 passed;
- DMS destroy contract tests: 5 passed, including an executable first-run/idempotent-rerun scenario;
- `bash tools/ci/check-python.sh`: module catalog, compile/import checks, and 208 tests passed;
- Ruff 0.13.2: passed;
- `bash tools/ci/check-yaml.sh`: passed;
- `bash tools/ci/check-ansible.sh`: passed;
- `bash tools/ci/lint-ansible.sh`: passed (one pre-existing line-length warning in the question issue template);
- direct syntax check and production-profile lint of the destroy playbook: passed with no warnings;
- `git diff --check`: passed.

The destroy flow was also exercised twice against an authenticated GCP lane: the first run removed the remaining DMS objects and the second completed idempotently. The destination Cloud SQL instance was not deleted.

## Assumptions and scope

This module owns the DMS migration job and connection profiles only. Any promoted or independent Cloud SQL database remains under its own lifecycle and is deliberately not force-deleted here.
