### PR TITLE
Fix installed pack discovery without wrapper environment

### DIFF
--- a/hyops/runtime/packs.py
+++ b/hyops/runtime/packs.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 import os
+import sys
 
 
 class PackResolveError(RuntimeError):
@@ -55,6 +56,13 @@ def _find_packs_root_from_here(start: Path) -> Path | None:
     return None
 
 
+def _find_packs_root_from_install_prefix(prefix: Path) -> Path | None:
+    candidate = prefix.expanduser().resolve().parent / "app" / "packs"
+    if candidate.is_dir():
+        return candidate.resolve()
+    return None
+
+
 def resolve_packs_root(packs_root: str | None = None) -> Path:
     if packs_root:
         p = Path(packs_root).expanduser().resolve()
@@ -80,6 +88,10 @@ def resolve_packs_root(packs_root: str | None = None) -> Path:
     discovered = _find_packs_root_from_here(Path(__file__))
     if discovered:
         return discovered
+
+    installed = _find_packs_root_from_install_prefix(Path(sys.prefix))
+    if installed:
+        return installed
 
     raise PackNotFoundError("packs root not found; set HYOPS_PACKS_ROOT to an existing packs directory")
 

--- a/hyops/runtime/tests/test_packs.py
+++ b/hyops/runtime/tests/test_packs.py
@@ -1,0 +1,60 @@
+"""Pack root resolution contracts."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from hyops.runtime.packs import PackNotFoundError, resolve_packs_root
+
+
+class PackRootResolutionTests(unittest.TestCase):
+    def test_explicit_root_keeps_highest_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            explicit = root / "explicit"
+            environment = root / "environment"
+            core = root / "core"
+            for path in (explicit, environment, core / "packs"):
+                path.mkdir(parents=True)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "HYOPS_PACKS_ROOT": str(environment),
+                    "HYOPS_CORE_ROOT": str(core),
+                },
+            ):
+                self.assertEqual(resolve_packs_root(str(explicit)), explicit.resolve())
+
+    def test_installed_venv_finds_sibling_app_packs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            install_root = Path(tmp) / "core"
+            venv = install_root / "venv"
+            packs = install_root / "app" / "packs"
+            venv.mkdir(parents=True)
+            packs.mkdir(parents=True)
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {"HYOPS_PACKS_ROOT": "", "HYOPS_CORE_ROOT": ""},
+                ),
+                patch("hyops.runtime.packs.sys.prefix", str(venv)),
+                patch("hyops.runtime.packs._find_packs_root_from_here", return_value=None),
+            ):
+                self.assertEqual(resolve_packs_root(), packs.resolve())
+
+    def test_invalid_explicit_root_does_not_fall_back(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "missing"
+
+            with self.assertRaisesRegex(PackNotFoundError, "packs root not found"):
+                resolve_packs_root(str(missing))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -100,6 +100,7 @@ TMPDIR=/dev/shm ./pkg/verify_release.sh dist/releases/hybridops-core-<label>.tar
 - the shipped checksum manifest matches the extracted payload
 - `install.sh` can install the bundle into an isolated runtime root
 - installed `hyops` runs without relying on the source checkout
+- the installed runtime resolves its shipped packs without wrapper environment variables
 - the bundle and installed payload do not include vendored HybridOps collection source
 - installed `hyops` exposes `setup galaxy` and the compatible `setup ansible` path
 - the installed payload matches the shipped checksum manifest

--- a/pkg/verify_release.sh
+++ b/pkg/verify_release.sh
@@ -128,6 +128,19 @@ if [[ "${INSTALLED_VERSION}" != "${EXPECTED_VERSION}" ]]; then
   echo "ERR: installed version ${INSTALLED_VERSION} does not match release version ${EXPECTED_VERSION}" >&2
   exit 3
 fi
+INSTALLED_PACKS="$(
+  cd /
+  env -u PYTHONPATH -u HYOPS_CORE_ROOT -u HYOPS_PACKS_ROOT \
+    HOME="${HOME_DIR}" "${INSTALL_ROOT}/venv/bin/python3" - <<'PY'
+from hyops.runtime.packs import resolve_packs_root
+
+print(resolve_packs_root())
+PY
+)"
+if [[ "${INSTALLED_PACKS}" != "${INSTALLED_APP}/packs" ]]; then
+  echo "ERR: installed runtime resolved packs to ${INSTALLED_PACKS}, expected ${INSTALLED_APP}/packs" >&2
+  exit 3
+fi
 
 (
   cd /


### PR DESCRIPTION
Closes #238

## What changed

- preserve the existing explicit, environment, wrapper-root, and source-tree pack resolution paths
- add an installed-layout fallback that finds `app/packs` beside the active HybridOps virtual environment
- add unit coverage for precedence, installed-layout discovery, and invalid explicit paths
- make release verification prove that an isolated installed runtime resolves packs with `PYTHONPATH`, `HYOPS_CORE_ROOT`, and `HYOPS_PACKS_ROOT` removed
- document the new release verification contract

## Root cause

The public release already ships `packs/`, and the supported `hyops` wrapper exports `HYOPS_CORE_ROOT`. The internal virtual-environment entry point did not carry that wrapper environment and could not infer the installer's deterministic sibling `app` directory.

## Impact

Normal wrapper behaviour is unchanged. The fallback is additive and runs only after the existing resolution paths do not find a packs directory.

## Validation

- focused pack resolver tests: 3 passed
- full Python suite: 211 passed
- installer quality gate: passed
- Ruff: passed
- ShellCheck: passed
- release archive build: passed
- isolated release installation and pack-resolution verification: passed
