### PR TITLE
Fix secrets exec argument routing

### DIFF
--- a/hyops/secrets/command.py
+++ b/hyops/secrets/command.py
@@ -227,7 +227,7 @@ def add_secrets_subparser(sp: argparse._SubParsersAction) -> None:
     x.add_argument("--vault-password-file", default=None, help="Vault password file.")
     x.add_argument("--vault-password-command", default=None, help="Command to output vault password.")
     x.add_argument(
-        "cmd",
+        "exec_argv",
         nargs=argparse.REMAINDER,
         help="Command to run (use -- before the command if it contains flags).",
     )
@@ -1997,7 +1997,7 @@ def run_exec(ns) -> int:
         print(f"ERR: vault file not found: {vault_path}")
         return CONFIG_INVALID
 
-    argv = list(getattr(ns, "cmd", []) or [])
+    argv = list(getattr(ns, "exec_argv", []) or [])
     if argv and argv[0] == "--":
         argv = argv[1:]
     if not argv:

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -67,6 +67,16 @@ class CliRoutingTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("invalid choice", result.stderr)
 
+    def test_secrets_exec_keeps_top_level_command_name(self) -> None:
+        from hyops.cli import build_parser
+
+        parsed = build_parser().parse_args(
+            ["secrets", "exec", "--env", "test", "--", "true"]
+        )
+
+        self.assertEqual(parsed.cmd, "secrets")
+        self.assertEqual(parsed.exec_argv, ["--", "true"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #242.

## Change

Give the command remainder its own parser destination so it cannot replace the top-level `secrets` command selection. Add a routing regression test for forwarded arguments.

## Validation

- `bash tools/ci/check-python.sh`
- `bash tools/ci/check-ruff.sh`
- live authenticated GNS3 API checks through `hyops secrets exec`.