### PR TITLE
reject misplaced step settings during blueprint validation (#260)

### DIFF
--- a/.github/workflows/ci-ingestion.yml
+++ b/.github/workflows/ci-ingestion.yml
@@ -1,0 +1,39 @@
+name: CI (ingestion)
+
+on:
+  pull_request:
+    paths:
+      - "packages/ingestion/**"
+      - ".github/workflows/ci-ingestion.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/ingestion/**"
+      - ".github/workflows/ci-ingestion.yml"
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/ingestion
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: packages/ingestion/pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint (ruff check)
+        run: ruff check .
+
+      - name: Format check (ruff format)
+        run: ruff format --check .
+
+      - name: Test (pytest)
+        run: pytest

--- a/packages/ingestion/tests/test_loaders.py
+++ b/packages/ingestion/tests/test_loaders.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ingestion.loaders.local import load_document, load_pdf, load_txt
+
+
+def test_load_txt(tmp_path):
+    txt_file = tmp_path / "sample.txt"
+    txt_file.write_text("Hello OpenUni", encoding="utf-8")
+
+    content = load_txt(str(txt_file))
+    assert content == "Hello OpenUni"
+
+
+def test_load_document_txt_and_md(tmp_path):
+    txt_file = tmp_path / "doc.txt"
+    txt_file.write_text("Text content", encoding="utf-8")
+    assert load_document(str(txt_file)) == "Text content"
+
+    md_file = tmp_path / "guide.md"
+    md_file.write_text("Markdown content", encoding="utf-8")
+    assert load_document(str(md_file)) == "Markdown content"
+
+
+def test_load_pdf(tmp_path):
+    pdf_file = tmp_path / "document.pdf"
+    pdf_file.touch()
+
+    mock_page1 = MagicMock()
+    mock_page1.get_text.return_value = "Page 1 text"
+    mock_page2 = MagicMock()
+    mock_page2.get_text.return_value = "Page 2 text"
+
+    mock_doc = [mock_page1, mock_page2]
+
+    with patch("ingestion.loaders.local.fitz.open", return_value=mock_doc):
+        text = load_pdf(str(pdf_file))
+        assert "Page 1 text" in text
+        assert "Page 2 text" in text
+
+    with patch("ingestion.loaders.local.fitz.open", return_value=mock_doc):
+        text_from_doc = load_document(str(pdf_file))
+        assert "Page 1 text" in text_from_doc
+
+
+def test_load_document_unsupported_format(tmp_path):
+    unsupported_file = tmp_path / "file.docx"
+    unsupported_file.touch()
+
+    with pytest.raises(ValueError, match="Unsupported file format: .docx"):
+        load_document(str(unsupported_file))

--- a/packages/ingestion/tests/test_ollama.py
+++ b/packages/ingestion/tests/test_ollama.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from ingestion.embeddings.ollama import OllamaEmbedder
+
+
+def test_ensure_model_pulled_model_already_available():
+    mock_get_resp = MagicMock()
+    mock_get_resp.json.return_value = {"models": [{"name": "nomic-embed-text:latest"}]}
+
+    with (
+        patch("httpx.get", return_value=mock_get_resp) as mock_get,
+        patch("httpx.post") as mock_post,
+    ):
+        embedder = OllamaEmbedder(base_url="http://localhost:11434", model="nomic-embed-text")
+        embedder.ensure_model_pulled()
+
+    mock_get.assert_called_once_with("http://localhost:11434/api/tags")
+    mock_post.assert_not_called()
+
+
+def test_ensure_model_pulled_pulls_missing_model():
+    mock_get_resp = MagicMock()
+    mock_get_resp.json.return_value = {"models": []}
+
+    mock_post_resp = MagicMock()
+
+    with (
+        patch("httpx.get", return_value=mock_get_resp),
+        patch("httpx.post", return_value=mock_post_resp) as mock_post,
+    ):
+        embedder = OllamaEmbedder(base_url="http://localhost:11434", model="nomic-embed-text")
+        embedder.ensure_model_pulled()
+
+    mock_post.assert_called_once_with(
+        "http://localhost:11434/api/pull",
+        json={"name": "nomic-embed-text", "stream": False},
+        timeout=300.0,
+    )
+
+
+def test_ensure_model_pulled_connection_error_raises():
+    with patch("httpx.get", side_effect=httpx.RequestError("Connection refused")):
+        embedder = OllamaEmbedder()
+        with pytest.raises(httpx.RequestError):
+            embedder.ensure_model_pulled()
+
+
+def test_embed_documents():
+    mock_post_resp = MagicMock()
+    mock_post_resp.json.side_effect = [
+        {"embedding": [0.1, 0.2]},
+        {"embedding": [0.3, 0.4]},
+    ]
+
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_post_resp
+    mock_client_context = MagicMock()
+    mock_client_context.__enter__.return_value = mock_client
+
+    with patch("httpx.Client", return_value=mock_client_context):
+        embedder = OllamaEmbedder(model="nomic-embed-text")
+        embeddings = embedder.embed_documents(["first text", "second text"])
+
+    assert embeddings == [[0.1, 0.2], [0.3, 0.4]]
+    assert mock_client.post.call_count == 2

--- a/packages/ingestion/tests/test_qdrant.py
+++ b/packages/ingestion/tests/test_qdrant.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock, patch
+
+from ingestion.vector_store.qdrant import QdrantStore
+
+
+def test_qdrant_store_creates_collection_if_not_exists():
+    mock_client = MagicMock()
+    mock_client.get_collections.return_value = MagicMock(collections=[])
+
+    with patch("ingestion.vector_store.qdrant.QdrantClient", return_value=mock_client):
+        store = QdrantStore(
+            url="http://localhost:6333", collection_name="test_col", vector_size=768
+        )
+
+    assert store.collection_name == "test_col"
+    mock_client.create_collection.assert_called_once()
+    _, kwargs = mock_client.create_collection.call_args
+    assert kwargs["collection_name"] == "test_col"
+    assert kwargs["vectors_config"].size == 768
+
+
+def test_qdrant_store_skips_creation_if_collection_exists():
+    mock_client = MagicMock()
+    existing_col = MagicMock()
+    existing_col.name = "test_col"
+    mock_client.get_collections.return_value = MagicMock(collections=[existing_col])
+
+    with patch("ingestion.vector_store.qdrant.QdrantClient", return_value=mock_client):
+        QdrantStore(url="http://localhost:6333", collection_name="test_col")
+
+    mock_client.create_collection.assert_not_called()
+
+
+def test_delete_university_data():
+    mock_client = MagicMock()
+    mock_client.get_collections.return_value = MagicMock(collections=[])
+
+    with patch("ingestion.vector_store.qdrant.QdrantClient", return_value=mock_client):
+        store = QdrantStore(collection_name="test_col")
+        store.delete_university_data("demo")
+
+    mock_client.delete.assert_called_once()
+    _, kwargs = mock_client.delete.call_args
+    assert kwargs["collection_name"] == "test_col"
+
+
+def test_upsert_points_valid():
+    mock_client = MagicMock()
+    mock_client.get_collections.return_value = MagicMock(collections=[])
+
+    vectors = [[0.1, 0.2], [0.3, 0.4]]
+    payloads = [{"text": "a"}, {"text": "b"}]
+
+    with patch("ingestion.vector_store.qdrant.QdrantClient", return_value=mock_client):
+        store = QdrantStore(collection_name="test_col")
+        store.upsert_points(vectors, payloads)
+
+    mock_client.upsert.assert_called_once()
+    _, kwargs = mock_client.upsert.call_args
+    assert kwargs["collection_name"] == "test_col"
+    assert len(kwargs["points"]) == 2
+
+
+def test_upsert_points_guards_against_empty_or_mismatched():
+    mock_client = MagicMock()
+    mock_client.get_collections.return_value = MagicMock(collections=[])
+
+    with patch("ingestion.vector_store.qdrant.QdrantClient", return_value=mock_client):
+        store = QdrantStore(collection_name="test_col")
+        store.upsert_points([], [])
+        store.upsert_points([[0.1]], [{"text": "a"}, {"text": "b"}])
+
+    mock_client.upsert.assert_not_called()

--- a/packages/ingestion/tests/test_text_splitter.py
+++ b/packages/ingestion/tests/test_text_splitter.py
@@ -1,0 +1,25 @@
+from ingestion.chunking.text_splitter import chunk_text
+
+
+def test_chunk_text_normal_case():
+    text = "one two three four five six seven eight nine ten"
+    chunks = chunk_text(text, chunk_size=4, overlap=2)
+    assert len(chunks) == 4
+    assert chunks[0] == "one two three four"
+    assert chunks[1] == "three four five six"
+    assert chunks[2] == "five six seven eight"
+    assert chunks[3] == "seven eight nine ten"
+
+
+def test_chunk_text_empty_string():
+    assert chunk_text("") == []
+    assert chunk_text("   \n\t  ") == []
+
+
+def test_chunk_text_overlap_greater_than_or_equal_to_chunk_size():
+    text = "word1 word2 word3 word4 word5"
+    chunks_equal = chunk_text(text, chunk_size=3, overlap=3)
+    assert chunks_equal == ["word1 word2 word3"]
+
+    chunks_greater = chunk_text(text, chunk_size=3, overlap=5)
+    assert chunks_greater == ["word1 word2 word3"]


### PR DESCRIPTION
a new check enforces step contract boundaries during blueprint validation and rejects misplaced keys.
the edge control plane blueprint is updated to nest firewall and ssh settings under step inputs.