### PR TITLE
reject misplaced step settings during blueprint validation (#260)

### DIFF
--- a/blueprints/networking/edge-control-plane@v1/blueprint.yml
+++ b/blueprints/networking/edge-control-plane@v1/blueprint.yml
@@ -214,12 +214,12 @@ steps:
       ssh_username: opsadmin
       ssh_keys_from_init: true
       public_ipv6_enabled: false
-    firewall_name: CHANGE_ME_CONTROL_FIREWALL_NAME
-    ssh_source_cidrs:
-      - CHANGE_ME_OPERATOR_CIDR
-    firewall_extra_tcp_ports:
-      - 80
-      - 443
+      firewall_name: CHANGE_ME_CONTROL_FIREWALL_NAME
+      ssh_source_cidrs:
+        - CHANGE_ME_OPERATOR_CIDR
+      firewall_extra_tcp_ports:
+        - 80
+        - 443
   - id: edge_control_runner
     module_ref: platform/linux/ops-runner
     state_instance: edge_control_runner

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -314,6 +314,25 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
     steps: list[dict[str, Any]] = []
     step_ids: set[str] = set()
 
+    allowed_step_keys = {
+        "id",
+        "module_ref",
+        "execution_profile",
+        "action",
+        "phase",
+        "requires",
+        "with_deps",
+        "skip_if_state_ok",
+        "verify_state_on_skip",
+        "retain_on_destroy",
+        "optional",
+        "inputs",
+        "inputs_file",
+        "state_instance",
+        "presentation",
+        "contracts",
+    }
+
     for idx, raw in enumerate(raw_steps, start=1):
         step = as_mapping(raw, f"steps[{idx}]")
         step_id = as_non_empty_string(step.get("id"), f"steps[{idx}].id")
@@ -322,6 +341,12 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         if step_id in step_ids:
             raise ValueError(f"duplicate step id: {step_id}")
         step_ids.add(step_id)
+
+        unknown_step_keys = sorted([str(k) for k in step.keys() if str(k) not in allowed_step_keys])
+        if unknown_step_keys:
+            raise ValueError(
+                f"step '{step_id}' has unknown keys: {', '.join(unknown_step_keys)}"
+            )
 
         module_ref = module_ref_field(step.get("module_ref"), f"steps[{idx}].module_ref")
         execution_profile = str(step.get("execution_profile") or "").strip()

--- a/hyops/blueprint/tests/test_catalog.py
+++ b/hyops/blueprint/tests/test_catalog.py
@@ -105,6 +105,33 @@ class BlueprintCatalogTests(unittest.TestCase):
             failures, count = check_blueprint_catalog(repo)
             self.assertTrue(len(failures) > 0)
 
+    def test_check_blueprint_catalog_unknown_step_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = Path(tmp_dir)
+            blueprints = repo / "blueprints" / "test" / "sample@v1"
+            blueprints.mkdir(parents=True)
+            modules = repo / "modules" / "test" / "sample-module"
+            modules.mkdir(parents=True)
+            (modules / "spec.yml").write_text("kind: ModuleSpec\n")
+
+            bp_spec = {
+                "api_version": "hybridops/v1",
+                "kind": "BlueprintSpec",
+                "blueprint_ref": "test/sample@v1",
+                "mode": "hybrid",
+                "steps": [
+                    {
+                        "id": "step1",
+                        "module_ref": "test/sample-module",
+                        "firewall_name": "invalid",
+                    }
+                ],
+            }
+            (blueprints / "blueprint.yml").write_text(yaml.dump(bp_spec))
+
+            failures, count = check_blueprint_catalog(repo)
+            self.assertTrue(any("step 'step1' has unknown keys: firewall_name" in f for f in failures))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
a new check enforces step contract boundaries during blueprint validation and rejects misplaced keys.
the edge control plane blueprint is updated to nest firewall and ssh settings under step inputs.