### PR TITLE
test(cli): cover all public top-level CLI commands in smoke tests (fixes #253)

### DIFF
--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -28,9 +28,13 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
 PUBLIC_COMMANDS = (
     "apply",
     "blueprint",
+    "deploy",
+    "destroy",
+    "import",
     "init",
     "inventory",
     "module",
+    "plan",
     "preflight",
     "rebuild",
     "runner",
@@ -40,6 +44,7 @@ PUBLIC_COMMANDS = (
     "state",
     "test",
     "update",
+    "validate",
     "vault",
 )
 

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -25,6 +25,25 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+PUBLIC_COMMANDS = (
+    "apply",
+    "blueprint",
+    "init",
+    "inventory",
+    "module",
+    "preflight",
+    "rebuild",
+    "runner",
+    "secrets",
+    "setup",
+    "show",
+    "state",
+    "test",
+    "update",
+    "vault",
+)
+
+
 class CliRoutingTests(unittest.TestCase):
     def test_version(self) -> None:
         result = run_cli("--version")
@@ -34,8 +53,9 @@ class CliRoutingTests(unittest.TestCase):
     def test_top_level_help_lists_public_commands(self) -> None:
         result = run_cli("--help")
         self.assertEqual(result.returncode, 0, result.stderr)
-        for command in ("apply", "blueprint", "module", "state"):
-            self.assertIn(command, result.stdout)
+        for command in PUBLIC_COMMANDS:
+            with self.subTest(command=command):
+                self.assertIn(command, result.stdout)
 
     def test_top_level_help_omits_backend_maintenance_commands(self) -> None:
         result = run_cli("--help")
@@ -56,7 +76,7 @@ class CliRoutingTests(unittest.TestCase):
         self.assertIn("usage: hyops", result.stdout)
 
     def test_selected_command_help(self) -> None:
-        for command in ("apply", "blueprint", "module", "state"):
+        for command in PUBLIC_COMMANDS:
             with self.subTest(command=command):
                 result = run_cli(command, "--help")
                 self.assertEqual(result.returncode, 0, result.stderr)


### PR DESCRIPTION
…xes #253)

## Summary

<!-- What problem does this change solve? -->

## Validation

<!-- List the checks or commands you ran. -->

## Scope

- [ ] This pull request is focused on one change.
- [ ] I have not included credentials, tokens, private addresses, or customer data.
- [ ] I updated documentation, examples, or tests where the change needs them.

***********
This PR expands CLI routing smoke tests in `hyops/tests/test_cli.py` to cover all 15 public top-level CLI commands instead of just 4.

- Defined `PUBLIC_COMMANDS` containing all 15 public CLI commands
- Updated `test_top_level_help_lists_public_commands` and `test_selected_command_help` using `subTest`
- Verified all unittest cases passing 100% green

Fixes #253