### PR TITLE
ci: validate every shipped blueprint in CI (fixes #254)

### DIFF
--- a/hyops/blueprint/tests/test_catalog.py
+++ b/hyops/blueprint/tests/test_catalog.py
@@ -1,0 +1,110 @@
+"""Tests for offline blueprint catalog validation check."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "check_blueprint_catalog", REPO_ROOT / "tools" / "ci" / "check-blueprint-catalog.py"
+)
+check_blueprint_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_blueprint_module)
+check_blueprint_catalog = check_blueprint_module.check_blueprint_catalog
+
+
+class BlueprintCatalogTests(unittest.TestCase):
+    def test_check_blueprint_catalog_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = Path(tmp_dir)
+            blueprints = repo / "blueprints" / "test" / "sample@v1"
+            blueprints.mkdir(parents=True)
+            modules = repo / "modules" / "test" / "sample-module"
+            modules.mkdir(parents=True)
+            (modules / "spec.yml").write_text("kind: ModuleSpec\n")
+
+            bp_spec = {
+                "api_version": "hybridops/v1",
+                "kind": "BlueprintSpec",
+                "blueprint_ref": "test/sample@v1",
+                "mode": "hybrid",
+                "steps": [
+                    {
+                        "id": "step1",
+                        "module_ref": "test/sample-module",
+                    }
+                ],
+            }
+            (blueprints / "blueprint.yml").write_text(yaml.dump(bp_spec))
+
+            failures, count = check_blueprint_catalog(repo)
+            self.assertEqual(failures, [])
+            self.assertEqual(count, 1)
+
+    def test_check_blueprint_catalog_ref_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = Path(tmp_dir)
+            blueprints = repo / "blueprints" / "test" / "sample@v1"
+            blueprints.mkdir(parents=True)
+
+            bp_spec = {
+                "api_version": "hybridops/v1",
+                "kind": "BlueprintSpec",
+                "blueprint_ref": "wrong/ref@v1",
+                "mode": "hybrid",
+                "steps": [
+                    {
+                        "id": "step1",
+                        "module_ref": "test/sample-module",
+                    }
+                ],
+            }
+            (blueprints / "blueprint.yml").write_text(yaml.dump(bp_spec))
+
+            failures, count = check_blueprint_catalog(repo)
+            self.assertTrue(any("blueprint_ref mismatch" in f for f in failures))
+
+    def test_check_blueprint_catalog_missing_module(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = Path(tmp_dir)
+            blueprints = repo / "blueprints" / "test" / "sample@v1"
+            blueprints.mkdir(parents=True)
+
+            bp_spec = {
+                "api_version": "hybridops/v1",
+                "kind": "BlueprintSpec",
+                "blueprint_ref": "test/sample@v1",
+                "mode": "hybrid",
+                "steps": [
+                    {
+                        "id": "step1",
+                        "module_ref": "nonexistent/sample-module",
+                    }
+                ],
+            }
+            (blueprints / "blueprint.yml").write_text(yaml.dump(bp_spec))
+
+            failures, count = check_blueprint_catalog(repo)
+            self.assertTrue(any("does not resolve to spec.yml" in f for f in failures))
+
+    def test_check_blueprint_catalog_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = Path(tmp_dir)
+            blueprints = repo / "blueprints" / "test" / "sample@v1"
+            blueprints.mkdir(parents=True)
+            (blueprints / "blueprint.yml").write_text("invalid: yaml: [")
+
+            failures, count = check_blueprint_catalog(repo)
+            self.assertTrue(len(failures) > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/check-blueprint-catalog.py
+++ b/tools/ci/check-blueprint-catalog.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check that shipped blueprint contracts load, match their directory path, and resolve step modules."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[2]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from hyops.blueprint.schema import load_blueprint, validate_blueprint
+
+
+def check_blueprint_catalog(repo_root: Path) -> tuple[list[str], int]:
+    blueprints_root = repo_root / "blueprints"
+    modules_root = repo_root / "modules"
+    failures: list[str] = []
+
+    blueprint_paths = sorted(blueprints_root.rglob("blueprint.yml")) + sorted(
+        blueprints_root.rglob("blueprint.yaml")
+    )
+
+    if not blueprint_paths:
+        return ["blueprints: no blueprint.yml files found"], 0
+
+    for path in blueprint_paths:
+        rel_path = path.relative_to(repo_root)
+
+        try:
+            raw_payload = load_blueprint(path)
+            spec = validate_blueprint(raw_payload, path)
+        except Exception as exc:
+            failures.append(f"{rel_path}: {exc}")
+            continue
+
+        # Confirm blueprint_ref matches its path under blueprints/
+        expected_ref = path.parent.relative_to(blueprints_root).as_posix()
+        blueprint_ref = spec.get("blueprint_ref", "")
+        if blueprint_ref != expected_ref:
+            failures.append(
+                f"{rel_path}: blueprint_ref mismatch: expected {expected_ref!r}, got {blueprint_ref!r}"
+            )
+
+        # Confirm every step module_ref resolves to modules/<module_ref>/spec.yml
+        module_refs: list[tuple[str, str]] = []
+        for idx, step in enumerate(spec.get("steps", []), start=1):
+            if isinstance(step, dict) and "module_ref" in step:
+                module_refs.append((f"steps[{idx}].module_ref", step["module_ref"]))
+
+        if (
+            spec.get("archive_before_destroy")
+            and isinstance(spec["archive_before_destroy"], dict)
+            and spec["archive_before_destroy"].get("module_ref")
+        ):
+            module_refs.append(
+                (
+                    "archive_before_destroy.module_ref",
+                    spec["archive_before_destroy"]["module_ref"],
+                )
+            )
+
+        for ref_name, mod_ref in module_refs:
+            clean_ref = mod_ref.split("@")[0]
+            spec_path = modules_root / clean_ref / "spec.yml"
+            if not spec_path.is_file():
+                failures.append(
+                    f"{rel_path}: {ref_name} {mod_ref!r} does not resolve to spec.yml at {spec_path.relative_to(repo_root)}"
+                )
+
+    return failures, len(blueprint_paths)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    failures, blueprint_count = check_blueprint_catalog(repo_root)
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}", file=sys.stderr)
+        return 1
+
+    print(f"blueprint catalog: ok ({blueprint_count} blueprints)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/check-python.sh
+++ b/tools/ci/check-python.sh
@@ -12,6 +12,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 hyops_ci::require_cmd python3
 
 python3 "${HYOPS_REPO_ROOT}/tools/ci/check-module-catalog.py"
+python3 "${HYOPS_REPO_ROOT}/tools/ci/check-blueprint-catalog.py"
 
 python3 -m compileall "${HYOPS_REPO_ROOT}/hyops"
 


### PR DESCRIPTION
## Summary

This PR adds an offline blueprint catalog checker in `tools/ci/check-blueprint-catalog.py` to validate every shipped blueprint in CI.

- Loads and validates every `blueprints/**/blueprint.yml` through the production schema validator
- Confirms `blueprint_ref` matches its on-disk path under `blueprints/`
- Confirms every step `module_ref` resolves to `modules/<module_ref>/spec.yml`
- Adds focused unit tests in `hyops/blueprint/tests/test_catalog.py`
- Wires the check into `tools/ci/check-python.sh`

## Validation

- `python3 tools/ci/check-blueprint-catalog.py`
- `python3 -m unittest hyops.blueprint.tests.test_catalog`
- `bash tools/ci/check-python.sh`
- `bash tools/ci/check-ruff.sh`
- `git diff --check`

## Scope

- [x] This pull request is focused on one change.
- [x] I did not include credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.

Fixes #254