### PR TITLE
Create Windows launch shortcuts after installation

### DIFF
--- a/pkg/build_release.sh
+++ b/pkg/build_release.sh
@@ -292,8 +292,8 @@ HybridOps.Core for Windows 11 (WSL2)
 1. Extract every file from this ZIP archive.
 2. Run Install HybridOps.cmd.
 
-After a successful installation, use the optional HybridOps.Core desktop
-shortcut or open Ubuntu 24.04 from the Windows Start menu.
+After a successful installation, open HybridOps.Core from the desktop or from
+the extracted installer folder.
 
 The first Ubuntu launch may ask you to create a Linux username and password.
 Complete that prompt. Control returns to the installer automatically.

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -67,10 +67,12 @@ if grep -Fq 'start "Ubuntu 24.04 account setup"' "${WINDOWS_INSTALLER}"; then
   echo "ERR: Windows installer opens a separate Ubuntu account window" >&2
   exit 1
 fi
-grep -Fq "CreateShortcut([Environment]::GetFolderPath('Desktop')" "${WINDOWS_INSTALLER}"
+grep -Fq "Join-Path ([Environment]::GetFolderPath('Desktop')) 'HybridOps.Core.lnk'" "${WINDOWS_INSTALLER}"
+grep -Fq '$shell.CreateShortcut($shortcutPath)' "${WINDOWS_INSTALLER}"
 grep -Fq '$shortcut.TargetPath = $launcherPath' "${WINDOWS_INSTALLER}"
 grep -Fq 'set "LAUNCHER=!LAUNCHER_DIR!\Open HybridOps.cmd"' "${WINDOWS_INSTALLER}"
 grep -Fq 'copy /y "%PAYLOAD_DIR%\launcher.cmd" "!LAUNCHER!"' "${WINDOWS_INSTALLER}"
+grep -Fq 'set "INSTALL_DIR=%~dp0"' "${WINDOWS_INSTALLER}"
 WINDOWS_LAUNCHER="${HYOPS_REPO_ROOT}/tools/install/windows/launcher.cmd"
 grep -Fq 'Starting HybridOps.Core' "${WINDOWS_LAUNCHER}"
 grep -Fq "Write-Host 'HybridOps.Core ready.' -ForegroundColor Green" "${WINDOWS_LAUNCHER}"
@@ -86,14 +88,16 @@ grep -Fq 'set "HELPER=%PAYLOAD_DIR%\install-wsl.sh"' "${WINDOWS_INSTALLER}"
 grep -Fq 'test -e \"${HOME}/.hybridops/core\"' "${WINDOWS_INSTALLER}"
 grep -Fq 'Existing HybridOps.Core installation found.' "${WINDOWS_INSTALLER}"
 grep -Fq 'set "FORCE=true"' "${WINDOWS_INSTALLER}"
-grep -Fq "Copy-Item -Force -LiteralPath '%PAYLOAD_DIR%\hybridops.ico'" "${WINDOWS_INSTALLER}"
-grep -Fq "Test-Path -LiteralPath" "${WINDOWS_INSTALLER}"
-grep -Fq "set \"SHORTCUT_EXISTS=true\"" "${WINDOWS_INSTALLER}"
+grep -Fq "Copy-Item -Force -LiteralPath (Join-Path \$env:PAYLOAD_DIR 'hybridops.ico')" "${WINDOWS_INSTALLER}"
+grep -Fq "Join-Path \$env:INSTALL_DIR 'HybridOps.Core.lnk'" "${WINDOWS_INSTALLER}"
 if grep -Fq "Desktop shortcut updated:" "${WINDOWS_INSTALLER}"; then
   echo "ERR: Windows update announces routine shortcut refresh" >&2
   exit 1
 fi
-grep -Fq 'Create a HybridOps.Core desktop shortcut? [y/N]:' "${WINDOWS_INSTALLER}"
+if grep -Fq 'Create a HybridOps.Core desktop shortcut?' "${WINDOWS_INSTALLER}"; then
+  echo "ERR: Windows installer still prompts before creating launch shortcuts" >&2
+  exit 1
+fi
 grep -Fq 'set "WSL_SETUP_MARKER=%HYOPS_USER_DIR%\wsl-setup.pending"' "${WINDOWS_INSTALLER}"
 grep -Fq "Get-Process -Name 'wslsettings'" "${WINDOWS_INSTALLER}"
 grep -Fq '[void]$_.CloseMainWindow()' "${WINDOWS_INSTALLER}"

--- a/tools/install/windows/install-windows.cmd
+++ b/tools/install/windows/install-windows.cmd
@@ -5,6 +5,7 @@ rem purpose: Install HybridOps.Core into Ubuntu 24.04 on Windows WSL2.
 rem maintainer: HybridOps.Tech
 
 set "DISTRO=Ubuntu-24.04"
+set "INSTALL_DIR=%~dp0"
 set "PAYLOAD_DIR=%~dp0payload"
 set "HYOPS_USER_DIR=%LOCALAPPDATA%\HybridOps"
 set "WSL_SETUP_MARKER=%HYOPS_USER_DIR%\wsl-setup.pending"
@@ -306,32 +307,19 @@ if errorlevel 1 (
 )
 
 echo.
