### PR TITLE
Clean licence formatting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,8 +17,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
----
-
 # Documentation (CC BY 4.0)
 
 Documentation shipped in this repository (for example, content under `modules/`
@@ -33,8 +31,6 @@ commercially, under the following terms:
   but not in any way that suggests HybridOps endorses you or your use.
 
 Full license text: https://creativecommons.org/licenses/by/4.0/
-
----
 
 # Branding and trademarks
 


### PR DESCRIPTION
## Summary

Remove the two decorative Markdown separators from `LICENSE`.

The licence wording and scope are unchanged.

## Validation

Reviewed the final diff to confirm that only the separator lines were removed.
