### PR TITLE
docs: connect published research to external technical review

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ credentials, vault material, private addresses, or unredacted evidence.
 - Python ≥ 3.11
 - Tool dependencies vary by module: `terraform`, `terragrunt`, `ansible`, `packer`, `gcloud`, `kubectl`; only the tools used by the modules you run need to be present
 
+## Research and external review
+
+HybridOps Core also serves as the public reference implementation for ongoing
+research in platform engineering and infrastructure automation.
+
+See [Research and External Review](RESEARCH.md) for published papers,
+implementation mappings, and independent practitioner assessments.
+
 ## Documentation
 
 - **Full docs and reference scenarios:** [docs.hybridops.tech](https://docs.hybridops.tech)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT-0" src="https://img.shields.io/badge/license-MIT--0-blue.svg"></a>
-  <a href="https://www.python.org/"><img alt="Python >= 3.11" src="https://img.shields.io/badge/python-%3E%3D3.11-blue"></a>
+  <a href="https://www.python.org/"><img alt="Python >= 3.11" src="https://img.shields.io/badge/python-%3E%3D3.11-blue.svg"></a>
   <a href="https://github.com/hybridops-tech/hybridops-core/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/hybridops-tech/hybridops-core/actions/workflows/ci.yml/badge.svg"></a>
 </p>
 
@@ -180,7 +180,7 @@ HybridOps Core also serves as the public reference implementation for ongoing
 research in platform engineering and infrastructure automation.
 
 See [Research and External Review](RESEARCH.md) for published papers,
-implementation mappings, and independent practitioner assessments.
+implementation maps, and external technical reviews.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT-0" src="https://img.shields.io/badge/license-MIT--0-blue.svg"></a>
-  <a href="https://www.python.org/"><img alt="Python >= 3.11" src="https://img.shields.io/badge/python-%3E%3D3.11-blue.svg"></a>
+  <a href="https://www.python.org/"><img alt="Python >= 3.11" src="https://img.shields.io/badge/python-%3E%3D3.11-blue"></a>
   <a href="https://github.com/hybridops-tech/hybridops-core/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/hybridops-tech/hybridops-core/actions/workflows/ci.yml/badge.svg"></a>
 </p>
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,0 +1,95 @@
+# Research and External Review
+
+HybridOps Core is the public reference implementation for research exploring platform engineering, infrastructure automation, operational evidence, recovery, source-of-truth design, and reproducible infrastructure environments.
+
+The papers below document the research and map the proposed approaches to corresponding implementation areas in HybridOps Core.
+
+## Published research
+
+### HybridOps Contract Runtime — Technical Review v1.0
+
+**Paper:** https://hybridops.tech/papers/hybridops-contract-runtime-technical-review-v1.0.pdf
+
+**Implementation areas:**
+- module intent contracts
+- profiles and drivers
+- implementation packs
+- preflight validation
+- blueprints
+- structured run records
+
+**External review:** https://github.com/hybridops-tech/hybridops-core/issues/269
+
+---
+
+### Build, Boot, Verify, Publish v1.0
+
+**Paper:** https://hybridops.tech/papers/build-boot-verify-publish-v1.0.pdf
+
+**Implementation areas:**
+- image and template build lifecycle
+- Packer integration
+- validation gates
+- publication workflow
+- reproducibility and evidence
+
+**External review:** https://github.com/hybridops-tech/hybridops-core/issues/270
+
+---
+
+### Reproducible Network Training Labs v1.0
+
+**Paper:** https://hybridops.tech/papers/reproducible-network-training-labs-v1.0.pdf
+
+**Implementation areas:**
+- EVE-NG and GNS3 blueprints
+- disposable infrastructure
+- repeatable environment provisioning
+- archive and restore
+- cost and lifecycle controls
+
+**External review:** https://github.com/hybridops-tech/hybridops-core/issues/271
+
+---
+
+### Authority Before Automation v1.0
+
+**Paper:** https://hybridops.tech/papers/authority-before-automation-v1.0.pdf
+
+**Implementation areas:**
+- source-of-truth architecture
+- NetBox-backed infrastructure intent
+- validation before execution
+- authoritative state versus pipeline-generated state
+
+**External review:** https://github.com/hybridops-tech/hybridops-core/issues/272
+
+---
+
+### Recovery Operating Model v1.0
+
+**Paper:** https://hybridops.tech/papers/recovery-operating-model-v1.0.pdf
+
+**Implementation areas:**
+- recovery workflows
+- structured execution evidence
+- failover and failback
+- environment reconstruction
+- recovery validation and handoff
+
+**External review:** https://github.com/hybridops-tech/hybridops-core/issues/273
+
+## External review
+
+Independent practitioners are invited to assess the published research against the corresponding public implementation.
+
+Reviews may address:
+
+- whether the problem reflects real operational practice
+- technical credibility
+- practical value
+- architectural limitations
+- unsupported assumptions or failure modes
+- whether the implementation supports the claims made in the paper
+
+Critical findings are as useful as positive assessments.

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,14 +1,14 @@
 # Research and External Review
 
-HybridOps Core provides the public implementation material for the research papers listed below. Each paper is linked to relevant documentation, blueprint formations, and source code where applicable.
+HybridOps Core contains the public implementation references for the research papers below. Each paper links to the relevant documentation, blueprint formations, and source code.
 
 ## Using the implementation maps
 
-Each map uses three types of reference:
+Each map points to three types of reference where relevant:
 
 - **Public docs:** architecture context, reference scenarios, runbooks, and the generated blueprint catalog.
 - **Blueprint formations:** shipped blueprint directories that show the README, `blueprint.yml`, and related files together.
-- **Runtime and module source:** the code that implements the relevant contract, validation, lifecycle, or evidence behaviour.
+- **Runtime and module source:** code that implements the relevant contract, validation, lifecycle, or evidence behaviour.
 
 The [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) is the main catalog for shipped formations, runbooks, and source contracts. The repository [Blueprints directory](blueprints/) documents the contract model and exposes the formations directly.
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -9,10 +9,10 @@ The papers below document the research and map each line of inquiry to public do
 Each map uses three kinds of references where relevant:
 
 - **Public docs** — architecture context, reference scenarios, runbooks, and the generated blueprint catalog.
-- **Blueprint formation** — the shipped blueprint README showing the ordered module chain that implements the outcome.
+- **Blueprint formation** — the shipped blueprint directory, where GitHub presents the formation README together with its `blueprint.yml` and related files.
 - **Runtime/module source** — the concrete runtime or module implementation behind the paper's claims.
 
-The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) is the catalog entry point for all shipped formations, runbooks, and source contracts. The repository-level [Blueprints README](blueprints/README.md) documents the blueprint operating modes and contract model.
+The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) is the catalog entry point for all shipped formations, runbooks, and source contracts. The repository-level [Blueprints directory](blueprints/) documents the blueprint operating modes and contract model while exposing the shipped formations directly.
 
 ## Published research
 
