### PR TITLE
docs: refine Core positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">HybridOps Core</h1>
 
 <p align="center">
-  <strong>A contract-driven runtime for repeatable infrastructure execution across on-prem, cloud, Kubernetes, and local targets.</strong>
+  <strong>A contract-driven runtime for governed infrastructure operations across hybrid environments.</strong>
 </p>
 
 <p align="center">
@@ -15,7 +15,7 @@
     <td align="center"><strong>80</strong><br><sub>runtime modules</sub></td>
     <td align="center"><strong>28</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
-    <td align="center"><strong>8</strong><br><sub>supported targets</sub></td>
+    <td align="center"><strong>8</strong><br><sub>execution targets</sub></td>
   </tr>
 </table>
 
@@ -23,11 +23,9 @@
 
 ## What this is
 
-HybridOps Core provides one operator contract for infrastructure lifecycles across **Proxmox, Hetzner, GCP, AWS, Azure, Kubernetes, Cloudflare, and local** targets.
+HybridOps Core is the runtime that gives infrastructure operations a stable operator contract across environments, lifecycle stages, and implementation changes.
 
-Module specs define intent. Profiles carry environment policy. Drivers adapt execution. Packs contain versioned implementation assets. Blueprints compose modules into dependency-aware operations. The runtime validates the resolved contract, performs preflight, executes the selected implementation, publishes outputs, and writes a structured run record.
-
-Terraform, Terragrunt, Ansible, Packer, Kubernetes tooling, provider CLIs, and APIs integrate through the runtime rather than defining the operator workflow themselves.
+A `ModuleSpec` defines intended capability. A `Profile` carries environment policy. A `Driver` binds execution. A versioned `Pack` carries implementation assets. A `Blueprint` composes modules into a dependency-aware lifecycle. The runtime resolves these contracts, performs preflight, executes the selected implementation, publishes outputs, and writes a structured run record.
 
 Core standardises:
 
@@ -40,9 +38,9 @@ Core standardises:
 
 HybridOps is exercised through complete platform paths rather than isolated configuration examples.
 
-- **[Authoritative on-prem foundation](https://docs.hybridops.tech/reference-scenarios/authoritative-onprem-foundation/):** NetBox-backed source-of-truth operations and Proxmox SDN baseline
-- **[PostgreSQL HA failover and failback](https://docs.hybridops.tech/reference-scenarios/postgresql-ha-dr-cycle/):** Patroni, pgBackRest, GCP recovery, and controlled failback
-- **[RKE2 HA platform foundation](https://docs.hybridops.tech/reference-scenarios/gitops-kubernetes-foundation/):** RKE2 cluster foundation with GitOps delivery
+- **[Authoritative on-prem foundation](https://docs.hybridops.tech/reference-scenarios/authoritative-onprem-foundation/):** source-of-truth network and platform foundation
+- **[PostgreSQL HA recovery cycle](https://docs.hybridops.tech/reference-scenarios/postgresql-ha-dr-cycle/):** backup continuity, failover, failback, and controlled cutover
+- **[Kubernetes HA platform foundation](https://docs.hybridops.tech/reference-scenarios/gitops-kubernetes-foundation/):** highly available cluster foundation with GitOps delivery
 
 See the full [reference scenario library](https://docs.hybridops.tech/reference-scenarios/).
 
@@ -68,7 +66,7 @@ flowchart LR
     driver["Driver<br/>execute in workdir"]
     record["Run record<br/>redacted output"]
     profile["Profile<br/>policy and defaults"]
-    pack["Pack<br/>tool assets"]
+    pack["Pack<br/>implementation assets"]
 
     spec --> cli
     profile --> cli
@@ -89,7 +87,7 @@ Run records are written under stable paths such as:
 ## Requirements
 
 - Python >= 3.11
-- Tool dependencies vary by module: `terraform`, `terragrunt`, `ansible`, `packer`, `gcloud`, `kubectl`
+- Module-specific execution dependencies are documented with the relevant module and runbook
 
 ## Research and external review
 


### PR DESCRIPTION
Keeps the repository front door focused on the HybridOps runtime rather than the underlying execution ecosystem.

The opening now defines the contract model directly, removes provider and tool lists from the primary positioning, and keeps implementation-specific detail in the scenarios and deeper documentation.

README only.