### PR TITLE
Align the README module count

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <table align="center">
   <tr>
-    <td align="center"><strong>79</strong><br><sub>runtime modules</sub></td>
+    <td align="center"><strong>80</strong><br><sub>runtime modules</sub></td>
     <td align="center"><strong>28</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported targets</sub></td>


### PR DESCRIPTION
Closes #246.

## Change

- update the README runtime-module count from 79 to 80

## Validation

- confirmed 80 module specifications in the current catalogue
- ran the public metadata audit with the matching homepage correction
- `git diff --check`