@@ -23,8 +23,8 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 **Implementation map:**
 
 - [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — generated catalog of shipped blueprint formations, runbooks, and source contracts.
-- [Blueprint contract model](blueprints/README.md) — operating modes, intent, policy, delivery contracts, and verification model.
-- [On-Prem Authoritative Foundation](blueprints/onprem/authoritative-foundation@v1/README.md) — representative five-step authority-gated blueprint chain.
+- [Blueprint contract model](blueprints/) — operating modes, intent, policy, delivery contracts, verification model, and shipped formations.
+- [On-Prem Authoritative Foundation](blueprints/onprem/authoritative-foundation@v1/) — representative five-step authority-gated blueprint chain.
 - [`hyops blueprint` runtime](hyops/blueprint/command.py) — validation, planning, preflight, deploy, rebuild, destroy, and operator guardrails.
 - [`hyops` command router](hyops/cli.py) — runtime command registration and command-level run-record capture.
 - [Preflight protocol](https://docs.hybridops.tech/architecture/contracts/hyops-preflight-contract/) — published readiness and validation contract.
@@ -41,9 +41,9 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 **Implementation map:**
 
 - [Capability Map](https://docs.hybridops.tech/evidence_map/) — public navigation for the image/bootstrap lifecycle and supporting runbooks.
-- [Proxmox template-image module](modules/core/onprem/template-image/README.md) — Packer-driven build, publish, clone/boot smoke validation, and run-record outputs.
-- [On-Prem RKE2 formation](blueprints/onprem/rke2@v1/README.md) — template build → VM provisioning → RKE2 installation.
-- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/README.md) — template build consumed by a wider SDN/VM/PostgreSQL/NetBox chain.
+- [Proxmox template-image module](modules/core/onprem/template-image/) — Packer-driven build, publish, clone/boot smoke validation, run-record outputs, and implementation files in one view.
+- [On-Prem RKE2 formation](blueprints/onprem/rke2@v1/) — template build → VM provisioning → RKE2 installation.
+- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/) — template build consumed by a wider SDN/VM/PostgreSQL/NetBox chain.
 - [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — shows other shipped formations that consume image-build steps.
 - [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — persisted build, validation, and execution records.
 
@@ -59,10 +59,10 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 
 - [EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/) — operator workflow for the governed lab lifecycle.
 - [EVE-NG training environment reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/) — public scenario tying design, operation, and verification together.
-- [GCP EVE-NG formation](blueprints/gcp/eve-ng@v1/README.md) — private GCP network → VM → EVE-NG → images → health check, with archive/restore and lifecycle controls.
-- [GCP GNS3 formation](blueprints/gcp/gns3@v1/README.md) — private GCP network → VM → GNS3 server/images/starter lab → health check.
-- [On-Prem EVE-NG formation](blueprints/onprem/eve-ng@v1/README.md) — template-image → Proxmox VM → EVE-NG configuration/images/health check.
-- [On-Prem GNS3 formation](blueprints/onprem/gns3@v1/README.md) — verified template → Proxmox VM → GNS3 server/images/starter lab/health check.
+- [GCP EVE-NG formation](blueprints/gcp/eve-ng@v1/) — private GCP network → VM → EVE-NG → images → health check, with archive/restore and lifecycle controls.
+- [GCP GNS3 formation](blueprints/gcp/gns3@v1/) — private GCP network → VM → GNS3 server/images/starter lab → health check.
+- [On-Prem EVE-NG formation](blueprints/onprem/eve-ng@v1/) — template-image → Proxmox VM → EVE-NG configuration/images/health check.
+- [On-Prem GNS3 formation](blueprints/onprem/gns3@v1/) — verified template → Proxmox VM → GNS3 server/images/starter lab/health check.
 - [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — comparative view of the on-prem and GCP lab formations.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/271
@@ -76,9 +76,9 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 **Implementation map:**
 
 - [Authoritative on-prem foundation reference scenario](https://docs.hybridops.tech/reference-scenarios/authoritative-onprem-foundation/) — public source-of-truth operating model and implementation narrative.
-- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/README.md) — SDN → template → VMs → PostgreSQL → NetBox bootstrap chain.
-- [Authoritative Foundation formation](blueprints/onprem/authoritative-foundation@v1/README.md) — NetBox-backed state gates later platform VM expansion.
-- [NetBox HA cutover formation](blueprints/onprem/netbox-ha-cutover@v1/README.md) — example of downstream state-contract consumption during service cutover.
+- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/) — SDN → template → VMs → PostgreSQL → NetBox bootstrap chain.
+- [Authoritative Foundation formation](blueprints/onprem/authoritative-foundation@v1/) — NetBox-backed state gates later platform VM expansion.
+- [NetBox HA cutover formation](blueprints/onprem/netbox-ha-cutover@v1/) — example of downstream state-contract consumption during service cutover.
 - [Proxmox SDN operations runbook](https://docs.hybridops.tech/ops/runbooks/networking/sdn_operations/) — plan/preflight/apply path for the network foundation feeding authoritative inventory/IPAM.
 - [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — documents the `authoritative` operating mode across shipped formations.
 
@@ -93,9 +93,9 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 **Implementation map:**
 
 - [PostgreSQL HA DR Cycle reference scenario](https://docs.hybridops.tech/reference-scenarios/postgresql-ha-dr-cycle/) — recorded restore-to-GCP, backup continuity, controlled failback, and final DNS truth.
-- [PostgreSQL HA backup formation](blueprints/dr/postgresql-ha-backup-gcp@v1/README.md) — GCS object repository → pgBackRest backup readiness.
-- [PostgreSQL HA failover formation](blueprints/dr/postgresql-ha-failover-gcp@v1/README.md) — GCP network/VM restore path through PostgreSQL HA, backup, and DNS cutover.
-- [PostgreSQL HA failback formation](blueprints/dr/postgresql-ha-failback-onprem@v1/README.md) — template/VM rebuild → restore → backup → DNS cutback.
+- [PostgreSQL HA backup formation](blueprints/dr/postgresql-ha-backup-gcp@v1/) — GCS object repository → pgBackRest backup readiness.
+- [PostgreSQL HA failover formation](blueprints/dr/postgresql-ha-failover-gcp@v1/) — GCP network/VM restore path through PostgreSQL HA, backup, and DNS cutover.
+- [PostgreSQL HA failback formation](blueprints/dr/postgresql-ha-failback-onprem@v1/) — template/VM rebuild → restore → backup → DNS cutback.
 - [GCP Ops Runner runbook](https://docs.hybridops.tech/ops/runbooks/networking/blueprints/hyops-blueprint-gcp-ops-runner/) — runner-local execution model used for DR and burst workflows.
 - [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — self-managed and managed PostgreSQL recovery formations in one catalog.
 - [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — stable non-secret execution records used to review recovery outcomes.

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -1,34 +1,32 @@
 # Research and External Review
 
-HybridOps Core is the public reference implementation for research exploring platform engineering, infrastructure automation, operational evidence, recovery, source-of-truth design, and reproducible infrastructure environments.
+HybridOps Core provides the public implementation material for the research papers listed below. Each paper is linked to relevant documentation, blueprint formations, and source code where applicable.
 
-The papers below document the research and map each line of inquiry to public documentation, representative blueprint formations, and implementation source in HybridOps Core.
+## Using the implementation maps
 
-## How to read the implementation maps
+Each map uses three types of reference:
 
-Each map uses three kinds of references where relevant:
+- **Public docs:** architecture context, reference scenarios, runbooks, and the generated blueprint catalog.
+- **Blueprint formations:** shipped blueprint directories that show the README, `blueprint.yml`, and related files together.
+- **Runtime and module source:** the code that implements the relevant contract, validation, lifecycle, or evidence behaviour.
 
-- **Public docs** — architecture context, reference scenarios, runbooks, and the generated blueprint catalog.
-- **Blueprint formation** — the shipped blueprint directory, where GitHub presents the formation README together with its `blueprint.yml` and related files.
-- **Runtime/module source** — the concrete runtime or module implementation behind the paper's claims.
-
-The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) is the catalog entry point for all shipped formations, runbooks, and source contracts. The repository-level [Blueprints directory](blueprints/) documents the blueprint operating modes and contract model while exposing the shipped formations directly.
+The [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) is the main catalog for shipped formations, runbooks, and source contracts. The repository [Blueprints directory](blueprints/) documents the contract model and exposes the formations directly.
 
 ## Published research
 
-### HybridOps Contract Runtime — Technical Review v1.0
+### HybridOps Contract Runtime: Technical Review v1.0
 
 **Paper:** https://hybridops.tech/papers/hybridops-contract-runtime-technical-review-v1.0.pdf
 
 **Implementation map:**
 
-- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — generated catalog of shipped blueprint formations, runbooks, and source contracts.
-- [Blueprint contract model](blueprints/) — operating modes, intent, policy, delivery contracts, verification model, and shipped formations.
-- [On-Prem Authoritative Foundation](blueprints/onprem/authoritative-foundation@v1/) — representative five-step authority-gated blueprint chain.
-- [`hyops blueprint` runtime](hyops/blueprint/command.py) — validation, planning, preflight, deploy, rebuild, destroy, and operator guardrails.
-- [`hyops` command router](hyops/cli.py) — runtime command registration and command-level run-record capture.
-- [Preflight protocol](https://docs.hybridops.tech/architecture/contracts/hyops-preflight-contract/) — published readiness and validation contract.
-- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — run-record, traceability, and redaction requirements.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/): catalog of shipped blueprint formations, runbooks, and source contracts.
+- [Blueprint contract model](blueprints/): operating modes, intent, policy, delivery contracts, verification model, and shipped formations.
+- [On-Prem Authoritative Foundation](blueprints/onprem/authoritative-foundation@v1/): representative authority-gated blueprint chain.
+- [`hyops blueprint` runtime](hyops/blueprint/command.py): validation, planning, preflight, deploy, rebuild, destroy, and operator guardrails.
+- [`hyops` command router](hyops/cli.py): runtime command registration and command-level run-record capture.
+- [Preflight protocol](https://docs.hybridops.tech/architecture/contracts/hyops-preflight-contract/): readiness and validation contract.
+- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/): run-record, traceability, and redaction requirements.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/269
 
@@ -40,12 +38,12 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 
 **Implementation map:**
 
-- [Capability Map](https://docs.hybridops.tech/evidence_map/) — public navigation for the image/bootstrap lifecycle and supporting runbooks.
-- [Proxmox template-image module](modules/core/onprem/template-image/) — Packer-driven build, publish, clone/boot smoke validation, run-record outputs, and implementation files in one view.
-- [On-Prem RKE2 formation](blueprints/onprem/rke2@v1/) — template build → VM provisioning → RKE2 installation.
-- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/) — template build consumed by a wider SDN/VM/PostgreSQL/NetBox chain.
-- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — shows other shipped formations that consume image-build steps.
-- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — persisted build, validation, and execution records.
+- [Capability Map](https://docs.hybridops.tech/evidence_map/): navigation for the image and bootstrap lifecycle and related runbooks.
+- [Proxmox template-image module](modules/core/onprem/template-image/): Packer-driven build, publish, clone and boot smoke validation, run-record outputs, and implementation files.
+- [On-Prem RKE2 formation](blueprints/onprem/rke2@v1/): builds a template, provisions VMs, then installs RKE2.
+- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/): uses the template build in the wider SDN, VM, PostgreSQL, and NetBox chain.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/): other shipped formations that consume image-build steps.
+- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/): persisted build, validation, and execution records.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/270
 
@@ -57,13 +55,13 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 
 **Implementation map:**
 
-- [EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/) — operator workflow for the governed lab lifecycle.
-- [EVE-NG training environment reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/) — public scenario tying design, operation, and verification together.
-- [GCP EVE-NG formation](blueprints/gcp/eve-ng@v1/) — private GCP network → VM → EVE-NG → images → health check, with archive/restore and lifecycle controls.
-- [GCP GNS3 formation](blueprints/gcp/gns3@v1/) — private GCP network → VM → GNS3 server/images/starter lab → health check.
-- [On-Prem EVE-NG formation](blueprints/onprem/eve-ng@v1/) — template-image → Proxmox VM → EVE-NG configuration/images/health check.
-- [On-Prem GNS3 formation](blueprints/onprem/gns3@v1/) — verified template → Proxmox VM → GNS3 server/images/starter lab/health check.
-- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — comparative view of the on-prem and GCP lab formations.
+- [EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/): operator workflow for the lab lifecycle.
+- [EVE-NG training environment reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/): design, operation, and verification in one scenario.
+- [GCP EVE-NG formation](blueprints/gcp/eve-ng@v1/): creates the private GCP network and VM, installs EVE-NG and images, then runs a health check. It also supports archive and restore.
+- [GCP GNS3 formation](blueprints/gcp/gns3@v1/): creates the private GCP network and VM, installs GNS3 and starter content, then runs a health check.
+- [On-Prem EVE-NG formation](blueprints/onprem/eve-ng@v1/): builds from a template image, provisions the Proxmox VM, installs EVE-NG and images, then validates the host.
+- [On-Prem GNS3 formation](blueprints/onprem/gns3@v1/): builds from a verified template, provisions the Proxmox VM, installs GNS3 and starter content, then validates the host.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/): comparative view of the on-prem and GCP lab formations.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/271
 
@@ -75,12 +73,12 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 
 **Implementation map:**
 
-- [Authoritative on-prem foundation reference scenario](https://docs.hybridops.tech/reference-scenarios/authoritative-onprem-foundation/) — public source-of-truth operating model and implementation narrative.
-- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/) — SDN → template → VMs → PostgreSQL → NetBox bootstrap chain.
-- [Authoritative Foundation formation](blueprints/onprem/authoritative-foundation@v1/) — NetBox-backed state gates later platform VM expansion.
-- [NetBox HA cutover formation](blueprints/onprem/netbox-ha-cutover@v1/) — example of downstream state-contract consumption during service cutover.
-- [Proxmox SDN operations runbook](https://docs.hybridops.tech/ops/runbooks/networking/sdn_operations/) — plan/preflight/apply path for the network foundation feeding authoritative inventory/IPAM.
-- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — documents the `authoritative` operating mode across shipped formations.
+- [Authoritative on-prem foundation reference scenario](https://docs.hybridops.tech/reference-scenarios/authoritative-onprem-foundation/): source-of-truth operating model and implementation narrative.
+- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/): builds the SDN, template, VMs, PostgreSQL, and NetBox bootstrap chain.
+- [Authoritative Foundation formation](blueprints/onprem/authoritative-foundation@v1/): uses NetBox-backed state to gate later platform VM expansion.
+- [NetBox HA cutover formation](blueprints/onprem/netbox-ha-cutover@v1/): shows downstream state-contract consumption during service cutover.
+- [Proxmox SDN operations runbook](https://docs.hybridops.tech/ops/runbooks/networking/sdn_operations/): plan, preflight, and apply path for the network foundation that feeds authoritative inventory and IPAM.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/): bootstrap and authoritative formations in one catalog.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/272
 
@@ -92,21 +90,21 @@ The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/
 
 **Implementation map:**
 
-- [PostgreSQL HA DR Cycle reference scenario](https://docs.hybridops.tech/reference-scenarios/postgresql-ha-dr-cycle/) — recorded restore-to-GCP, backup continuity, controlled failback, and final DNS truth.
-- [PostgreSQL HA backup formation](blueprints/dr/postgresql-ha-backup-gcp@v1/) — GCS object repository → pgBackRest backup readiness.
-- [PostgreSQL HA failover formation](blueprints/dr/postgresql-ha-failover-gcp@v1/) — GCP network/VM restore path through PostgreSQL HA, backup, and DNS cutover.
-- [PostgreSQL HA failback formation](blueprints/dr/postgresql-ha-failback-onprem@v1/) — template/VM rebuild → restore → backup → DNS cutback.
-- [GCP Ops Runner runbook](https://docs.hybridops.tech/ops/runbooks/networking/blueprints/hyops-blueprint-gcp-ops-runner/) — runner-local execution model used for DR and burst workflows.
-- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — self-managed and managed PostgreSQL recovery formations in one catalog.
-- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — stable non-secret execution records used to review recovery outcomes.
+- [PostgreSQL HA DR Cycle reference scenario](https://docs.hybridops.tech/reference-scenarios/postgresql-ha-dr-cycle/): restore to GCP, backup continuity, controlled failback, and final DNS state.
+- [PostgreSQL HA backup formation](blueprints/dr/postgresql-ha-backup-gcp@v1/): creates the GCS object repository and configures pgBackRest backup readiness.
+- [PostgreSQL HA failover formation](blueprints/dr/postgresql-ha-failover-gcp@v1/): restores PostgreSQL HA in GCP and performs the DNS cutover path.
+- [PostgreSQL HA failback formation](blueprints/dr/postgresql-ha-failback-onprem@v1/): rebuilds the on-prem path, restores the database, re-establishes backup, and returns DNS.
+- [GCP Ops Runner runbook](https://docs.hybridops.tech/ops/runbooks/networking/blueprints/hyops-blueprint-gcp-ops-runner/): runner-local execution model used for DR and burst workflows.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/): self-managed and managed PostgreSQL recovery formations in one catalog.
+- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/): stable non-secret execution records used to review recovery outcomes.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/273
 
 ## External review
 
-Independent practitioners are invited to assess the published research against the corresponding public implementation.
+Independent practitioners are invited to assess the papers against the corresponding public implementation.
 
-Reviews may address:
+A review may cover:
 
 - whether the problem reflects real operational practice
 - technical credibility
@@ -115,4 +113,4 @@ Reviews may address:
 - unsupported assumptions or failure modes
 - whether the implementation supports the claims made in the paper
 
-Critical findings are as useful as positive assessments.
+Critical findings are welcome.

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -2,7 +2,17 @@
 
 HybridOps Core is the public reference implementation for research exploring platform engineering, infrastructure automation, operational evidence, recovery, source-of-truth design, and reproducible infrastructure environments.
 
-The papers below document the research and map the proposed approaches to corresponding implementation areas in HybridOps Core.
+The papers below document the research and map each line of inquiry to public documentation, representative blueprint formations, and implementation source in HybridOps Core.
+
+## How to read the implementation maps
+
+Each map uses three kinds of references where relevant:
+
+- **Public docs** — architecture context, reference scenarios, runbooks, and the generated blueprint catalog.
+- **Blueprint formation** — the shipped blueprint README showing the ordered module chain that implements the outcome.
+- **Runtime/module source** — the concrete runtime or module implementation behind the paper's claims.
+
+The generated [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) is the catalog entry point for all shipped formations, runbooks, and source contracts. The repository-level [Blueprints README](blueprints/README.md) documents the blueprint operating modes and contract model.
 
 ## Published research
 
@@ -10,13 +20,15 @@ The papers below document the research and map the proposed approaches to corres
 
 **Paper:** https://hybridops.tech/papers/hybridops-contract-runtime-technical-review-v1.0.pdf
 
-**Implementation areas:**
-- module intent contracts
-- profiles and drivers
-- implementation packs
-- preflight validation
-- blueprints
-- structured run records
+**Implementation map:**
+
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — generated catalog of shipped blueprint formations, runbooks, and source contracts.
+- [Blueprint contract model](blueprints/README.md) — operating modes, intent, policy, delivery contracts, and verification model.
+- [On-Prem Authoritative Foundation](blueprints/onprem/authoritative-foundation@v1/README.md) — representative five-step authority-gated blueprint chain.
+- [`hyops blueprint` runtime](hyops/blueprint/command.py) — validation, planning, preflight, deploy, rebuild, destroy, and operator guardrails.
+- [`hyops` command router](hyops/cli.py) — runtime command registration and command-level run-record capture.
+- [Preflight protocol](https://docs.hybridops.tech/architecture/contracts/hyops-preflight-contract/) — published readiness and validation contract.
+- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — run-record, traceability, and redaction requirements.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/269
 
@@ -26,12 +38,14 @@ The papers below document the research and map the proposed approaches to corres
 
 **Paper:** https://hybridops.tech/papers/build-boot-verify-publish-v1.0.pdf
 
-**Implementation areas:**
-- image and template build lifecycle
-- Packer integration
-- validation gates
-- publication workflow
-- reproducibility and evidence
+**Implementation map:**
+
+- [Capability Map](https://docs.hybridops.tech/evidence_map/) — public navigation for the image/bootstrap lifecycle and supporting runbooks.
+- [Proxmox template-image module](modules/core/onprem/template-image/README.md) — Packer-driven build, publish, clone/boot smoke validation, and run-record outputs.
+- [On-Prem RKE2 formation](blueprints/onprem/rke2@v1/README.md) — template build → VM provisioning → RKE2 installation.
+- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/README.md) — template build consumed by a wider SDN/VM/PostgreSQL/NetBox chain.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — shows other shipped formations that consume image-build steps.
+- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — persisted build, validation, and execution records.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/270
 
@@ -41,12 +55,15 @@ The papers below document the research and map the proposed approaches to corres
 
 **Paper:** https://hybridops.tech/papers/reproducible-network-training-labs-v1.0.pdf
 
-**Implementation areas:**
-- EVE-NG and GNS3 blueprints
-- disposable infrastructure
-- repeatable environment provisioning
-- archive and restore
-- cost and lifecycle controls
+**Implementation map:**
+
+- [EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/) — operator workflow for the governed lab lifecycle.
+- [EVE-NG training environment reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/) — public scenario tying design, operation, and verification together.
+- [GCP EVE-NG formation](blueprints/gcp/eve-ng@v1/README.md) — private GCP network → VM → EVE-NG → images → health check, with archive/restore and lifecycle controls.
+- [GCP GNS3 formation](blueprints/gcp/gns3@v1/README.md) — private GCP network → VM → GNS3 server/images/starter lab → health check.
+- [On-Prem EVE-NG formation](blueprints/onprem/eve-ng@v1/README.md) — template-image → Proxmox VM → EVE-NG configuration/images/health check.
+- [On-Prem GNS3 formation](blueprints/onprem/gns3@v1/README.md) — verified template → Proxmox VM → GNS3 server/images/starter lab/health check.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — comparative view of the on-prem and GCP lab formations.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/271
 
@@ -56,11 +73,14 @@ The papers below document the research and map the proposed approaches to corres
 
 **Paper:** https://hybridops.tech/papers/authority-before-automation-v1.0.pdf
 
-**Implementation areas:**
-- source-of-truth architecture
-- NetBox-backed infrastructure intent
-- validation before execution
-- authoritative state versus pipeline-generated state
+**Implementation map:**
+
+- [Authoritative on-prem foundation reference scenario](https://docs.hybridops.tech/reference-scenarios/authoritative-onprem-foundation/) — public source-of-truth operating model and implementation narrative.
+- [Bootstrap NetBox formation](blueprints/onprem/bootstrap-netbox@v1/README.md) — SDN → template → VMs → PostgreSQL → NetBox bootstrap chain.
+- [Authoritative Foundation formation](blueprints/onprem/authoritative-foundation@v1/README.md) — NetBox-backed state gates later platform VM expansion.
+- [NetBox HA cutover formation](blueprints/onprem/netbox-ha-cutover@v1/README.md) — example of downstream state-contract consumption during service cutover.
+- [Proxmox SDN operations runbook](https://docs.hybridops.tech/ops/runbooks/networking/sdn_operations/) — plan/preflight/apply path for the network foundation feeding authoritative inventory/IPAM.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — documents the `authoritative` operating mode across shipped formations.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/272
 
@@ -70,12 +90,15 @@ The papers below document the research and map the proposed approaches to corres
 
 **Paper:** https://hybridops.tech/papers/recovery-operating-model-v1.0.pdf
 
-**Implementation areas:**
-- recovery workflows
-- structured execution evidence
-- failover and failback
-- environment reconstruction
-- recovery validation and handoff
+**Implementation map:**
+
+- [PostgreSQL HA DR Cycle reference scenario](https://docs.hybridops.tech/reference-scenarios/postgresql-ha-dr-cycle/) — recorded restore-to-GCP, backup continuity, controlled failback, and final DNS truth.
+- [PostgreSQL HA backup formation](blueprints/dr/postgresql-ha-backup-gcp@v1/README.md) — GCS object repository → pgBackRest backup readiness.
+- [PostgreSQL HA failover formation](blueprints/dr/postgresql-ha-failover-gcp@v1/README.md) — GCP network/VM restore path through PostgreSQL HA, backup, and DNS cutover.
+- [PostgreSQL HA failback formation](blueprints/dr/postgresql-ha-failback-onprem@v1/README.md) — template/VM rebuild → restore → backup → DNS cutback.
+- [GCP Ops Runner runbook](https://docs.hybridops.tech/ops/runbooks/networking/blueprints/hyops-blueprint-gcp-ops-runner/) — runner-local execution model used for DR and burst workflows.
+- [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) — self-managed and managed PostgreSQL recovery formations in one catalog.
+- [Evidence and redaction standard](https://docs.hybridops.tech/architecture/standards/evidence-and-redaction/) — stable non-secret execution records used to review recovery outcomes.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/273
 


### PR DESCRIPTION
## Summary

Adds a public research and external review index that connects HybridOps research papers to concrete implementation paths in HybridOps Core.

## Changes

- add `RESEARCH.md` with five published papers
- map each paper to relevant public docs, blueprint formations, and runtime or module source
- link each paper to a dedicated external technical review issue
- add a short Research and external review section to the main README

## Mapping approach

The research index uses three types of reference:

- **Public docs:** reference scenarios, runbooks, standards, and the Blueprint Index
- **Blueprint formations:** directory links that show the README, `blueprint.yml`, and related files together
- **Runtime and module source:** code behind the relevant contract, validation, lifecycle, or evidence behaviour

This gives reviewers a direct path from the paper to the operating context, the shipped formation, and the implementation.

## External review threads

- #269: HybridOps Contract Runtime v1.0
- #270: Build, Boot, Verify, Publish v1.0
- #271: Reproducible Network Training Labs v1.0
- #272: Authority Before Automation v1.0
- #273: Recovery Operating Model v1.0