### PR TITLE
Preserve GNS3 projects across blueprint teardown

### DIFF
--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -1,7 +1,7 @@
 # GCP GNS3 Teaching Lab
 
 Deploy a private GNS3 server and a zero-image starter topology on Google Cloud.
-The VM has no public IP; SSH and desktop-client access use IAP.
+The VM has no public IP; SSH, Web UI and desktop-client access use IAP.
 
 ## Execution chain
 
@@ -33,21 +33,36 @@ hyops blueprint preflight --env gns3-gcp --ref gcp/gns3@v1
 hyops blueprint deploy --env gns3-gcp --ref gcp/gns3@v1 --execute
 ```
 
-## Connect a desktop client
+## Connect to GNS3
 
 ```bash
 hyops blueprint access --env gns3-gcp --ref gcp/gns3@v1
 ```
 
-Keep the command running and configure the GNS3 desktop client to use the
-printed loopback endpoint. Retrieve the API password when required:
+Keep the command running. Open the printed HTTP endpoint in a browser or
+configure the GNS3 desktop client to use it. The default username is `gns3`.
+Retrieve the password from the environment vault:
 
 ```bash
-hyops secrets show --env gns3-gcp GNS3_SERVER_PASSWORD
+hyops secrets show --env gns3-gcp --raw GNS3_SERVER_PASSWORD
 ```
 
 ## Remove the lab
 
 ```bash
 hyops blueprint destroy --env gns3-gcp --ref gcp/gns3@v1 --execute
+```
+
+The interactive destroy flow can export and verify GNS3 projects before
+teardown. Project topology, controller metadata and writable node disks are
+preserved; downloadable base images are rebuilt from their declarations.
+
+Restore the latest verified archive during redeployment:
+
+```bash
+hyops blueprint deploy \
+  --env gns3-gcp \
+  --ref gcp/gns3@v1 \
+  --execute \
+  --restore-labs
 ```

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -23,6 +23,28 @@ access:
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
 
+archive_before_destroy:
+  module_ref: "platform/linux/gns3-lab-archive"
+  state_instance: "gcp_gns3_lab_archive"
+  contract_prefix: "gns3_lab_archive"
+  contents_label: "projects and node state"
+  node_state: false
+  restore_overwrite_default: true
+  inputs:
+    inventory_state_ref: "platform/gcp/platform-vm#gcp_gns3_vm"
+    inventory_vm_groups:
+      targets:
+        - "gns3-01"
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: "~/.ssh/id_ed25519"
+    ssh_access_mode: "gcp-iap"
+    connectivity_wait_s: 90
+    become: true
+    become_user: "root"
+    gns3_lab_archive_action: "export"
+    gns3_lab_archive_include_images: false
+
 steps:
   - id: gcp_gns3_network
     module_ref: "platform/gcp/lab-network"

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -5,8 +5,8 @@ template. The blueprint provisions the VM and configures the authenticated
 GNS3 API through the provider-neutral Linux module.
 
 The API listens on the VM loopback interface. The access command opens a private
-SSH tunnel for the GNS3 desktop client; the server is not exposed to the local
-network by this blueprint.
+SSH tunnel for the bundled Web UI and GNS3 desktop client; the server is not
+exposed to the local network by this blueprint.
 
 ## Execution chain
 
@@ -46,7 +46,7 @@ hyops blueprint deploy \
   --execute
 ```
 
-## Connect a desktop client
+## Connect to GNS3
 
 ```bash
 hyops blueprint access \
@@ -54,12 +54,13 @@ hyops blueprint access \
   --ref onprem/gns3@v1
 ```
 
