### PR TITLE
Fix source version metadata

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - Unreleased
+  - aligned source package and runtime version metadata with the v0.1.4 pre-release and added regression coverage to prevent placeholder versions returning
   - added checksum-verified GNS3 image installation and template registration
   - added a private GCP GNS3 teaching blueprint with IAP desktop-client access
   - added an idempotent zero-image GNS3 starter-lab module and blueprint stage

--- a/hyops/__init__.py
+++ b/hyops/__init__.py
@@ -5,4 +5,4 @@ maintainer: HybridOps.Tech
 """
 
 __all__ = ["__version__"]
-__version__ = "0.0.0-dev"
+__version__ = "0.1.4"

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -54,6 +55,16 @@ class CliRoutingTests(unittest.TestCase):
         result = run_cli("--version")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertRegex(result.stdout.strip(), r"^\d+\.\d+\.\d+(?:[-+].*)?$")
+
+    def test_source_version_metadata_matches_runtime(self) -> None:
+        import hyops
+
+        project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        package_version = project["project"]["version"]
+
+        self.assertEqual(package_version, hyops.__version__)
+        self.assertFalse(package_version.startswith("0.0.0"))
+        self.assertNotIn("dev", package_version.lower())
 
     def test_top_level_help_lists_public_commands(self) -> None:
         result = run_cli("--help")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hybridops-core"
-version = "0.0.0.dev0"
+version = "0.1.4"
 description = "HybridOps.Core runtime scaffold"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- set source package and runtime metadata to `0.1.4`, matching the current pre-release line
- remove the stale `0.0.0.dev0` / `0.0.0-dev` placeholders from the source tree
- add a regression test that keeps `pyproject.toml` and `hyops.__version__` aligned and prevents placeholder development versions returning
- record the correction under Unreleased in the changelog

## Context

`v0.1.3` remains the current stable release and `v0.1.4` is the pre-release line. Release bundles were already stamped from the release tag during packaging, but the repository source metadata still exposed the original development placeholders, including at the `v0.1.4` tag.

## Scope

This keeps the existing release-bundle stamping mechanism unchanged. It only makes source-tree metadata truthful and adds regression coverage against future drift.