-set "CREATE_SHORTCUT="
-set "SHORTCUT_CREATED=false"
-set "SHORTCUT_EXISTS=false"
-powershell.exe -NoProfile -Command "$path = Join-Path ([Environment]::GetFolderPath('Desktop')) 'HybridOps.Core.lnk'; if (Test-Path -LiteralPath $path) { exit 0 }; exit 1"
-if not errorlevel 1 (
-  set "SHORTCUT_EXISTS=true"
-  set "CREATE_SHORTCUT=y"
+set "SHORTCUTS_CREATED=false"
+set "LAUNCHER_DIR=%HYOPS_USER_DIR%"
+set "LAUNCHER=!LAUNCHER_DIR!\Open HybridOps.cmd"
+if not exist "!LAUNCHER_DIR!" mkdir "!LAUNCHER_DIR!"
+copy /y "%PAYLOAD_DIR%\launcher.cmd" "!LAUNCHER!" >nul
+if errorlevel 1 (
+  echo WARN: unable to install the HybridOps.Core launcher.
 ) else (
-  set /p "CREATE_SHORTCUT=Create a HybridOps.Core desktop shortcut? [y/N]: "
-)
-if /I "!CREATE_SHORTCUT!"=="y" (
-  set "LAUNCHER_DIR=%HYOPS_USER_DIR%"
-  set "LAUNCHER=!LAUNCHER_DIR!\Open HybridOps.cmd"
-  if not exist "!LAUNCHER_DIR!" mkdir "!LAUNCHER_DIR!"
-  copy /y "%PAYLOAD_DIR%\launcher.cmd" "!LAUNCHER!" >nul
+  powershell.exe -NoProfile -Command "$iconDir = Join-Path $env:LOCALAPPDATA 'HybridOps'; $iconPath = Join-Path $iconDir 'hybridops.ico'; $launcherPath = $env:LAUNCHER; Copy-Item -Force -LiteralPath (Join-Path $env:PAYLOAD_DIR 'hybridops.ico') -Destination $iconPath; $shortcutPaths = @((Join-Path ([Environment]::GetFolderPath('Desktop')) 'HybridOps.Core.lnk'), (Join-Path $env:INSTALL_DIR 'HybridOps.Core.lnk')); $shell = New-Object -ComObject WScript.Shell; foreach ($shortcutPath in $shortcutPaths) { $shortcut = $shell.CreateShortcut($shortcutPath); $shortcut.TargetPath = $launcherPath; $shortcut.WorkingDirectory = $env:USERPROFILE; $shortcut.IconLocation = $iconPath + ',0'; $shortcut.Description = 'Open HybridOps.Core in Ubuntu'; $shortcut.Save() }"
   if errorlevel 1 (
-    echo WARN: unable to install the HybridOps.Core launcher.
-  )
-  powershell.exe -NoProfile -Command "$iconDir = Join-Path $env:LOCALAPPDATA 'HybridOps'; $iconPath = Join-Path $iconDir 'hybridops.ico'; $launcherPath = Join-Path $iconDir 'Open HybridOps.cmd'; Copy-Item -Force -LiteralPath '%PAYLOAD_DIR%\hybridops.ico' -Destination $iconPath; $shell = New-Object -ComObject WScript.Shell; $shortcut = $shell.CreateShortcut([Environment]::GetFolderPath('Desktop') + '\HybridOps.Core.lnk'); $shortcut.TargetPath = $launcherPath; $shortcut.WorkingDirectory = $env:USERPROFILE; $shortcut.IconLocation = $iconPath + ',0'; $shortcut.Description = 'Open HybridOps.Core in Ubuntu'; $shortcut.Save()"
-  if errorlevel 1 (
-    echo WARN: unable to create the HybridOps.Core desktop shortcut.
+    echo WARN: unable to create the HybridOps.Core launch shortcuts.
   ) else (
-    set "SHORTCUT_CREATED=true"
-    if not "!SHORTCUT_EXISTS!"=="true" (
-      echo Desktop shortcut created: HybridOps.Core
-    )
+    set "SHORTCUTS_CREATED=true"
   )
 )
 
@@ -342,8 +330,8 @@ if exist "%WSL_SETUP_MARKER%" (
 
 echo.
 echo HybridOps.Core installation completed.
-if "!SHORTCUT_CREATED!"=="true" (
-  echo Open HybridOps.Core from the desktop shortcut, then run: hyops --help
+if "!SHORTCUTS_CREATED!"=="true" (
+  echo Open HybridOps.Core from the desktop or this folder, then run: hyops --help
 ) else (
   echo Open Ubuntu 24.04 from the Windows Start menu, then run: hyops --help
 )


### PR DESCRIPTION
Closes #248\n\n## What changed\n\n- installs the managed Windows launcher and icon after a successful Core installation\n- creates or refreshes HybridOps.Core shortcuts on the desktop and beside Install HybridOps.cmd\n- removes the desktop-shortcut prompt\n- aligns the Windows bundle instructions and installer regression checks\n\n## Validation\n\n- Windows installer and release-package checks passed\n- diff validation passed\n- root installation smoke skipped because passwordless sudo is unavailable locally\n- ShellCheck will run in CI because it is not installed on this workstation