-Keep the command running and configure the GNS3 desktop client to use host
-`127.0.0.1`, port `3080` and protocol `HTTP`. Retrieve the generated password
-from the environment vault when configuring the client:
+Keep the command running. Open `http://127.0.0.1:3080/` in a browser or
+configure the GNS3 desktop client to use host `127.0.0.1`, port `3080` and
+protocol `HTTP`. The default username is `gns3`. Retrieve the generated
+password from the environment vault:
 
 ```bash
-hyops secrets show --env gns3-lab GNS3_SERVER_PASSWORD
+hyops secrets show --env gns3-lab --raw GNS3_SERVER_PASSWORD
 ```
 
 Press Ctrl-C in the access terminal to close the tunnel.
@@ -74,4 +75,17 @@ Press Ctrl-C in the access terminal to close the tunnel.
 - API: authenticated HTTP on VM loopback port 3080
 
 Ordinary blueprint destroy removes the workload VM and retains the reusable
-Ubuntu template.
+Ubuntu template. The interactive destroy flow can export and verify GNS3
+projects before teardown. Project topology, controller metadata and writable
+node disks are preserved; downloadable base images are rebuilt from their
+declarations.
+
+Restore the latest verified archive during redeployment:
+
+```bash
+hyops blueprint deploy \
+  --env gns3-lab \
+  --ref onprem/gns3@v1 \
+  --execute \
+  --restore-labs
+```

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -22,6 +22,26 @@ access:
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
 
+archive_before_destroy:
+  module_ref: "platform/linux/gns3-lab-archive"
+  state_instance: "gns3_lab_archive"
+  contract_prefix: "gns3_lab_archive"
+  contents_label: "projects and node state"
+  node_state: false
+  restore_overwrite_default: true
+  inputs:
+    inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+    inventory_vm_groups:
+      targets:
+        - "gns3-01"
+    target_user: "opsadmin"
+    ssh_proxy_jump_auto: true
+    ssh_proxy_jump_user: "root"
+    become: true
+    become_user: "root"
+    gns3_lab_archive_action: "export"
+    gns3_lab_archive_include_images: false
+
 steps:
   - id: template_image_jammy
     module_ref: "core/onprem/template-image"

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1377,6 +1377,25 @@ def run_access(ns) -> int:
         return OPERATOR_ERROR
 
 
