### PR TITLE
Bound AzureRM provider below v5

### DIFF
--- a/packs/iac/terragrunt/azure/core/00-foundation-global/10-resource-group@v1.0/stack/main.tf
+++ b/packs/iac/terragrunt/azure/core/00-foundation-global/10-resource-group@v1.0/stack/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0"
+      version = ">= 3.100.0, < 5.0.0"
     }
   }
 }

--- a/packs/iac/terragrunt/azure/core/00-foundation-global/20-vnet@v1.0/stack/main.tf
+++ b/packs/iac/terragrunt/azure/core/00-foundation-global/20-vnet@v1.0/stack/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0"
+      version = ">= 3.100.0, < 5.0.0"
     }
   }
 }

--- a/packs/iac/terragrunt/azure/core/00-foundation-global/30-nat-gateway@v1.0/stack/main.tf
+++ b/packs/iac/terragrunt/azure/core/00-foundation-global/30-nat-gateway@v1.0/stack/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0"
+      version = ">= 3.100.0, < 5.0.0"
     }
   }
 }

--- a/packs/iac/terragrunt/azure/core/10-shared-services-global/10-container-registry@v1.0/stack/main.tf
+++ b/packs/iac/terragrunt/azure/core/10-shared-services-global/10-container-registry@v1.0/stack/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0"
+      version = ">= 3.100.0, < 5.0.0"
     }
   }
 }

--- a/packs/iac/terragrunt/azure/org/10-pgbackrest-repo@v1.0/stack/terraform/main.tf
+++ b/packs/iac/terragrunt/azure/org/10-pgbackrest-repo@v1.0/stack/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.100.0"
+      version = ">= 3.100.0, < 5.0.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- keep the shipped Azure stacks on the supported AzureRM 3.x and 4.x contract
- prevent an unplanned AzureRM 5.x resolution from breaking Terraform validation

## Validation

- `PATH=/tmp/hybridops-tflint-0.60.0:$PATH bash tools/ci/check-terraform.sh`

The post-merge run first exposed this when AzureRM 5.0.1 rejected the existing storage container argument.