+def _lab_archive_contract(lifecycle: dict[str, Any]) -> dict[str, Any]:
+    prefix = str(lifecycle.get("contract_prefix") or "eveng_lab_archive").strip()
+    return {
+        "prefix": prefix,
+        "contents_label": str(
+            lifecycle.get("contents_label") or "lab definitions"
+        ).strip(),
+        "node_state": bool(lifecycle.get("node_state", True)),
+        "restore_overwrite_default": bool(
+            lifecycle.get("restore_overwrite_default", False)
+        ),
+        "path_output": f"{prefix}_path",
+        "sha256_output": f"{prefix}_sha256",
+        "node_included_output": f"{prefix}_node_state_included",
+        "node_path_output": f"{prefix}_node_state_archive_path",
+        "node_sha256_output": f"{prefix}_node_state_sha256",
+    }
+
+
 def _verified_lab_archive(
     payload: dict[str, Any],
     paths,
@@ -1394,10 +1413,9 @@ def _verified_lab_archive(
     except FileNotFoundError:
         return None
     outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
-    archive_path = Path(
-        str(outputs.get("eveng_lab_archive_path") or "")
-    ).expanduser()
-    expected = str(outputs.get("eveng_lab_archive_sha256") or "").strip().lower()
+    contract = _lab_archive_contract(lifecycle)
+    archive_path = Path(str(outputs.get(contract["path_output"]) or "")).expanduser()
+    expected = str(outputs.get(contract["sha256_output"]) or "").strip().lower()
     if not archive_path.is_file() or not re.fullmatch(r"[0-9a-f]{64}", expected):
         return None
 
@@ -1410,12 +1428,14 @@ def _verified_lab_archive(
 
     node_archive: Path | None = None
     node_checksum = ""
-    if bool(outputs.get("eveng_lab_archive_node_state_included", False)):
+    if contract["node_state"] and bool(
+        outputs.get(contract["node_included_output"], False)
+    ):
         candidate = Path(
-            str(outputs.get("eveng_lab_archive_node_state_archive_path") or "")
+            str(outputs.get(contract["node_path_output"]) or "")
         ).expanduser()
         candidate_checksum = str(
-            outputs.get("eveng_lab_archive_node_state_sha256") or ""
+            outputs.get(contract["node_sha256_output"]) or ""
         ).strip().lower()
         if not candidate.is_file() or not re.fullmatch(
             r"[0-9a-f]{64}", candidate_checksum
@@ -1481,26 +1501,32 @@ def _run_lab_restore(
     archive: tuple[Path, str, Path | None, str],
 ) -> int:
     lifecycle = payload["archive_before_destroy"]
+    contract = _lab_archive_contract(lifecycle)
+    prefix = contract["prefix"]
     archive_path, checksum, node_archive_path, node_checksum = archive
     restore_inputs = dict(lifecycle.get("inputs") or {})
     restore_inputs.update(
         {
-            "eveng_lab_archive_action": "restore",
-            "eveng_lab_archive_path": str(archive_path),
-            "eveng_lab_archive_expected_sha256": checksum,
-            "eveng_lab_archive_include_node_state": False,
-            "eveng_lab_archive_stop_running_nodes": False,
-            "eveng_lab_archive_overwrite": bool(
-                getattr(ns, "overwrite_labs", False)
-            ),
+            f"{prefix}_action": "restore",
+            f"{prefix}_path": str(archive_path),
+            f"{prefix}_expected_sha256": checksum,
+            f"{prefix}_overwrite": bool(getattr(ns, "overwrite_labs", False))
+            or contract["restore_overwrite_default"],
         }
     )
-    if node_archive_path is not None:
+    if contract["node_state"]:
         restore_inputs.update(
             {
-                "eveng_lab_archive_restore_node_state": True,
-                "eveng_lab_archive_node_state_path": str(node_archive_path),
-                "eveng_lab_archive_node_state_expected_sha256": node_checksum,
+                f"{prefix}_include_node_state": False,
+                f"{prefix}_stop_running_nodes": False,
+            }
+        )
+    if contract["node_state"] and node_archive_path is not None:
+        restore_inputs.update(
+            {
+                f"{prefix}_restore_node_state": True,
+                f"{prefix}_node_state_path": str(node_archive_path),
+                f"{prefix}_node_state_expected_sha256": node_checksum,
             }
         )
     restore_step = {
@@ -2079,10 +2105,11 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
             state_instance=archive["state_instance"],
         )
         outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
+        contract = _lab_archive_contract(archive)
         archive_path = Path(
-            str(outputs.get("eveng_lab_archive_path") or "")
+            str(outputs.get(contract["path_output"]) or "")
         ).expanduser()
-        expected = str(outputs.get("eveng_lab_archive_sha256") or "").strip().lower()
+        expected = str(outputs.get(contract["sha256_output"]) or "").strip().lower()
         if not archive_path.is_file() or not expected:
             raise ValueError("lab export did not publish a verifiable archive")
         digest = hashlib.sha256()
@@ -2096,17 +2123,19 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
     if actual != expected:
         print("ERR: lab archive checksum verification failed; no resources were destroyed")
         return OPERATOR_ERROR
-    archive_contents = ["lab definitions"]
+    archive_contents = [contract["contents_label"]]
     verbose = bool(os.getenv("HYOPS_VERBOSE"))
     if verbose:
         print(f"lab archive: {archive_path}")
         print(f"sha256: {actual}")
-    if bool(outputs.get("eveng_lab_archive_node_state_included", False)):
+    if contract["node_state"] and bool(
+        outputs.get(contract["node_included_output"], False)
+    ):
         node_archive_path = Path(
-            str(outputs.get("eveng_lab_archive_node_state_archive_path") or "")
+            str(outputs.get(contract["node_path_output"]) or "")
         ).expanduser()
         node_expected = str(
-            outputs.get("eveng_lab_archive_node_state_sha256") or ""
+            outputs.get(contract["node_sha256_output"]) or ""
         ).strip().lower()
         if not node_archive_path.is_file() or not re.fullmatch(
             r"[0-9a-f]{64}", node_expected

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -252,7 +252,15 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         raw_archive = as_mapping(
             spec.get("archive_before_destroy"), "archive_before_destroy"
         )
-        allowed = {"module_ref", "state_instance", "inputs"}
+        allowed = {
+            "module_ref",
+            "state_instance",
+            "inputs",
+            "contract_prefix",
+            "contents_label",
+            "node_state",
+            "restore_overwrite_default",
+        }
         unknown = sorted(str(key) for key in raw_archive if str(key) not in allowed)
         if unknown:
             raise ValueError(
@@ -273,7 +281,31 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 "archive_before_destroy.state_instance",
             ),
             "inputs": archive_inputs if isinstance(archive_inputs, dict) else {},
+            "contract_prefix": as_non_empty_string(
+                raw_archive.get("contract_prefix", "eveng_lab_archive"),
+                "archive_before_destroy.contract_prefix",
+            ),
+            "contents_label": as_non_empty_string(
+                raw_archive.get("contents_label", "lab definitions"),
+                "archive_before_destroy.contents_label",
+            ),
+            "node_state": bool_field(
+                raw_archive.get("node_state", True),
+                "archive_before_destroy.node_state",
+            ),
+            "restore_overwrite_default": bool_field(
+                raw_archive.get("restore_overwrite_default", False),
+                "archive_before_destroy.restore_overwrite_default",
+            ),
         }
+        if not re.fullmatch(
+            r"[a-z][a-z0-9_]*",
+            archive_before_destroy["contract_prefix"],
+        ):
+            raise ValueError(
+                "archive_before_destroy.contract_prefix must be a lowercase "
+                "input/output prefix"
+            )
 
     raw_steps = spec.get("steps")
     if not isinstance(raw_steps, list) or not raw_steps:

--- a/hyops/blueprint/tests/test_gcp_gns3.py
+++ b/hyops/blueprint/tests/test_gcp_gns3.py
@@ -42,6 +42,17 @@ class GCPGNS3BlueprintTest(TestCase):
         self.assertEqual(health["requires"], ["gcp_gns3_starter_lab"])
         self.assertTrue(health["inputs"]["gns3_healthcheck_deep"])
 
+    def test_destroy_protects_gns3_project_state(self) -> None:
+        archive = self.blueprint["archive_before_destroy"]
+        self.assertEqual(
+            archive["module_ref"],
+            "platform/linux/gns3-lab-archive",
+        )
+        self.assertEqual(archive["contract_prefix"], "gns3_lab_archive")
+        self.assertFalse(archive["node_state"])
+        self.assertTrue(archive["restore_overwrite_default"])
+        self.assertFalse(archive["inputs"]["gns3_lab_archive_include_images"])
+
     def test_images_are_verified_before_starter_lab(self) -> None:
         image_step = self.blueprint["steps"][3]
         self.assertEqual(image_step["requires"], ["gcp_gns3_server"])

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -59,6 +59,17 @@ class OnPremGNS3BlueprintTest(TestCase):
             "ubuntu-22.04",
         )
 
+    def test_destroy_protects_gns3_project_state(self) -> None:
+        archive = self.blueprint["archive_before_destroy"]
+        self.assertEqual(
+            archive["module_ref"],
+            "platform/linux/gns3-lab-archive",
+        )
+        self.assertEqual(archive["contract_prefix"], "gns3_lab_archive")
+        self.assertFalse(archive["node_state"])
+        self.assertTrue(archive["restore_overwrite_default"])
+        self.assertFalse(archive["inputs"]["gns3_lab_archive_include_images"])
+
     def test_healthcheck_runs_disposable_vpcs_lifecycle(self) -> None:
         health_step = self.blueprint["steps"][5]
         self.assertEqual(health_step["requires"], ["gns3_starter_lab"])

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -157,3 +157,43 @@ class BlueprintLabRestoreTest(TestCase):
             inputs["eveng_lab_archive_node_state_expected_sha256"],
             "c" * 64,
         )
+
+    def test_gns3_restore_uses_declared_archive_contract(self):
+        payload = {
+            "archive_before_destroy": {
+                "module_ref": "platform/linux/gns3-lab-archive",
+                "state_instance": "gns3_archive",
+                "contract_prefix": "gns3_lab_archive",
+                "node_state": False,
+                "restore_overwrite_default": True,
+                "inputs": {
+                    "inventory_state_ref": "platform/test/vm#gns3_vm",
+                    "gns3_lab_archive_action": "export",
+                },
+            }
+        }
+        archive = (Path("/tmp/gns3-labs.tar.gz"), "d" * 64, None, "")
+        with patch(
+            "hyops.blueprint.command.run_step_module_command",
+            return_value=0,
+        ) as command:
+            rc = _run_lab_restore(
+                _namespace(restore_labs=True),
+                payload,
+                SimpleNamespace(),
+                archive,
+            )
+
+        self.assertEqual(rc, 0)
+        inputs = command.call_args.args[0]["inputs"]
+        self.assertEqual(inputs["gns3_lab_archive_action"], "restore")
+        self.assertEqual(
+            inputs["gns3_lab_archive_path"],
+            "/tmp/gns3-labs.tar.gz",
+        )
+        self.assertEqual(
+            inputs["gns3_lab_archive_expected_sha256"],
+            "d" * 64,
+        )
+        self.assertTrue(inputs["gns3_lab_archive_overwrite"])
+        self.assertNotIn("gns3_lab_archive_include_node_state", inputs)

--- a/hyops/validators/builtin/register.py
+++ b/hyops/validators/builtin/register.py
@@ -50,6 +50,7 @@ from hyops.validators.platform.linux import (
     eve_ng_images,
     eve_ng_lab_archive,
     eve_ng_labs,
+    gns3_lab_archive,
     gns3_images,
 )
 from hyops.validators.platform.onprem import (
@@ -109,6 +110,7 @@ def register_all() -> None:
     register("platform/linux/eve-ng-labs", eve_ng_labs.validate)
     register("platform/linux/eve-ng-healthcheck", eve_ng_healthcheck.validate)
     register("platform/linux/gns3-images", gns3_images.validate)
+    register("platform/linux/gns3-lab-archive", gns3_lab_archive.validate)
     register("platform/network/vyos-edge-wan", vyos_edge_wan.validate)
     register("platform/network/edge-observability", edge_observability.validate)
     register("platform/network/cloudflare-traffic-steering", cloudflare_traffic_steering.validate)

--- a/hyops/validators/platform/linux/gns3_lab_archive.py
+++ b/hyops/validators/platform/linux/gns3_lab_archive.py
@@ -1,0 +1,95 @@
+"""
+purpose: Validate inputs for platform/linux/gns3-lab-archive module.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePath
+import re
+from typing import Any
+
+from hyops.validators.common import (
+    normalize_required_env,
+    require_mapping,
+    require_non_empty_str,
+    require_port,
+    require_str_list,
+)
+from hyops.validators.platform.linux._eve_ng_common import validate_target_access
+
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def validate(inputs: dict[str, Any]) -> None:
+    data = require_mapping(inputs, "inputs")
+    validate_target_access(
+        data,
+        module_ref="platform/linux/gns3-lab-archive",
+        require_ubuntu=True,
+        require_eveng=False,
+    )
+    require_non_empty_str(
+        data.get("gns3_lab_archive_role_fqcn"),
+        "inputs.gns3_lab_archive_role_fqcn",
+    )
+    action = require_non_empty_str(
+        data.get("gns3_lab_archive_action"),
+        "inputs.gns3_lab_archive_action",
+    ).lower()
+    if action not in {"export", "restore"}:
+        raise ValueError("inputs.gns3_lab_archive_action must be export or restore")
+
+    for field in (
+        "gns3_lab_archive_data_root",
+        "gns3_lab_archive_remote_dir",
+    ):
+        value = require_non_empty_str(data.get(field), f"inputs.{field}")
+        if not value.startswith("/"):
+            raise ValueError(f"inputs.{field} must be an absolute path")
+
+    if action == "export":
+        archive_name = require_non_empty_str(
+            data.get("gns3_lab_archive_name"),
+            "inputs.gns3_lab_archive_name",
+        )
+        if archive_name != PurePath(archive_name).name:
+            raise ValueError("inputs.gns3_lab_archive_name must be a safe filename")
+    else:
+        archive_path = require_non_empty_str(
+            data.get("gns3_lab_archive_path"),
+            "inputs.gns3_lab_archive_path",
+        )
+        if not archive_path.startswith("/"):
+            raise ValueError("inputs.gns3_lab_archive_path must be an absolute path")
+        checksum = require_non_empty_str(
+            data.get("gns3_lab_archive_expected_sha256"),
+            "inputs.gns3_lab_archive_expected_sha256",
+        )
+        if not _SHA256_RE.fullmatch(checksum):
+            raise ValueError(
+                "inputs.gns3_lab_archive_expected_sha256 must contain "
+                "64 hexadecimal characters"
+            )
+
+    for field in (
+        "gns3_lab_archive_overwrite",
+        "gns3_lab_archive_include_images",
+        "gns3_lab_archive_manage_service",
+    ):
+        if not isinstance(data.get(field), bool):
+            raise ValueError(f"inputs.{field} must be a boolean")
+
+    require_port(data.get("gns3_lab_archive_port"), "inputs.gns3_lab_archive_port")
+    require_non_empty_str(
+        data.get("gns3_lab_archive_username"),
+        "inputs.gns3_lab_archive_username",
+    )
+    require_non_empty_str(
+        data.get("gns3_lab_archive_password_env"),
+        "inputs.gns3_lab_archive_password_env",
+    )
+    if data.get("required_env_destroy") is not None:
+        require_str_list(data.get("required_env_destroy"), "inputs.required_env_destroy")
+    normalize_required_env(data.get("required_env"), "inputs.required_env")

--- a/hyops/validators/platform/linux/tests/test_gns3_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_gns3_lab_archive.py
@@ -1,0 +1,64 @@
+"""Tests for the GNS3 lab archive module validator."""
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from hyops.validators.platform.linux.gns3_lab_archive import validate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MODULE_ROOT = REPO_ROOT / "modules" / "platform" / "linux" / "gns3-lab-archive"
+
+
+def valid_inputs() -> dict:
+    spec = yaml.safe_load((MODULE_ROOT / "spec.yml").read_text(encoding="utf-8"))
+    inputs = deepcopy(spec["inputs"]["defaults"])
+    inputs.update(
+        {
+            "target_host": "127.0.0.1",
+            "connectivity_check": False,
+        }
+    )
+    return inputs
+
+
+class GNS3LabArchiveValidatorTests(unittest.TestCase):
+    def test_export_defaults_are_valid(self) -> None:
+        validate(valid_inputs())
+
+    def test_restore_requires_archive_and_checksum(self) -> None:
+        inputs = valid_inputs()
+        inputs["gns3_lab_archive_action"] = "restore"
+        with self.assertRaises(ValueError):
+            validate(inputs)
+
+    def test_restore_accepts_verified_archive(self) -> None:
+        inputs = valid_inputs()
+        inputs.update(
+            {
+                "gns3_lab_archive_action": "restore",
+                "gns3_lab_archive_path": "/tmp/labs.tar.gz",
+                "gns3_lab_archive_expected_sha256": "a" * 64,
+                "gns3_lab_archive_overwrite": True,
+            }
+        )
+        validate(inputs)
+
+    def test_relative_data_root_is_rejected(self) -> None:
+        inputs = valid_inputs()
+        inputs["gns3_lab_archive_data_root"] = "var/lib/gns3"
+        with self.assertRaisesRegex(ValueError, "absolute path"):
+            validate(inputs)
+
+    def test_boolean_settings_are_required(self) -> None:
+        inputs = valid_inputs()
+        inputs["gns3_lab_archive_include_images"] = "false"
+        with self.assertRaisesRegex(ValueError, "must be a boolean"):
+            validate(inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/platform/linux/gns3-lab-archive/README.md
+++ b/modules/platform/linux/gns3-lab-archive/README.md
@@ -1,0 +1,18 @@
+# platform/linux/gns3-lab-archive
+
+Export GNS3 projects and controller metadata before workload teardown and
+restore them after redeployment. Project directories include topology files
+and writable node disks.
+
+Base images are excluded by default because the declared image step can
+download them again. Set `gns3_lab_archive_include_images` only when the archive
+must carry the image library.
+
+The default controller-side archive path is:
+
+```text
+artifacts/gns3/labs/gns3-labs.tar.gz
+```
+
+Restore verifies the recorded SHA-256 checksum before replacing the freshly
+generated GNS3 controller state.

--- a/modules/platform/linux/gns3-lab-archive/examples/export.yml
+++ b/modules/platform/linux/gns3-lab-archive/examples/export.yml
@@ -1,0 +1,7 @@
+inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+inventory_vm_groups:
+  targets:
+    - "gns3-01"
+target_user: "opsadmin"
+gns3_lab_archive_action: export
+gns3_lab_archive_include_images: false

--- a/modules/platform/linux/gns3-lab-archive/examples/restore.yml
+++ b/modules/platform/linux/gns3-lab-archive/examples/restore.yml
@@ -1,0 +1,9 @@
+inventory_state_ref: "platform/onprem/platform-vm#gns3_vm"
+inventory_vm_groups:
+  targets:
+    - "gns3-01"
+target_user: "opsadmin"
+gns3_lab_archive_action: restore
+gns3_lab_archive_path: "/srv/hybridops/gns3/gns3-labs.tar.gz"
+gns3_lab_archive_expected_sha256: "CHANGE_ME"
+gns3_lab_archive_overwrite: true

--- a/modules/platform/linux/gns3-lab-archive/spec.yml
+++ b/modules/platform/linux/gns3-lab-archive/spec.yml
@@ -1,0 +1,81 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/gns3-lab-archive"
+
+metadata:
+  title: "Linux GNS3 Lab Archive"
+  description: "Export or restore GNS3 projects and controller state without retaining the workload VM."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+
+    required_env:
+      - "GNS3_SERVER_PASSWORD"
+    required_env_destroy: []
+    load_vault_env: true
+
+    gns3_lab_archive_role_fqcn: "hybridops.app.gns3_lab_archive"
+    gns3_lab_archive_action: "export"
+    gns3_lab_archive_data_root: "/var/lib/gns3"
+    gns3_lab_archive_name: "gns3-labs.tar.gz"
+    gns3_lab_archive_path: ""
+    gns3_lab_archive_expected_sha256: ""
+    gns3_lab_archive_overwrite: false
+    gns3_lab_archive_include_images: false
+    gns3_lab_archive_remote_dir: "/tmp/hyops-gns3-lab-archive"
+    gns3_lab_archive_owner: "gns3"
+    gns3_lab_archive_group: "gns3"
+    gns3_lab_archive_service: "gns3server"
+    gns3_lab_archive_manage_service: true
+    gns3_lab_archive_port: 3080
+    gns3_lab_archive_username: "gns3"
+    gns3_lab_archive_password_env: "GNS3_SERVER_PASSWORD"
+    gns3_lab_archive_api_wait_timeout: 60
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/49-gns3-lab-archive@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.gns3.archive
+    - gns3_lab_archive_action
+    - gns3_lab_archive_path
+    - gns3_lab_archive_manifest_path
+    - gns3_lab_archive_sha256
+    - gns3_lab_archive_created_at
+    - gns3_lab_archive_members
+    - gns3_lab_archive_images_included
+
+probes: []
+constraints: []

--- a/packs/config/ansible/linux/common/platform/49-gns3-lab-archive@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/49-gns3-lab-archive@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,19 @@
+---
+- name: Destroy platform/linux/gns3-lab-archive
+  hosts: targets
+  become: false
+  gather_facts: false
+
+  tasks: []
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.archive': 'retained'
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/49-gns3-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/49-gns3-lab-archive@v1.0/stack/playbook.yml
@@ -1,0 +1,58 @@
+---
+- name: platform/linux/gns3-lab-archive
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_runtime_root: "{{ lookup('env', 'HYOPS_RUNTIME_ROOT') | default('', true) | trim }}"
+    _hyops_archive_path: >-
+      {{
+        (gns3_lab_archive_path | default('') | trim)
+        if (gns3_lab_archive_path | default('') | trim | length > 0)
+        else (
+          _hyops_runtime_root ~ '/artifacts/gns3/labs/' ~
+          (gns3_lab_archive_name | default('gns3-labs.tar.gz'))
+        )
+      }}
+    gns3_lab_archive_password: >-
+      {{ lookup('env', gns3_lab_archive_password_env) }}
+
+  tasks:
+    - name: Require HybridOps runtime root for the default archive path
+      ansible.builtin.assert:
+        that:
+          - _hyops_archive_path | trim | length > 0
+          - >-
+            (gns3_lab_archive_path | default('') | trim | length > 0)
+            or (_hyops_runtime_root | length > 0)
+        fail_msg: "HYOPS_RUNTIME_ROOT is required when gns3_lab_archive_path is empty"
+
+    - name: Export or restore GNS3 labs
+      ansible.builtin.include_role:
+        name: "{{ gns3_lab_archive_role_fqcn }}"
+      vars:
+        gns3_lab_archive_resolved_path: "{{ _hyops_archive_path }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.gns3.archive': 'ready',
+            'gns3_lab_archive_action': gns3_lab_archive_results.action,
+            'gns3_lab_archive_path': gns3_lab_archive_results.archive_path,
+            'gns3_lab_archive_manifest_path':
+              gns3_lab_archive_results.manifest_path | default(''),
+            'gns3_lab_archive_sha256': gns3_lab_archive_results.sha256,
+            'gns3_lab_archive_created_at':
+              gns3_lab_archive_results.created_at | default(''),
+            'gns3_lab_archive_members':
+              gns3_lab_archive_results.members | default([]),
+            'gns3_lab_archive_images_included':
+              gns3_lab_archive_results.images_included | default(false)
+          } | to_json }}

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -6,7 +6,7 @@ collections:
     version: "0.1.8"
 
   - name: hybridops.app
-    version: "0.1.7"
+    version: "0.1.8"
 
   - name: ansible.posix
     version: "1.6.2"


### PR DESCRIPTION
Closes #240.

## Change

- generalise the blueprint archive contract for workload-specific inputs and outputs
- add the GNS3 archive module, validator and execution pack
- protect GCP and Proxmox GNS3 teardown with verified project export
- restore the latest verified archive after redeployment
- document browser and desktop-client access in both blueprint READMEs
- require the published `hybridops.app 0.1.8` collection

Base images remain outside the default archive and are recreated from their declarations.

## Validation

- `bash tools/ci/check-python.sh`
- `bash tools/ci/check-ruff.sh`
- `bash tools/ci/check-ansible.sh`
- live Proxmox export, teardown, redeployment and restore
- clean Galaxy installation of `hybridops.app 0.1.8`

Depends on hybridops-tech/ansible-collection-app#24.