### PR TITLE
feat(device-automation): add managed lab access

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -6,8 +6,10 @@ labels:
 body:
   - type: markdown
     attributes:
-      value: |
-        Use this for focused questions and documentation clarification. Do not include credentials, tokens, private addresses, customer data, or unredacted run records.
+      value: >-
+        Use this for focused questions and documentation clarification. Do not
+        include credentials, tokens, private addresses, customer data, or
+        unredacted run records.
   - type: dropdown
     id: area
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,10 @@ jobs:
         shell: bash
         run: |
           export HYOPS_RELEASE_LABEL="${GITHUB_SHA::12}"
-          export HYOPS_RELEASE_VERSION="0.0.${GITHUB_RUN_NUMBER}"
+          export HYOPS_RELEASE_VERSION="$(
+            python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])'
+          )"
+          echo "HYOPS_RELEASE_VERSION=${HYOPS_RELEASE_VERSION}" >> "${GITHUB_ENV}"
           bash pkg/build_release.sh
           TARBALL="$(ls -1 dist/releases/hybridops-core-*.tar.gz | head -n 1)"
           bash pkg/build_macos_pkg.sh \
@@ -126,6 +129,7 @@ jobs:
           PKG="$(ls -1 dist/releases/hybridops-core-*-macos-${{ matrix.architecture }}.pkg | head -n 1)"
           sudo installer -pkg "${PKG}" -target /
           /usr/local/bin/hyops --help >/dev/null
+          test "$(/usr/local/bin/hyops --version)" = "${HYOPS_RELEASE_VERSION}"
           test -x "/Applications/HybridOps.Core.app/Contents/MacOS/HybridOps.Core"
           test -s "/Applications/HybridOps.Core.app/Contents/Resources/hybridops.icns"
           test -x "${HOME}/.hybridops/config/macos-shell.command"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 # Changelog
 
 - Unreleased
+  - made initialized environment blueprints the automatic execution source while retaining `--file` as an explicit override
+  - added private workstation-to-device automation access for EVE-NG and GNS3, including scoped SSH and automation client files, DHCP discovery, and optional local routing
+  - added vault-backed EVE-NG IOL and GNS3 IOU licence placement with checksum-verified image registration and archive exclusion
   - aligned source package and runtime version metadata with the v0.1.4 pre-release and added regression coverage to prevent placeholder versions returning
   - added checksum-verified GNS3 image installation and template registration
   - added a private GCP GNS3 teaching blueprint with IAP desktop-client access

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -87,6 +87,12 @@ The [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/) is the m
 - [GCP GNS3 operation](blueprints/gcp/gns3@v1/): creates the private GCP network and VM, installs GNS3 and starter content, then runs a health check.
 - [On-Prem EVE-NG operation](blueprints/onprem/eve-ng@v1/): builds from a template image, provisions the Proxmox VM, installs EVE-NG and images, then validates the host.
 - [On-Prem GNS3 operation](blueprints/onprem/gns3@v1/): builds from a verified template, provisions the Proxmox VM, installs GNS3 and starter content, then validates the host.
+
+The EVE-NG and GNS3 operations also declare a private device-management plane.
+An access session can publish environment-scoped SSH and automation client
+material, proxy workstation traffic through the existing private host path,
+and optionally route the management subnet after checking for local conflicts.
+No device or management subnet is opened to the public network.
 - [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/): comparative view of the on-premises and GCP lab operations.
 
 **External review:** https://github.com/hybridops-tech/hybridops-core/issues/271

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -98,6 +98,20 @@ hyops blueprint preflight --env <env> \
   --blueprints-root blueprints
 ```
 
+After `init`, open a local overlay directly in your default editor:
+
+```bash
+hyops blueprint init --env <env> --ref gcp/eve-ng@v1 --edit
+```
+
+You can also run a separate edit step:
+
+```bash
+hyops blueprint edit --env <env> --ref gcp/eve-ng@v1
+```
+
+Use `--file` when you need to target a different local overlay path.
+
 Execution begins only when `deploy` is given `--execute`:
 
 ```bash

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -90,6 +90,22 @@ through the existing IAP SSH path with the declared HybridOps key, opens the
 browser, and keeps access active until `Ctrl-C`. Port 80 remains closed at the
 GCP firewall. Use `--no-browser` when only the printed local URL is required.
 
+For workstation automation, connect a device management interface to `Cloud8`
+and run:
+
+```bash
+hyops blueprint access --env <env> --ref gcp/eve-ng@v1 --automation
+```
+
+The command keeps the UI private, discovers management leases and writes a
+scoped SSH configuration and automation inventory. Use the printed SSH config
+from a second terminal or VS Code while the access session remains open.
+DHCP supplies the management gateway; static devices must use `172.29.128.1`.
+On Linux or WSL, `--route-lab` additionally creates a temporary layer-3 route
+and verifies the management gateway when `172.29.128.0/24` does not conflict
+locally. Windows and macOS applications can use the generated SSH configuration
+or local proxy.
+
 After an interactive access session closes, the blueprint reports billing
 status and resource-state age, provides the project-specific GCP Billing link
 for trial, credit and spend details, then offers to keep the environment,

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -30,6 +30,13 @@ access:
   guest_network_label: "Cloud9"
   guest_gateway: "172.29.129.1"
   guest_dhcp_range: "172.29.129.50-172.29.129.200"
+  automation:
+    management_network_label: "Cloud8"
+    management_cidr: "172.29.128.0/24"
+    management_gateway: "172.29.128.1"
+    management_dhcp_range: "172.29.128.50-172.29.128.200"
+    lease_file: "/var/lib/misc/dnsmasq.leases"
+    default_user: "admin"
   offer_destroy_on_close: true
 
 archive_before_destroy:
@@ -144,6 +151,7 @@ steps:
       connectivity_wait_s: 90
       eveng_resource_profile: "standard"
       eveng_guest_nat_enabled: true
+      eveng_management_access_enabled: true
 
   - id: gcp_eve_ng_images
     module_ref: "platform/linux/eve-ng-images"
@@ -177,6 +185,13 @@ steps:
       eveng_images_source: "url"
       eveng_images_logging_enabled: true
       eveng_images_generate_report: true
+      # Keep authorised IOL licence content in the environment vault, not in
+      # this file. Import it once with `hyops secrets set --from-file`, then
+      # enable these inputs when an item below uses type: "iol":
+      # load_vault_env: true
+      # required_env: ["EVENG_IOL_LICENSE"]
+      # eveng_images_iol_license_env: "EVENG_IOL_LICENSE"
+      # eveng_images_iol_license_required: true
       eveng_images_list:
         # Small, broadly useful starter set for a first lab deployment.
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/LhBG1ZQI"
@@ -191,6 +206,11 @@ steps:
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/uoIABDjA"
           name: "linux-ubuntu-24.04.01-server.tar.gz"
           type: "qemu"
+
+        # Authorised IOL image example:
+        # - url: "https://example.invalid/operator-supplied-iol.bin"
+        #   name: "operator-supplied-iol.bin"
+        #   type: "iol"
 
         # Optional public images. Enable only what a lab needs; desktop,
         # security and legacy images can add substantial download and disk use.

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -39,6 +39,15 @@ hyops blueprint deploy --env gns3-gcp --ref gcp/gns3@v1 --execute
 hyops blueprint access --env gns3-gcp --ref gcp/gns3@v1
 ```
 
+For workstation automation, add a GNS3 Cloud node mapped to `hyops-mgmt0`,
+connect device management interfaces to it, and run access with `--automation`.
+HybridOps discovers management leases and writes a scoped SSH config, target
+file and automation inventory. Optional `--route-lab` routing requires
+Linux or WSL with TUN support and a non-conflicting `172.29.130.0/24` local
+route. Windows and macOS applications use the generated SSH configuration or
+local proxy. DHCP supplies the management gateway; static devices must use
+`172.29.130.1`.
+
 Keep the command running. Open the printed HTTP endpoint in a browser or
 configure the GNS3 desktop client to use it. The default username is `gns3`.
 Retrieve the password from the environment vault:

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -22,6 +22,13 @@ access:
   open_browser: false
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
+  automation:
+    management_network_label: "hyops-mgmt0"
+    management_cidr: "172.29.130.0/24"
+    management_gateway: "172.29.130.1"
+    management_dhcp_range: "172.29.130.50-172.29.130.200"
+    lease_file: "/var/lib/misc/dnsmasq.hybridops-gns3-management.leases"
+    default_user: "admin"
 
 archive_before_destroy:
   module_ref: "platform/linux/gns3-lab-archive"
@@ -137,6 +144,7 @@ steps:
       gns3_server_enable_kvm: true
       gns3_server_require_kvm: true
       gns3_server_install_emulators: true
+      gns3_server_management_access_enabled: true
 
   - id: gcp_gns3_images
     module_ref: "platform/linux/gns3-images"
@@ -161,6 +169,12 @@ steps:
       connectivity_wait_s: 90
       become: true
       become_user: "root"
+      # Keep authorised IOU licence content in the environment vault, not in
+      # this file. Import it once with `hyops secrets set --from-file`, then
+      # enable these inputs when an item below uses type: "iou":
+      # load_vault_env: true
+      # required_env: ["GNS3_SERVER_PASSWORD", "GNS3_IOU_LICENSE"]
+      # gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
       gns3_images_items:
         - name: "Alpine Linux 3.24"
           url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"
@@ -170,6 +184,12 @@ steps:
           template:
             ram: 512
             adapters: 2
+        # Authorised IOU image example:
+        # - name: "Operator supplied IOU"
+        #   url: "https://example.invalid/operator-supplied-iou.bin"
+        #   filename: "operator-supplied-iou.bin"
+        #   checksum: "sha256:<64-hex-character-checksum>"
+        #   type: "iou"
 
   - id: gcp_gns3_starter_lab
     module_ref: "platform/linux/gns3-starter-lab"

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -86,6 +86,15 @@ Open the private UI:
 hyops blueprint access --env <env> --ref onprem/eve-ng@v1
 ```
 
+Connect a device management interface to `Cloud8`, then add `--automation` to
+open a private workstation-to-device path. HybridOps writes the SSH config,
+device target file and automation inventory under the selected environment.
+The access session must remain open. DHCP supplies the management gateway;
+static devices must use `172.29.128.1`. On Linux or WSL, optional
+`--route-lab` creates a temporary layer-3 route when `172.29.128.0/24` does not
+conflict locally. Windows and macOS applications use the generated SSH
+configuration or local proxy.
+
 When access closes, HybridOps offers to keep the environment, export its lab
 definitions before teardown, or destroy without an export. Direct interactive
 destroy uses the same choices. Automation must pass either
@@ -116,6 +125,7 @@ The shipped blueprint provisions one VM:
 - disk: `256` GB
 - network: `vmbr0` with DHCP
 - guest egress network: `Cloud9` (`172.29.129.0/24`)
+- private automation network: `Cloud8` (`172.29.128.0/24`)
 - SSH user: `opsadmin`
 
 The VM consumes the template state from:

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -30,6 +30,13 @@ access:
   guest_network_label: "Cloud9"
   guest_gateway: "172.29.129.1"
   guest_dhcp_range: "172.29.129.50-172.29.129.200"
+  automation:
+    management_network_label: "Cloud8"
+    management_cidr: "172.29.128.0/24"
+    management_gateway: "172.29.128.1"
+    management_dhcp_range: "172.29.128.50-172.29.128.200"
+    lease_file: "/var/lib/misc/dnsmasq.leases"
+    default_user: "admin"
   offer_destroy_on_close: true
 
 archive_before_destroy:
@@ -122,6 +129,7 @@ steps:
       become_user: "root"
       eveng_resource_profile: "standard"
       eveng_guest_nat_enabled: true
+      eveng_management_access_enabled: true
 
   - id: eve_ng_images
     module_ref: "platform/linux/eve-ng-images"
@@ -157,6 +165,13 @@ steps:
       eveng_images_source: "url"
       eveng_images_logging_enabled: true
       eveng_images_generate_report: true
+      # Keep authorised IOL licence content in the environment vault, not in
+      # this file. Import it once with `hyops secrets set --from-file`, then
+      # enable these inputs when an item below uses type: "iol":
+      # load_vault_env: true
+      # required_env: ["EVENG_IOL_LICENSE"]
+      # eveng_images_iol_license_env: "EVENG_IOL_LICENSE"
+      # eveng_images_iol_license_required: true
       eveng_images_list:
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/LhBG1ZQI"
           name: "linux-alpine-3.21.3.tar.gz"
@@ -170,6 +185,11 @@ steps:
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/uoIABDjA"
           name: "linux-ubuntu-24.04.01-server.tar.gz"
           type: "qemu"
+
+        # Authorised IOL image example:
+        # - url: "https://example.invalid/operator-supplied-iol.bin"
+        #   name: "operator-supplied-iol.bin"
+        #   type: "iol"
 
   - id: eve_ng_healthcheck
     module_ref: "platform/linux/eve-ng-healthcheck"

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -54,6 +54,14 @@ hyops blueprint access \
   --ref onprem/gns3@v1
 ```
 
+For workstation automation, add a GNS3 Cloud node mapped to `hyops-mgmt0`,
+connect device management interfaces to it, and add `--automation`. The command
+writes a scoped SSH config, target file and automation inventory. Optional
+`--route-lab` routing requires Linux or WSL with TUN support and a
+non-conflicting `172.29.130.0/24` local route. Windows and macOS applications
+use the generated SSH configuration or local proxy. DHCP supplies the
+management gateway; static devices must use `172.29.130.1`.
+
 Keep the command running. Open `http://127.0.0.1:3080/` in a browser or
 configure the GNS3 desktop client to use host `127.0.0.1`, port `3080` and
 protocol `HTTP`. The default username is `gns3`. Retrieve the generated

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -21,6 +21,13 @@ access:
   local_port: 3080
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
+  automation:
+    management_network_label: "hyops-mgmt0"
+    management_cidr: "172.29.130.0/24"
+    management_gateway: "172.29.130.1"
+    management_dhcp_range: "172.29.130.50-172.29.130.200"
+    lease_file: "/var/lib/misc/dnsmasq.hybridops-gns3-management.leases"
+    default_user: "admin"
 
 archive_before_destroy:
   module_ref: "platform/linux/gns3-lab-archive"
@@ -109,6 +116,7 @@ steps:
       gns3_server_enable_kvm: true
       gns3_server_require_kvm: true
       gns3_server_install_emulators: true
+      gns3_server_management_access_enabled: true
 
   - id: gns3_images
     module_ref: "platform/linux/gns3-images"
@@ -129,6 +137,12 @@ steps:
       ssh_proxy_jump_user: "root"
       become: true
       become_user: "root"
+      # Keep authorised IOU licence content in the environment vault, not in
+      # this file. Import it once with `hyops secrets set --from-file`, then
+      # enable these inputs when an item below uses type: "iou":
+      # load_vault_env: true
+      # required_env: ["GNS3_SERVER_PASSWORD", "GNS3_IOU_LICENSE"]
+      # gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
       gns3_images_items:
         - name: "Alpine Linux 3.24"
           url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"
@@ -138,6 +152,12 @@ steps:
           template:
             ram: 512
             adapters: 2
+        # Authorised IOU image example:
+        # - name: "Operator supplied IOU"
+        #   url: "https://example.invalid/operator-supplied-iou.bin"
+        #   filename: "operator-supplied-iou.bin"
+        #   checksum: "sha256:<64-hex-character-checksum>"
+        #   type: "iou"
 
   - id: gns3_starter_lab
     module_ref: "platform/linux/gns3-starter-lab"

--- a/hyops/blueprint/automation_access.py
+++ b/hyops/blueprint/automation_access.py
@@ -1,0 +1,624 @@
+"""Client material for private access to devices inside network labs."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_TARGET_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$")
+
+
+def _safe_name(value: str, *, fallback: str = "device") -> str:
+    token = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip()).strip("-.")
+    if not token or not token[0].isalnum():
+        token = fallback
+    return token[:63]
+
+
+def _write_private(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.chmod(0o600)
+    temporary.replace(path)
+
+
+def parse_dnsmasq_leases(text: str, management_cidr: str, *, default_user: str) -> list[dict[str, Any]]:
+    """Return safe target candidates from a dnsmasq lease file."""
+
+    network = ipaddress.ip_network(management_cidr, strict=False)
+    candidates: list[dict[str, Any]] = []
+    used_names: set[str] = set()
+    for line in str(text or "").splitlines():
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        mac, address, hostname = fields[1], fields[2], fields[3]
+        try:
+            ip = ipaddress.ip_address(address)
+        except ValueError:
+            continue
+        if ip not in network:
+            continue
+        base = _safe_name(hostname if hostname not in {"", "*"} else f"device-{str(ip).split('.')[-1]}")
+        name = base
+        suffix = 2
+        while name in used_names:
+            name = f"{base[:58]}-{suffix}"
+            suffix += 1
+        used_names.add(name)
+        candidates.append(
+            {
+                "name": name,
+                "host": str(ip),
+                "user": default_user,
+                "port": 22,
+                "mac": mac.lower(),
+                "source": "dhcp-lease",
+            }
+        )
+    return sorted(candidates, key=lambda item: ipaddress.ip_address(item["host"]))
+
+
+def _load_targets(path: Path, management_cidr: str) -> list[dict[str, Any]]:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError(f"cannot read automation targets: {path}: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("targets", []), list):
+        raise ValueError(f"automation target file must contain a targets list: {path}")
+
+    network = ipaddress.ip_network(management_cidr, strict=False)
+    targets: list[dict[str, Any]] = []
+    names: set[str] = set()
+    for index, raw in enumerate(payload.get("targets") or [], start=1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"automation targets[{index}] must be a mapping")
+        name = str(raw.get("name") or "").strip()
+        host = str(raw.get("host") or "").strip()
+        user = str(raw.get("user") or "").strip()
+        if not _TARGET_NAME_RE.fullmatch(name):
+            raise ValueError(f"automation targets[{index}].name is invalid")
+        if name in names:
+            raise ValueError(f"automation target name is duplicated: {name}")
+        names.add(name)
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError as exc:
+            raise ValueError(f"automation target {name} must use an IPv4 address") from exc
+        if address not in network:
+            raise ValueError(
+                f"automation target {name} ({address}) is outside {network}"
+            )
+        if not user:
+            raise ValueError(f"automation target {name} requires user")
+        port = int(raw.get("port") or 22)
+        if not 1 <= port <= 65535:
+            raise ValueError(f"automation target {name} port must be between 1 and 65535")
+        identity = str(raw.get("identity_file") or "").strip()
+        if identity:
+            identity_path = Path(identity).expanduser().resolve()
+            if not identity_path.is_file():
+                raise ValueError(
+                    f"automation target {name} identity file does not exist: {identity_path}"
+                )
+            identity = str(identity_path)
+        groups_raw = raw.get("groups") or []
+        if not isinstance(groups_raw, list):
+            raise ValueError(f"automation target {name} groups must be a list")
+        groups = [_safe_name(str(group), fallback="devices") for group in groups_raw]
+        mac = str(raw.get("mac") or "").strip().lower()
+        source = str(raw.get("source") or "").strip()
+        platform = str(raw.get("platform") or "").strip()
+        targets.append(
+            {
+                "name": name,
+                "host": str(address),
+                "user": user,
+                "port": port,
+                "identity_file": identity,
+                "groups": list(dict.fromkeys(groups)),
+                "mac": mac,
+                "source": source,
+                "platform": platform,
+            }
+        )
+    return targets
+
+
+def _target_template(candidates: list[dict[str, Any]], management_label: str) -> str:
+    lines = [
+        "# Devices reachable through the HybridOps-managed lab network.",
+        f"# Connect a management interface to {management_label}, then set the SSH user.",
+        "# identity_file is optional; omit it to use agent, keyboard-interactive, or password auth.",
+        "version: 1",
+        "targets:",
+    ]
+    if not candidates:
+        lines.append("  []")
+    else:
+        for item in candidates:
+            lines.extend(
+                [
+                    f"  - name: {item['name']}",
+                    f"    host: {item['host']}",
+                    f"    user: {item['user']}",
+                    "    port: 22",
+                    f"    mac: {item['mac']}",
+                    "    source: dhcp-lease",
+                    "    groups: [network_devices]",
+                ]
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _merge_discovered_targets(
+    path: Path,
+    candidates: list[dict[str, Any]],
+    management_label: str,
+) -> list[str]:
+    """Add DHCP targets without replacing operator-managed target settings."""
+
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError(f"cannot read automation targets: {path}: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("targets", []), list):
+        raise ValueError(f"automation target file must contain a targets list: {path}")
+
+    targets = payload.get("targets") or []
+    by_mac: dict[str, dict[str, Any]] = {}
+    occupied_hosts: set[str] = set()
+    occupied_names: set[str] = set()
+    for raw in targets:
+        if not isinstance(raw, dict):
+            continue
+        host = str(raw.get("host") or "").strip()
+        name = str(raw.get("name") or "").strip()
+        mac = str(raw.get("mac") or "").strip().lower()
+        source = str(raw.get("source") or "").strip()
+        if host:
+            occupied_hosts.add(host)
+        if name:
+            occupied_names.add(name)
+        if mac and source == "dhcp-lease":
+            by_mac[mac] = raw
+
+    changed = False
+    added: list[str] = []
+    for candidate in candidates:
+        mac = str(candidate.get("mac") or "").lower()
+        existing = by_mac.get(mac)
+        if existing is not None:
+            previous_host = str(existing.get("host") or "").strip()
+            current_host = str(candidate["host"])
+            if previous_host != current_host and current_host not in occupied_hosts:
+                existing["host"] = current_host
+                occupied_hosts.discard(previous_host)
+                occupied_hosts.add(current_host)
+                changed = True
+            continue
+        if str(candidate["host"]) in occupied_hosts:
+            continue
+
+        name = str(candidate["name"])
+        base = name
+        suffix = 2
+        while name in occupied_names:
+            name = f"{base[:58]}-{suffix}"
+            suffix += 1
+        target = {
+            "name": name,
+            "host": str(candidate["host"]),
+            "user": str(candidate["user"]),
+            "port": int(candidate.get("port") or 22),
+            "mac": mac,
+            "source": "dhcp-lease",
+            "groups": ["network_devices"],
+        }
+        targets.append(target)
+        by_mac[mac] = target
+        occupied_names.add(name)
+        occupied_hosts.add(str(candidate["host"]))
+        added.append(name)
+        changed = True
+
+    if changed:
+        content = [
+            "# Devices reachable through the HybridOps-managed lab network.",
+            f"# DHCP devices on {management_label} are maintained automatically.",
+            "# Add static targets or adjust names and credentials when required.",
+            yaml.safe_dump({"version": 1, "targets": targets}, sort_keys=False).rstrip(),
+            "",
+        ]
+        _write_private(path, "\n".join(content))
+    return added
+
+
+def automation_session_paths(
+    *,
+    paths: Any,
+    blueprint_ref: str,
+    env_name: str,
+) -> dict[str, Any]:
+    """Return stable client paths and aliases for a blueprint environment."""
+
+    scope = _safe_name(blueprint_ref.replace("@", "-"), fallback="blueprint")
+    alias_prefix = _safe_name(f"hyops-{env_name or 'runtime'}", fallback="hyops-runtime")
+    config_dir = Path(paths.config_dir) / "automation" / scope
+    session_dir = Path(paths.root) / "artifacts" / "access" / scope
+    return {
+        "scope": scope,
+        "alias_prefix": alias_prefix,
+        "gateway_alias": f"{alias_prefix}-gateway",
+        "config_dir": config_dir,
+        "session_dir": session_dir,
+        "target_file": config_dir / "targets.yml",
+        "ssh_config": session_dir / "ssh_config",
+        "inventory": session_dir / "inventory.ini",
+        "ansible_config": session_dir / "ansible.cfg",
+        "proxy_env": session_dir / "proxy.env",
+        "nornir_hosts": session_dir / "nornir-hosts.yml",
+        "nornir_groups": session_dir / "nornir-groups.yml",
+        "nornir_defaults": session_dir / "nornir-defaults.yml",
+        "session_file": session_dir / "session.yml",
+    }
+
+
+def load_automation_targets(path: Path, management_cidr: str) -> list[dict[str, Any]]:
+    """Load validated targets for device commands."""
+
+    return _load_targets(path, management_cidr)
+
+
+def _ssh_config(
+    *,
+    gateway: dict[str, Any],
+    gateway_alias: str,
+    target_alias_prefix: str,
+    targets: list[dict[str, Any]],
+    target_known_hosts: Path,
+) -> str:
+    lines = [
+        "# Valid while the matching hyops blueprint access session is running.",
+        f"Host {gateway_alias}",
+        f"  HostName {gateway['host']}",
+        f"  User {gateway['user']}",
+        f"  Port {int(gateway.get('port') or 22)}",
+        f"  IdentityFile {gateway['identity_file']}",
+        "  IdentitiesOnly yes",
+        "  StrictHostKeyChecking accept-new",
+        f"  UserKnownHostsFile {gateway['known_hosts_file']}",
+        "  LogLevel ERROR",
+    ]
+    if gateway.get("host_key_alias"):
+        lines.append(f"  HostKeyAlias {gateway['host_key_alias']}")
+    for target in targets:
+        lines.extend(
+            [
+                "",
+                f"Host {target_alias_prefix}-{target['name']}",
+                f"  HostName {target['host']}",
+                f"  User {target['user']}",
+                f"  Port {target['port']}",
+                f"  ProxyJump {gateway_alias}",
+                "  StrictHostKeyChecking accept-new",
+                f"  UserKnownHostsFile {target_known_hosts}",
+                "  LogLevel ERROR",
+            ]
+        )
+        if target["identity_file"]:
+            lines.extend(
+                [
+                    f"  IdentityFile {target['identity_file']}",
+                    "  IdentitiesOnly yes",
+                ]
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _inventory(
+    targets: list[dict[str, Any]],
+    alias_prefix: str,
+    ssh_config: Path,
+) -> str:
+    groups: dict[str, list[dict[str, Any]]] = {"network_devices": list(targets)}
+    for target in targets:
+        for group in target["groups"]:
+            members = groups.setdefault(group, [])
+            if target not in members:
+                members.append(target)
+    lines: list[str] = []
+    for group, members in groups.items():
+        lines.append(f"[{group}]")
+        for target in members:
+            lines.append(f"{target['name']} ansible_host={alias_prefix}-{target['name']}")
+        lines.append("")
+    lines.extend(
+        [
+            "[all:vars]",
+            f"ansible_ssh_common_args='-F {ssh_config}'",
+            "",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _nornir_inventory(
+    targets: list[dict[str, Any]],
+    alias_prefix: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    hosts: dict[str, Any] = {}
+    groups: dict[str, Any] = {"network_devices": {}}
+    for target in targets:
+        target_groups = list(target["groups"] or ["network_devices"])
+        if "network_devices" not in target_groups:
+            target_groups.insert(0, "network_devices")
+        for group in target_groups:
+            groups.setdefault(group, {})
+        host: dict[str, Any] = {
+            "hostname": f"{alias_prefix}-{target['name']}",
+            "port": target["port"],
+            "username": target["user"],
+            "groups": target_groups,
+            "data": {
+                "management_address": target["host"],
+                "source": target["source"] or "static",
+            },
+        }
+        if target["platform"]:
+            host["platform"] = target["platform"]
+        hosts[target["name"]] = host
+    return hosts, groups, {}
+
+
+def prepare_automation_session(
+    *,
+    paths: Any,
+    blueprint_ref: str,
+    env_name: str,
+    automation: dict[str, Any],
+    gateway: dict[str, Any],
+    socks_port: int,
+    lease_text: str = "",
+    target_file_override: str = "",
+) -> dict[str, Any]:
+    """Create target configuration and client files for one access session."""
+
+    material = automation_session_paths(
+        paths=paths,
+        blueprint_ref=blueprint_ref,
+        env_name=env_name,
+    )
+    alias_prefix = material["alias_prefix"]
+    gateway_alias = material["gateway_alias"]
+    config_dir = material["config_dir"]
+    session_dir = material["session_dir"]
+    target_file = (
+        Path(target_file_override).expanduser().resolve()
+        if target_file_override
+        else config_dir / "targets.yml"
+    )
+    if target_file_override and not target_file.is_file():
+        raise ValueError(f"automation target file does not exist: {target_file}")
+    candidates = parse_dnsmasq_leases(
+        lease_text,
+        automation["management_cidr"],
+        default_user=automation["default_user"],
+    )
+    if not target_file.exists():
+        _write_private(
+            target_file,
+            _target_template(candidates, automation["management_network_label"]),
+        )
+    new_targets: list[str] = []
+    if not target_file_override and candidates:
+        new_targets = _merge_discovered_targets(
+            target_file,
+            candidates,
+            automation["management_network_label"],
+        )
+    targets = _load_targets(target_file, automation["management_cidr"])
+
+    discovered_file = session_dir / "discovered-targets.yml"
+    _write_private(
+        discovered_file,
+        yaml.safe_dump({"version": 1, "targets": candidates}, sort_keys=False),
+    )
+    target_known_hosts = session_dir / "device_known_hosts"
+    target_known_hosts.touch(mode=0o600, exist_ok=True)
+    try:
+        target_known_hosts.chmod(0o600)
+    except OSError:
+        pass
+    ssh_config = session_dir / "ssh_config"
+    inventory = session_dir / "inventory.ini"
+    ansible_config = session_dir / "ansible.cfg"
+    proxy_env = session_dir / "proxy.env"
+    _write_private(
+        ssh_config,
+        _ssh_config(
+            gateway=gateway,
+            gateway_alias=gateway_alias,
+            target_alias_prefix=alias_prefix,
+            targets=targets,
+            target_known_hosts=target_known_hosts,
+        ),
+    )
+    _write_private(inventory, _inventory(targets, alias_prefix, ssh_config))
+    nornir_hosts = session_dir / "nornir-hosts.yml"
+    nornir_groups = session_dir / "nornir-groups.yml"
+    nornir_defaults = session_dir / "nornir-defaults.yml"
+    hosts_payload, groups_payload, defaults_payload = _nornir_inventory(
+        targets,
+        alias_prefix,
+    )
+    _write_private(nornir_hosts, yaml.safe_dump(hosts_payload, sort_keys=False))
+    _write_private(nornir_groups, yaml.safe_dump(groups_payload, sort_keys=False))
+    _write_private(nornir_defaults, yaml.safe_dump(defaults_payload, sort_keys=False))
+    _write_private(
+        ansible_config,
+        "[defaults]\n"
+        f"inventory = {inventory}\n"
+        "host_key_checking = True\n\n"
+        "[ssh_connection]\n"
+        f"ssh_args = -F {ssh_config}\n",
+    )
+    proxy = f"socks5h://127.0.0.1:{socks_port}"
+    _write_private(
+        proxy_env,
+        f"export HYOPS_SOCKS_PROXY={shlex.quote(proxy)}\n"
+        f"export ALL_PROXY={shlex.quote(proxy)}\n",
+    )
+    session_file = session_dir / "session.yml"
+    _write_private(
+        session_file,
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "blueprint_ref": blueprint_ref,
+                "environment": env_name,
+                "socks_proxy": proxy,
+            },
+            sort_keys=False,
+        ),
+    )
+    return {
+        "target_file": target_file,
+        "discovered_file": discovered_file,
+        "ssh_config": ssh_config,
+        "inventory": inventory,
+        "ansible_config": ansible_config,
+        "proxy_env": proxy_env,
+        "nornir_hosts": nornir_hosts,
+        "nornir_groups": nornir_groups,
+        "nornir_defaults": nornir_defaults,
+        "session_file": session_file,
+        "targets": targets,
+        "discovered_count": len(candidates),
+        "aliases": [f"{alias_prefix}-{target['name']}" for target in targets],
+        "gateway_alias": gateway_alias,
+        "socks_proxy": proxy,
+        "new_targets": new_targets,
+    }
+
+
+def local_route_conflicts(management_cidr: str) -> list[str]:
+    """Return local routes that overlap the requested lab network."""
+
+    network = ipaddress.ip_network(management_cidr, strict=False)
+    ip_command = shutil.which("ip")
+    if ip_command:
+        result = subprocess.run(
+            [ip_command, "-o", "-4", "route", "show"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        routes: list[str] = []
+        for line in result.stdout.splitlines():
+            destination = line.split(maxsplit=1)[0] if line.strip() else ""
+            if destination in {"", "default"}:
+                continue
+            try:
+                candidate = ipaddress.ip_network(destination, strict=False)
+            except ValueError:
+                continue
+            if candidate.overlaps(network):
+                routes.append(line.strip())
+        return routes
+
+    netstat = shutil.which("netstat")
+    if netstat:
+        result = subprocess.run(
+            [netstat, "-rn", "-f", "inet"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        routes = []
+        for line in result.stdout.splitlines():
+            fields = line.split()
+            if not fields or fields[0] in {"default", "Destination"}:
+                continue
+            token = fields[0]
+            if "/" not in token:
+                continue
+            try:
+                candidate = ipaddress.ip_network(token, strict=False)
+            except ValueError:
+                continue
+            if candidate.overlaps(network):
+                routes.append(line.strip())
+        return routes
+    return []
+
+
+def linux_tunnel_plan(scope: str) -> dict[str, Any]:
+    """Return a deterministic, environment-scoped point-to-point tunnel plan."""
+
+    digest = hashlib.sha256(scope.encode("utf-8")).digest()
+    tunnel_id = 100 + (int.from_bytes(digest[:2], "big") % 800)
+    third_octet = 64 + (digest[2] % 64)
+    fourth_octet = (digest[3] // 4) * 4
+    local_ip = f"169.254.{third_octet}.{fourth_octet + 1}"
+    remote_ip = f"169.254.{third_octet}.{fourth_octet + 2}"
+    return {
+        "tunnel_id": tunnel_id,
+        "interface": f"tun{tunnel_id}",
+        "local_cidr": f"{local_ip}/30",
+        "local_ip": local_ip,
+        "remote_cidr": f"{remote_ip}/30",
+        "remote_ip": remote_ip,
+    }
+
+
+def build_tunnel_ssh_argv(
+    *,
+    gateway: dict[str, Any],
+    plan: dict[str, Any],
+    remote_helper: str,
+) -> list[str]:
+    """Build a true layer-3 tunnel command through the access host."""
+
+    ssh_command = gateway.get("ssh_command")
+    if not isinstance(ssh_command, list) or not ssh_command:
+        raise ValueError("automation gateway is missing its SSH command")
+    remote_command = shlex.join(
+        [
+            "sudo",
+            "-n",
+            remote_helper,
+            "session",
+            str(plan["interface"]),
+            str(plan["remote_cidr"]),
+            str(plan["local_ip"]),
+        ]
+    )
+    return [
+        *[str(item) for item in ssh_command],
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "Tunnel=point-to-point",
+        "-w",
+        f"{plan['tunnel_id']}:{plan['tunnel_id']}",
+        f"{gateway['user']}@{gateway['host']}",
+        remote_command,
+    ]

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -17,7 +17,9 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
+
+import yaml
 
 from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.browser import is_windows_wsl, open_operator_url
@@ -42,19 +44,66 @@ from .contracts import (
     resolved_step_inputs_file,
     step_state_ref,
 )
+from .automation_access import (
+    automation_session_paths,
+    build_tunnel_ssh_argv,
+    linux_tunnel_plan,
+    load_automation_targets,
+    local_route_conflicts,
+    prepare_automation_session,
+)
 from .planner import compute_preflight, run_step_module_command
 from .schema import load_blueprint, resolve_blueprint_file, validate_blueprint
 
 
-def _resolve_and_validate(ns) -> dict[str, Any]:
+def _runtime_overlay_for_ref(ns, blueprint_ref: str) -> str:
+    if not blueprint_ref:
+        return ""
+    if not (getattr(ns, "root", None) or getattr(ns, "env", None)):
+        return ""
+
+    paths = resolve_runtime_paths(getattr(ns, "root", None), getattr(ns, "env", None))
+    overlay_root = (paths.config_dir / "blueprints").resolve()
+    unresolved = overlay_root / _default_overlay_name(blueprint_ref)
+    candidate = unresolved.resolve()
+    try:
+        candidate.relative_to(overlay_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"initialized blueprint resolves outside {overlay_root}: {unresolved}"
+        ) from exc
+
+    if unresolved.is_symlink() and not candidate.exists():
+        raise FileNotFoundError(f"initialized blueprint link is broken: {unresolved}")
+    if candidate.exists() and not candidate.is_file():
+        raise ValueError(f"initialized blueprint is not a file: {candidate}")
+    return str(candidate) if candidate.is_file() else ""
+
+
+def _resolve_and_validate(
+    ns,
+    *,
+    allow_runtime_overlay: bool = True,
+) -> dict[str, Any]:
     blueprints_root = resolve_blueprints_root(getattr(ns, "blueprints_root", "blueprints"))
+    blueprint_ref = str(getattr(ns, "ref", "") or "").strip()
+    explicit_file = str(getattr(ns, "file", "") or "").strip()
+    overlay_file = ""
+    if allow_runtime_overlay and not explicit_file:
+        overlay_file = _runtime_overlay_for_ref(ns, blueprint_ref)
     path = resolve_blueprint_file(
-        ref=str(getattr(ns, "ref", "") or ""),
-        file_path=str(getattr(ns, "file", "") or ""),
+        ref=blueprint_ref,
+        file_path=explicit_file or overlay_file,
         blueprints_root=blueprints_root,
     )
     spec = load_blueprint(path)
-    return validate_blueprint(spec, path)
+    payload = validate_blueprint(spec, path)
+    if overlay_file and payload["blueprint_ref"] != blueprint_ref:
+        raise ValueError(
+            f"initialized blueprint ref mismatch: requested {blueprint_ref}, "
+            f"file declares {payload['blueprint_ref']}: {path}"
+        )
+    return payload
 
 
 def _enforce_runtime_blueprint_file_scope(ns, paths, *, command_label: str) -> None:
@@ -72,6 +121,70 @@ def _enforce_runtime_blueprint_file_scope(ns, paths, *, command_label: str) -> N
             f"{allowed_root} for the selected runtime. "
             "Copy the shipped blueprint there and rerun."
         ) from exc
+
+
+def _editor_argv(ns) -> list[str]:
+    explicit = str(getattr(ns, "editor", "") or "").strip()
+    for candidate in (
+        explicit,
+        os.environ.get("HYOPS_EDITOR", "").strip(),
+        os.environ.get("VISUAL", "").strip(),
+        os.environ.get("EDITOR", "").strip(),
+    ):
+        if candidate:
+            return shlex.split(candidate, posix=(os.name != "nt"))
+
+    candidates = ["nano", "vim", "vi", "code --wait", "open -e", "notepad"]
+    for candidate in candidates:
+        argv = shlex.split(candidate, posix=(os.name != "nt"))
+        if shutil.which(argv[0]):
+            return argv
+
+    raise RuntimeError("no editor command available. Set --editor or HYOPS_EDITOR.")
+
+
+def _blueprint_file_for_edit(ns) -> Path:
+    require_runtime_selection(
+        getattr(ns, "root", None),
+        getattr(ns, "env", None),
+        command_label="hyops blueprint edit",
+    )
+    paths = resolve_runtime_paths(getattr(ns, "root", None), getattr(ns, "env", None))
+    ensure_layout(paths)
+
+    explicit = str(getattr(ns, "file", "") or "").strip()
+    if explicit:
+        _enforce_runtime_blueprint_file_scope(ns, paths, command_label="blueprint edit")
+        explicit_path = Path(explicit).expanduser().resolve()
+        if not explicit_path.exists():
+            raise FileNotFoundError(f"blueprint file not found: {explicit_path}")
+        if not explicit_path.is_file():
+            raise ValueError(f"blueprint file is not a file: {explicit_path}")
+        return explicit_path
+
+    if not str(getattr(ns, "ref", "") or "").strip():
+        raise ValueError(
+            "blueprint edit requires --ref unless --file is set. "
+            "Run blueprint init to generate a runtime blueprint first."
+        )
+
+    overlay = _runtime_overlay_for_ref(ns, str(getattr(ns, "ref", "")).strip())
+    if not overlay:
+        raise FileNotFoundError(
+            f"initialized blueprint not found for {getattr(ns, 'ref', None)}; "
+            "run `hyops blueprint init` first."
+        )
+
+    return Path(overlay)
+
+
+def _resolve_edit_target(ns) -> Path:
+    blueprint_file = _blueprint_file_for_edit(ns)
+    if not blueprint_file.exists():
+        raise FileNotFoundError(f"blueprint file not found: {blueprint_file}")
+    if not blueprint_file.is_file():
+        raise ValueError(f"blueprint file is not a regular file: {blueprint_file}")
+    return blueprint_file
 
 
 def _emit(payload: dict[str, Any], *, json_mode: bool) -> None:
@@ -383,8 +496,19 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
     ssp = p.add_subparsers(dest="blueprint_cmd", required=True)
 
     def add_common_args(sub: argparse.ArgumentParser) -> None:
-        sub.add_argument("--ref", default="", help="Blueprint ref, e.g. onprem/eve-ng@v1.")
-        sub.add_argument("--file", default="", help="Explicit blueprint YAML path.")
+        sub.add_argument(
+            "--ref",
+            default="",
+            help=(
+                "Blueprint ref, e.g. onprem/eve-ng@v1. Uses the environment's "
+                "initialized blueprint automatically when available."
+            ),
+        )
+        sub.add_argument(
+            "--file",
+            default="",
+            help="Explicit blueprint YAML path; overrides automatic environment selection.",
+        )
         sub.add_argument(
             "--blueprints-root",
             default="blueprints",
@@ -409,10 +533,42 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Overwrite an existing runtime blueprint overlay.",
     )
+    i.add_argument(
+        "--edit",
+        action="store_true",
+        help="Open the initialized blueprint in a local editor immediately.",
+    )
+    i.add_argument(
+        "--editor",
+        default="",
+        help=(
+            "Editor command to use when --edit is set. "
+            "Defaults to HYOPS_EDITOR, VISUAL, EDITOR, then common editors."
+        ),
+    )
     i.set_defaults(_handler=run_init)
+
+    e = ssp.add_parser(
+        "edit",
+        help="Open a runtime blueprint file in a local editor.",
+    )
+    add_common_args(e)
+    e.add_argument("--root", default=None, help="Override runtime root for blueprint selection.")
+    e.add_argument("--env", default=None, help="Runtime environment namespace.")
+    e.add_argument(
+        "--editor",
+        default="",
+        help=(
+            "Editor command to use. Defaults to HYOPS_EDITOR, VISUAL, EDITOR, "
+            "then common editors."
+        ),
+    )
+    e.set_defaults(_handler=run_edit)
 
     q = ssp.add_parser("validate", help="Validate a blueprint manifest.")
     add_common_args(q)
+    q.add_argument("--root", default=None, help="Override runtime root for overlay selection.")
+    q.add_argument("--env", default=None, help="Runtime environment namespace.")
     q.set_defaults(_handler=run_validate)
 
     u = ssp.add_parser(
@@ -431,6 +587,8 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
 
     r = ssp.add_parser("plan", help="Render blueprint execution order (skeleton).")
     add_common_args(r)
+    r.add_argument("--root", default=None, help="Override runtime root for overlay selection.")
+    r.add_argument("--env", default=None, help="Runtime environment namespace.")
     r.set_defaults(_handler=run_plan)
 
     a = ssp.add_parser("access", help="Open a declared private blueprint access path.")
@@ -451,7 +609,87 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Forward active native console ports declared by the blueprint.",
     )
+    a.add_argument(
+        "--automation",
+        action="store_true",
+        help="Open private device automation access and write client configuration.",
+    )
+    a.add_argument(
+        "--socks-port",
+        type=int,
+        default=0,
+        help="Local device proxy port (default: choose an available port).",
+    )
+    a.add_argument(
+        "--targets",
+        default="",
+        help="Override the environment automation target file.",
+    )
+    a.add_argument(
+        "--route-lab",
+        action="store_true",
+        help="Route the declared management subnet through a Linux TUN interface.",
+    )
     a.set_defaults(_handler=run_access)
+
+    device = ssp.add_parser(
+        "device",
+        help="Use devices through an active private blueprint access session.",
+    )
+    device_commands = device.add_subparsers(dest="device_cmd", required=True)
+
+    def add_device_args(sub: argparse.ArgumentParser) -> None:
+        add_common_args(sub)
+        sub.add_argument("--root", default=None, help="Override runtime root.")
+        sub.add_argument("--env", default=None, help="Runtime environment namespace.")
+
+    device_list = device_commands.add_parser(
+        "list",
+        help="List discovered and operator-defined device targets.",
+    )
+    add_device_args(device_list)
+    device_list.set_defaults(_handler=run_device)
+
+    device_ping = device_commands.add_parser(
+        "ping",
+        help="Test a device address through the managed lab gateway.",
+    )
+    add_device_args(device_ping)
+    device_ping.add_argument("target", help="Device name or management IPv4 address.")
+    device_ping.add_argument(
+        "--count",
+        type=int,
+        default=3,
+        help="Number of probes (default: 3).",
+    )
+    device_ping.set_defaults(_handler=run_device)
+
+    device_ssh = device_commands.add_parser(
+        "ssh",
+        help="Open SSH to a device through the managed lab gateway.",
+    )
+    add_device_args(device_ssh)
+    device_ssh.add_argument("target", help="Discovered or operator-defined device name.")
+    device_ssh.set_defaults(_handler=run_device)
+
+    device_shell = device_commands.add_parser(
+        "shell",
+        help="Open a shell configured for the active device session.",
+    )
+    add_device_args(device_shell)
+    device_shell.set_defaults(_handler=run_device)
+
+    device_run = device_commands.add_parser(
+        "run",
+        help="Run a command with the active device-session environment.",
+    )
+    add_device_args(device_run)
+    device_run.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to run, normally after --.",
+    )
+    device_run.set_defaults(_handler=run_device)
 
     t = ssp.add_parser("deploy", help="Deploy blueprint steps in dependency order.")
     add_common_args(t)
@@ -595,6 +833,217 @@ def run_validate(ns) -> int:
         return OPERATOR_ERROR
 
 
+def _resolve_device_blueprint(ns, paths) -> dict[str, Any]:
+    if str(getattr(ns, "ref", "") or "").strip() or str(
+        getattr(ns, "file", "") or ""
+    ).strip():
+        return _resolve_and_validate(ns)
+
+    candidates: list[dict[str, Any]] = []
+    blueprint_dir = Path(paths.config_dir) / "blueprints"
+    for path in sorted(blueprint_dir.glob("*.yml")):
+        try:
+            payload = validate_blueprint(load_blueprint(path), path)
+        except (OSError, ValueError):
+            continue
+        access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
+        if isinstance(access.get("automation"), dict) and access["automation"]:
+            candidates.append(payload)
+    if not candidates:
+        raise ValueError(
+            "no initialized automation blueprint was found; pass --ref or run blueprint init"
+        )
+    if len(candidates) > 1:
+        refs = ", ".join(str(item.get("blueprint_ref") or "") for item in candidates)
+        raise ValueError(f"multiple automation blueprints are initialized ({refs}); pass --ref")
+    return candidates[0]
+
+
+def _device_context(ns) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+    require_runtime_selection(
+        getattr(ns, "root", None),
+        getattr(ns, "env", None),
+        command_label="hyops blueprint device",
+    )
+    paths = resolve_runtime_paths(getattr(ns, "root", None), getattr(ns, "env", None))
+    payload = _resolve_device_blueprint(ns, paths)
+    access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
+    automation = access.get("automation") if isinstance(access.get("automation"), dict) else {}
+    if not automation:
+        raise ValueError("blueprint does not declare device automation access")
+    env_name = str(getattr(ns, "env", "") or Path(paths.root).name)
+    material = automation_session_paths(
+        paths=paths,
+        blueprint_ref=str(payload.get("blueprint_ref") or "blueprint"),
+        env_name=env_name,
+    )
+    target_file = material["target_file"]
+    if not target_file.is_file():
+        raise ValueError(
+            "device targets are unavailable; run blueprint access with --automation"
+        )
+    targets = load_automation_targets(target_file, automation["management_cidr"])
+    return automation, material, targets
+
+
+def _resolve_device_target(
+    value: str,
+    automation: dict[str, Any],
+    targets: list[dict[str, Any]],
+) -> tuple[str, dict[str, Any] | None]:
+    token = str(value or "").strip()
+    for target in targets:
+        if token in {target["name"], target["host"]}:
+            return str(target["host"]), target
+    try:
+        address = ipaddress.ip_address(token)
+    except ValueError as exc:
+        raise ValueError(f"unknown device target: {token}") from exc
+    network = ipaddress.ip_network(automation["management_cidr"], strict=False)
+    if address not in network:
+        raise ValueError(f"device address {address} is outside {network}")
+    return str(address), None
+
+
+def _device_process_environment(material: dict[str, Any]) -> dict[str, str]:
+    required = {
+        "SSH configuration": Path(material["ssh_config"]),
+        "Ansible configuration": Path(material["ansible_config"]),
+        "Nornir host inventory": Path(material["nornir_hosts"]),
+        "Nornir group inventory": Path(material["nornir_groups"]),
+        "Nornir defaults": Path(material["nornir_defaults"]),
+        "session metadata": Path(material["session_file"]),
+    }
+    for label, path in required.items():
+        if not path.is_file():
+            raise ValueError(
+                f"{label} is unavailable; run blueprint access with --automation"
+            )
+    try:
+        session = yaml.safe_load(
+            Path(material["session_file"]).read_text(encoding="utf-8")
+        ) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError("device session metadata is invalid") from exc
+    proxy = str(session.get("socks_proxy") or "").strip()
+    inventory_options = {
+        "host_file": str(material["nornir_hosts"]),
+        "group_file": str(material["nornir_groups"]),
+        "defaults_file": str(material["nornir_defaults"]),
+    }
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "ANSIBLE_CONFIG": str(material["ansible_config"]),
+            "HYOPS_DEVICE_INVENTORY": str(material["inventory"]),
+            "HYOPS_DEVICE_TARGETS": str(material["target_file"]),
+            "HYOPS_DEVICE_SSH_CONFIG": str(material["ssh_config"]),
+            "HYOPS_DEVICE_PROXY": proxy,
+            "NORNIR_INVENTORY_PLUGIN": "SimpleInventory",
+            "NORNIR_INVENTORY_OPTIONS": json.dumps(inventory_options),
+            "NORNIR_SSH_CONFIG_FILE": str(material["ssh_config"]),
+        }
+    )
+    if proxy:
+        environment["ALL_PROXY"] = proxy
+        environment["all_proxy"] = proxy
+    return environment
+
+
+def run_device(ns) -> int:
+    try:
+        automation, material, targets = _device_context(ns)
+        action = str(getattr(ns, "device_cmd", "") or "")
+        if action == "list":
+            if bool(getattr(ns, "json", False)):
+                print(json.dumps({"targets": targets}, indent=2, sort_keys=True))
+            elif not targets:
+                print(
+                    "no devices discovered; connect a management interface to "
+                    f"{automation['management_network_label']}"
+                )
+            else:
+                for target in targets:
+                    source = "DHCP" if target.get("source") == "dhcp-lease" else "static"
+                    platform = target.get("platform") or "unspecified"
+                    print(f"{target['name']}  {target['host']}  {platform}  {source}")
+            return 0
+
+        ssh_config = Path(material["ssh_config"])
+        if not ssh_config.is_file():
+            raise ValueError(
+                "private access is not active; run blueprint access with --automation "
+                "and keep it open"
+            )
+        ssh = shutil.which("ssh")
+        if not ssh:
+            raise ValueError("ssh is required; run: hyops setup base")
+
+        if action == "ping":
+            count = int(getattr(ns, "count", 3) or 3)
+            if not 1 <= count <= 20:
+                raise ValueError("--count must be between 1 and 20")
+            address, _target = _resolve_device_target(ns.target, automation, targets)
+            result = subprocess.run(
+                [
+                    ssh,
+                    "-F",
+                    str(ssh_config),
+                    str(material["gateway_alias"]),
+                    "ping",
+                    "-c",
+                    str(count),
+                    "--",
+                    address,
+                ],
+                cwd=str(Path.home()),
+                check=False,
+            )
+            return int(result.returncode)
+
+        if action == "ssh":
+            _address, target = _resolve_device_target(ns.target, automation, targets)
+            if target is None:
+                raise ValueError("device SSH requires a named target; run device list")
+            alias = f"{material['alias_prefix']}-{target['name']}"
+            result = subprocess.run(
+                [ssh, "-F", str(ssh_config), alias],
+                cwd=str(Path.home()),
+                check=False,
+            )
+            return int(result.returncode)
+        if action in {"shell", "run"}:
+            environment = _device_process_environment(material)
+            if action == "shell":
+                shell = str(os.environ.get("SHELL") or shutil.which("bash") or "").strip()
+                if not shell:
+                    raise ValueError("an interactive shell is unavailable")
+                print("device automation environment ready; exit to leave")
+                result = subprocess.run(
+                    [shell, "-i"],
+                    cwd=str(Path.cwd()),
+                    env=environment,
+                    check=False,
+                )
+                return int(result.returncode)
+            command = list(getattr(ns, "command", []) or [])
+            if command and command[0] == "--":
+                command = command[1:]
+            if not command:
+                raise ValueError("device run requires a command after --")
+            result = subprocess.run(
+                command,
+                cwd=str(Path.cwd()),
+                env=environment,
+                check=False,
+            )
+            return int(result.returncode)
+        raise ValueError(f"unsupported device command: {action}")
+    except Exception as exc:
+        print(f"ERR: blueprint device failed: {exc}")
+        return OPERATOR_ERROR
+
+
 def run_init(ns) -> int:
     try:
         require_runtime_selection(
@@ -602,7 +1051,7 @@ def run_init(ns) -> int:
             getattr(ns, "env", None),
             command_label="hyops blueprint init",
         )
-        payload = _resolve_and_validate(ns)
+        payload = _resolve_and_validate(ns, allow_runtime_overlay=False)
         paths = resolve_runtime_paths(getattr(ns, "root", None), getattr(ns, "env", None))
         ensure_layout(paths)
         dest_dir = (paths.config_dir / "blueprints").resolve()
@@ -613,11 +1062,18 @@ def run_init(ns) -> int:
         dest_path = (dest_dir / dest_name).resolve()
         if dest_path.exists() and not bool(getattr(ns, "force", False)):
             raise FileExistsError(
-                f"blueprint overlay already exists: {dest_path} "
+                f"initialized blueprint already exists: {dest_path} "
                 "(use --force to overwrite)"
             )
         shutil.copy2(Path(payload["path"]), dest_path)
         dest_path.chmod(0o600)
+        if bool(getattr(ns, "edit", False)):
+            editor_argv = _editor_argv(ns)
+            editor_argv.append(str(dest_path))
+            print(f"Opening blueprint for edit: {dest_path}")
+            result = subprocess.run(editor_argv, check=False)
+            if result.returncode != 0:
+                raise RuntimeError(f"editor returned {result.returncode}")
         out = {
             "blueprint_ref": payload["blueprint_ref"],
             "status": "initialized",
@@ -628,11 +1084,26 @@ def run_init(ns) -> int:
             print(json.dumps(out, indent=2, sort_keys=True))
         else:
             print(f"blueprint={payload['blueprint_ref']} status=initialized")
-            print(f"source={payload['path']}")
             print(f"file={dest_path}")
         return 0
     except Exception as exc:
         print(f"ERR: blueprint init failed: {exc}")
+        return OPERATOR_ERROR
+
+
+def run_edit(ns) -> int:
+    try:
+        blueprint_file = _resolve_edit_target(ns)
+        editor_argv = _editor_argv(ns)
+        editor_argv.append(str(blueprint_file))
+        print(f"Opening blueprint for edit: {blueprint_file}")
+        result = subprocess.run(editor_argv, check=False)
+        if result.returncode != 0:
+            print(f"ERR: blueprint edit failed: editor returned {result.returncode}")
+            return OPERATOR_ERROR
+        return 0
+    except Exception as exc:
+        print(f"ERR: blueprint edit failed: {exc}")
         return OPERATOR_ERROR
 
 
@@ -1117,6 +1588,328 @@ def _stop_process(proc: subprocess.Popen | None) -> None:
         proc.wait(timeout=5)
 
 
+def _automation_settings(access: dict[str, Any], ns) -> dict[str, Any] | None:
+    requested = bool(getattr(ns, "automation", False) or getattr(ns, "route_lab", False))
+    if not requested:
+        return None
+    automation = access.get("automation")
+    if not isinstance(automation, dict) or not automation:
+        raise ValueError("blueprint does not declare device automation access")
+    return automation
+
+
+def _read_automation_leases(
+    ssh_base: list[str],
+    ssh_target: str,
+    automation: dict[str, Any],
+) -> str:
+    lease_file = str(automation.get("lease_file") or "").strip()
+    if not lease_file:
+        return ""
+    remote_command = (
+        f"cat -- {shlex.quote(lease_file)} 2>/dev/null || "
+        f"sudo -n cat -- {shlex.quote(lease_file)}"
+    )
+    result = subprocess.run(
+        [*ssh_base, ssh_target, remote_command],
+        cwd=str(Path.home()),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=20,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _prepare_automation_access(
+    *,
+    ns,
+    payload: dict[str, Any],
+    paths,
+    automation: dict[str, Any],
+    gateway: dict[str, Any],
+    ssh_base: list[str],
+    ssh_target: str,
+    reserved_ports: list[int] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    requested_port = int(getattr(ns, "socks_port", 0) or 0) or int(
+        automation.get("local_socks_port") or 0
+    )
+    socks_port = _available_local_port(requested_port)
+    reserved = set(reserved_ports or [])
+    if socks_port in reserved and requested_port:
+        raise ValueError(
+            f"device proxy port {socks_port} is already used by this access session"
+        )
+    while socks_port in reserved:
+        socks_port = _available_local_port(0)
+    _require_local_ports_available([socks_port])
+    lease_text = _read_automation_leases(ssh_base, ssh_target, automation)
+    session = prepare_automation_session(
+        paths=paths,
+        blueprint_ref=str(payload.get("blueprint_ref") or "blueprint"),
+        env_name=str(getattr(ns, "env", "") or Path(paths.root).name),
+        automation=automation,
+        gateway=gateway,
+        socks_port=socks_port,
+        lease_text=lease_text,
+        target_file_override=str(getattr(ns, "targets", "") or ""),
+    )
+    return socks_port, session
+
+
+def _automation_refresher(
+    *,
+    ns,
+    payload: dict[str, Any],
+    paths,
+    automation: dict[str, Any],
+    gateway: dict[str, Any],
+    ssh_base: list[str],
+    ssh_target: str,
+    socks_port: int,
+    session: dict[str, Any],
+) -> Callable[[], None] | None:
+    if str(getattr(ns, "targets", "") or ""):
+        return None
+
+    def refresh() -> None:
+        lease_text = _read_automation_leases(ssh_base, ssh_target, automation)
+        if not lease_text:
+            return
+        updated = prepare_automation_session(
+            paths=paths,
+            blueprint_ref=str(payload.get("blueprint_ref") or "blueprint"),
+            env_name=str(getattr(ns, "env", "") or Path(paths.root).name),
+            automation=automation,
+            gateway=gateway,
+            socks_port=socks_port,
+            lease_text=lease_text,
+        )
+        added = list(updated.get("new_targets") or [])
+        session.clear()
+        session.update(updated)
+        for name in added:
+            target = next(
+                (item for item in updated["targets"] if item["name"] == name),
+                None,
+            )
+            if target:
+                print(f"device discovered: {name} ({target['host']})", flush=True)
+
+    return refresh
+
+
+def _print_automation_access(
+    automation: dict[str, Any],
+    session: dict[str, Any],
+    *,
+    route_requested: bool = False,
+) -> None:
+    print(
+        "automation network: "
+        f"{automation['management_network_label']} "
+        f"({automation['management_cidr']})"
+    )
+    print("device discovery: watching management-network DHCP leases")
+    print("device commands: hyops blueprint device --help")
+    if verbose_enabled():
+        print(f"device proxy: {session['socks_proxy']}")
+        print(f"static target overrides: {session['target_file']}")
+        print(f"SSH and VS Code config: {session['ssh_config']}")
+        print(f"automation inventory: {session['inventory']}")
+        print(f"API proxy settings: {session['proxy_env']}")
+    if not route_requested:
+        print("direct routing: not active; use device commands or the API proxy")
+    if session["discovered_count"]:
+        print(f"management addresses discovered: {session['discovered_count']}")
+    if session["aliases"]:
+        print(f"SSH targets: {', '.join(session['aliases'])}")
+    else:
+        print(
+            "device targets: none discovered; connect a management interface to "
+            f"{automation['management_network_label']}"
+        )
+
+
+def _print_lab_route_ready(automation: dict[str, Any]) -> None:
+    print(f"local route: {automation['management_cidr']} through the lab host")
+    if is_windows_wsl():
+        print(
+            "route scope: HybridOps Linux environment; Windows applications "
+            "use the generated proxy or SSH config"
+        )
+
+
+def _start_lab_route(
+    automation: dict[str, Any],
+    gateway: dict[str, Any],
+    *,
+    scope: str,
+) -> tuple[subprocess.Popen, dict[str, Any]]:
+    if not sys.platform.startswith("linux"):
+        raise ValueError(
+            "--route-lab currently requires Linux; use --automation for "
+            "portable SSH and API access"
+        )
+    conflicts = local_route_conflicts(automation["management_cidr"])
+    if conflicts:
+        raise ValueError(
+            "management subnet conflicts with a local route: " + conflicts[0]
+        )
+    ip_command = shutil.which("ip")
+    if not ip_command:
+        raise ValueError("--route-lab requires the ip command")
+    if not Path("/dev/net/tun").exists():
+        raise ValueError("--route-lab requires Linux TUN support at /dev/net/tun")
+    plan = linux_tunnel_plan(scope)
+    if Path(f"/sys/class/net/{plan['interface']}").exists():
+        raise ValueError(
+            f"local tunnel interface is already in use: {plan['interface']}"
+        )
+    privilege: list[str] = []
+    if os.geteuid() != 0:
+        sudo = shutil.which("sudo")
+        if not sudo:
+            raise ValueError("--route-lab requires sudo to create a local route")
+        privilege = [sudo]
+
+    def run_ip(*arguments: str, check: bool = True) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            [*privilege, ip_command, *arguments],
+            cwd=str(Path.home()),
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE if check else subprocess.DEVNULL,
+            check=False,
+        )
+        if check and result.returncode != 0:
+            detail = str(result.stderr or "").strip().splitlines()
+            reason = detail[-1] if detail else f"ip exited with rc={result.returncode}"
+            raise ValueError(f"local route setup failed: {reason}")
+        return result
+
+    route_proc: subprocess.Popen | None = None
+    try:
+        run_ip(
+            "tuntap",
+            "add",
+            "dev",
+            plan["interface"],
+            "mode",
+            "tun",
+            "user",
+            str(os.getuid()),
+        )
+        run_ip(
+            "address",
+            "replace",
+            plan["local_cidr"],
+            "peer",
+            plan["remote_ip"],
+            "dev",
+            plan["interface"],
+        )
+        run_ip("link", "set", plan["interface"], "up")
+        route_proc = subprocess.Popen(
+            build_tunnel_ssh_argv(
+                gateway=gateway,
+                plan=plan,
+                remote_helper="/usr/local/sbin/hybridops-lab-route",
+            ),
+            cwd=str(Path.home()),
+        )
+        ping = shutil.which("ping")
+        if not ping:
+            raise ValueError("--route-lab requires ping to verify the tunnel")
+        deadline = time.monotonic() + 12
+        while time.monotonic() < deadline:
+            if route_proc.poll() is not None:
+                raise ValueError(f"lab route exited with rc={route_proc.returncode}")
+            probe = subprocess.run(
+                [ping, "-c", "1", "-W", "1", plan["remote_ip"]],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if probe.returncode == 0:
+                break
+            time.sleep(0.5)
+        else:
+            raise ValueError("timed out verifying the private lab route")
+        run_ip(
+            "route",
+            "replace",
+            automation["management_cidr"],
+            "via",
+            plan["remote_ip"],
+            "dev",
+            plan["interface"],
+        )
+        gateway_probe = subprocess.run(
+            [ping, "-c", "1", "-W", "2", automation["management_gateway"]],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if gateway_probe.returncode != 0:
+            raise ValueError(
+                "private management gateway did not respond through the lab route"
+            )
+        plan["privilege"] = privilege
+        plan["ip_command"] = ip_command
+        return route_proc, plan
+    except BaseException:
+        _stop_process(route_proc)
+        run_ip("link", "delete", plan["interface"], check=False)
+        raise
+
+
+def _stop_lab_route(
+    route_proc: subprocess.Popen | None,
+    route_plan: dict[str, Any] | None,
+) -> None:
+    _stop_process(route_proc)
+    if not route_plan:
+        return
+    ip_command = str(route_plan.get("ip_command") or "")
+    if not ip_command:
+        return
+    privilege = [str(item) for item in route_plan.get("privilege") or []]
+    subprocess.run(
+        [*privilege, ip_command, "link", "delete", route_plan["interface"]],
+        cwd=str(Path.home()),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def _wait_for_access_processes(
+    access_proc: subprocess.Popen,
+    route_proc: subprocess.Popen | None = None,
+    maintenance: Callable[[], None] | None = None,
+) -> int:
+    next_maintenance = time.monotonic() + 3
+    while True:
+        access_rc = access_proc.poll()
+        if access_rc is not None:
+            return int(access_rc)
+        if route_proc is not None:
+            route_rc = route_proc.poll()
+            if route_rc is not None:
+                return int(route_rc)
+        if maintenance is not None and time.monotonic() >= next_maintenance:
+            try:
+                maintenance()
+            except Exception as exc:
+                if verbose_enabled():
+                    print(f"WARN: device discovery refresh failed: {exc}")
+            next_maintenance = time.monotonic() + 8
+        time.sleep(0.5)
+
+
 def run_access(ns) -> int:
     try:
         payload = _resolve_and_validate(ns)
@@ -1138,12 +1931,17 @@ def run_access(ns) -> int:
         access_type = str(access.get("type") or "").strip()
         remote_port = int(access.get("remote_port") or 80)
         path = str(access.get("path") or "/")
+        automation = _automation_settings(access, ns)
 
         if access_type in {"direct-http", "ssh-forward", "ssh-tcp-forward"}:
             host = _extract_access_host(outputs)
             if not host:
                 raise ValueError(f"VM state does not contain a usable IPv4 address: {state_ref}")
             if access_type == "direct-http":
+                if automation:
+                    raise ValueError(
+                        "device automation access requires an SSH-forward access path"
+                    )
                 url = f"http://{host}:{remote_port}{path}"
                 print("opening direct EVE-NG access")
                 print(f"URL: {url}")
@@ -1210,8 +2008,32 @@ def run_access(ns) -> int:
             if requested_port:
                 _require_local_ports_available([port])
             url = f"http://127.0.0.1:{port}{path}"
+            automation_session: dict[str, Any] | None = None
+            socks_port = 0
+            gateway = {
+                "host": host,
+                "user": ssh_user,
+                "port": 22,
+                "identity_file": str(ssh_key),
+                "known_hosts_file": str(known_hosts_file),
+                "host_key_alias": "",
+                "ssh_command": ssh_base,
+            }
+            if automation:
+                socks_port, automation_session = _prepare_automation_access(
+                    ns=ns,
+                    payload=payload,
+                    paths=paths,
+                    automation=automation,
+                    gateway=gateway,
+                    ssh_base=ssh_base,
+                    ssh_target=ssh_target,
+                    reserved_ports=[port, *console_ports],
+                )
             argv = [*ssh_base, "-N", "-o", "ExitOnForwardFailure=yes"]
             argv.extend(["-L", f"127.0.0.1:{port}:127.0.0.1:{remote_port}"])
+            if automation:
+                argv.extend(["-D", f"127.0.0.1:{socks_port}"])
             for console_port in console_ports:
                 argv.extend(
                     ["-L", f"127.0.0.1:{console_port}:127.0.0.1:{console_port}"]
@@ -1222,26 +2044,69 @@ def run_access(ns) -> int:
                 print("opening private TCP access")
                 print(f"local endpoint: 127.0.0.1:{port}")
             else:
-                print("opening private Proxmox EVE-NG access")
+                print("opening private lab access")
                 print(f"local URL: {url}")
             _print_guest_network_guidance(access)
+            if automation and automation_session:
+                _print_automation_access(
+                    automation,
+                    automation_session,
+                    route_requested=bool(getattr(ns, "route_lab", False)),
+                )
             if bool(getattr(ns, "native_consoles", False)):
                 _print_native_console_client_guidance()
                 print(_native_console_status(console_ports))
                 if not console_ports:
                     print("native console setup: start a QEMU node, then rerun access with --native-consoles")
-            print("press Ctrl-C to close access")
             proc = subprocess.Popen(argv, cwd=str(Path.home()))
             time.sleep(2)
             if proc.poll() is not None:
                 return OPERATOR_ERROR
+            if automation:
+                _wait_for_local_port(socks_port, proc)
+            automation_refresh = None
+            if automation and automation_session:
+                automation_refresh = _automation_refresher(
+                    ns=ns,
+                    payload=payload,
+                    paths=paths,
+                    automation=automation,
+                    gateway=gateway,
+                    ssh_base=ssh_base,
+                    ssh_target=ssh_target,
+                    socks_port=socks_port,
+                    session=automation_session,
+                )
+            route_proc: subprocess.Popen | None = None
+            route_plan: dict[str, Any] | None = None
+            if automation and bool(getattr(ns, "route_lab", False)):
+                try:
+                    print("preparing private lab route", flush=True)
+                    route_proc, route_plan = _start_lab_route(
+                        automation,
+                        gateway,
+                        scope=f"{paths.root}:{payload['blueprint_ref']}",
+                    )
+                    _print_lab_route_ready(automation)
+                except BaseException:
+                    _stop_process(proc)
+                    raise
             if access_type != "ssh-tcp-forward" and not bool(
                 getattr(ns, "no_browser", False)
             ):
                 open_operator_url(url)
+            print("press Ctrl-C to close access")
             try:
-                return int(proc.wait())
+                rc = _wait_for_access_processes(
+                    proc,
+                    route_proc,
+                    maintenance=automation_refresh,
+                )
+                _stop_lab_route(route_proc, route_plan)
+                _stop_process(proc)
+                return rc
             except KeyboardInterrupt:
+                _stop_lab_route(route_proc, route_plan)
                 _stop_process(proc)
                 print("access closed")
                 return _offer_access_close_destroy(ns, payload, state)
@@ -1258,6 +2123,8 @@ def run_access(ns) -> int:
             paths=paths,
         )
         port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
+        if int(getattr(ns, "local_port", 0) or 0):
+            _require_local_ports_available([port])
         url = f"http://127.0.0.1:{port}{path}"
         gcloud = shutil.which("gcloud")
         if not gcloud:
@@ -1272,6 +2139,8 @@ def run_access(ns) -> int:
             if not ssh:
                 raise ValueError("ssh is required; run: hyops setup base")
             iap_port = _available_local_port(0)
+            while iap_port == port:
+                iap_port = _available_local_port(0)
             print("preparing private GCP IAP access", flush=True)
             iap_argv = [
                 gcloud, "compute", "start-iap-tunnel", instance, "22",
@@ -1315,14 +2184,43 @@ def run_access(ns) -> int:
                 console_ports = _parse_eve_qemu_console_ports(probe.stdout)
                 if console_ports:
                     _require_local_ports_available(console_ports)
+            automation_session: dict[str, Any] | None = None
+            socks_port = 0
+            host_key_alias = f"hyops-{known_hosts_file.stem}"
+            gateway = {
+                "host": "127.0.0.1",
+                "user": ssh_user,
+                "port": iap_port,
+                "identity_file": ssh_key,
+                "known_hosts_file": str(known_hosts_file),
+                "host_key_alias": host_key_alias,
+                "ssh_command": ssh_base,
+            }
+            if automation:
+                socks_port, automation_session = _prepare_automation_access(
+                    ns=ns,
+                    payload=payload,
+                    paths=paths,
+                    automation=automation,
+                    gateway=gateway,
+                    ssh_base=ssh_base,
+                    ssh_target=ssh_target,
+                    reserved_ports=[port, iap_port, *console_ports],
+                )
             argv = [*ssh_base, "-N", "-o", "ExitOnForwardFailure=yes"]
             argv.extend(["-L", f"127.0.0.1:{port}:127.0.0.1:{remote_port}"])
+            if automation:
+                argv.extend(["-D", f"127.0.0.1:{socks_port}"])
             for console_port in console_ports:
                 argv.extend(
                     ["-L", f"127.0.0.1:{console_port}:127.0.0.1:{console_port}"]
                 )
             argv.append(ssh_target)
         else:
+            if automation:
+                raise ValueError(
+                    "device automation access requires an SSH-forward access path"
+                )
             if bool(getattr(ns, "native_consoles", False)):
                 raise ValueError("native consoles require an SSH-forward access declaration")
             argv = [
@@ -1337,6 +2235,12 @@ def run_access(ns) -> int:
         else:
             print(f"local endpoint: 127.0.0.1:{port}")
         _print_guest_network_guidance(access)
+        if automation and automation_session:
+            _print_automation_access(
+                automation,
+                automation_session,
+                route_requested=bool(getattr(ns, "route_lab", False)),
+            )
         validated, enabled, _detail = diagnose_project_billing(project)
         print(f"billing: {'enabled' if enabled else 'disabled'}" if validated else "billing: unable to verify")
         _print_cost_estimate(cost_estimate, state=state)
@@ -1345,20 +2249,57 @@ def run_access(ns) -> int:
             print(_native_console_status(console_ports))
             if not console_ports:
                 print("native console setup: start a QEMU node, then rerun access with --native-consoles")
-        print("press Ctrl-C to close access")
         access_started_at = time.monotonic()
         proc = subprocess.Popen(argv, cwd=str(Path.home()))
         time.sleep(2)
         if proc.poll() is not None:
             _stop_process(iap_proc)
             return OPERATOR_ERROR
+        if automation:
+            _wait_for_local_port(socks_port, proc)
+        automation_refresh = None
+        if automation and automation_session:
+            automation_refresh = _automation_refresher(
+                ns=ns,
+                payload=payload,
+                paths=paths,
+                automation=automation,
+                gateway=gateway,
+                ssh_base=ssh_base,
+                ssh_target=ssh_target,
+                socks_port=socks_port,
+                session=automation_session,
+            )
+        route_proc: subprocess.Popen | None = None
+        route_plan: dict[str, Any] | None = None
+        if automation and bool(getattr(ns, "route_lab", False)):
+            try:
+                print("preparing private lab route", flush=True)
+                route_proc, route_plan = _start_lab_route(
+                    automation,
+                    gateway,
+                    scope=f"{paths.root}:{payload['blueprint_ref']}",
+                )
+                _print_lab_route_ready(automation)
+            except BaseException:
+                _stop_process(proc)
+                _stop_process(iap_proc)
+                raise
         if open_browser and not bool(getattr(ns, "no_browser", False)):
             open_operator_url(url)
+        print("press Ctrl-C to close access")
         try:
-            rc = int(proc.wait())
+            rc = _wait_for_access_processes(
+                proc,
+                route_proc,
+                maintenance=automation_refresh,
+            )
+            _stop_lab_route(route_proc, route_plan)
+            _stop_process(proc)
             _stop_process(iap_proc)
             return rc
         except KeyboardInterrupt:
+            _stop_lab_route(route_proc, route_plan)
             _stop_process(proc)
             _stop_process(iap_proc)
             print("access closed")

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from pathlib import Path
 import re
 from typing import Any
@@ -246,6 +247,89 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 "access guest network guidance requires guest_network_label, "
                 "guest_gateway, and guest_dhcp_range"
             )
+        raw_automation = raw_access.get("automation")
+        if raw_automation is not None:
+            automation = as_mapping(raw_automation, "access.automation")
+            management_cidr = as_non_empty_string(
+                automation.get("management_cidr"),
+                "access.automation.management_cidr",
+            )
+            management_gateway = as_non_empty_string(
+                automation.get("management_gateway"),
+                "access.automation.management_gateway",
+            )
+            try:
+                management_network = ipaddress.ip_network(
+                    management_cidr,
+                    strict=False,
+                )
+                gateway_address = ipaddress.ip_address(management_gateway)
+            except ValueError as exc:
+                raise ValueError(
+                    "access.automation requires a valid IPv4 management network"
+                ) from exc
+            if management_network.version != 4 or gateway_address.version != 4:
+                raise ValueError("access.automation supports IPv4 management networks")
+            if gateway_address not in management_network:
+                raise ValueError(
+                    "access.automation.management_gateway must be inside management_cidr"
+                )
+            management_dhcp_range = as_non_empty_string(
+                automation.get("management_dhcp_range"),
+                "access.automation.management_dhcp_range",
+            )
+            try:
+                dhcp_start_raw, dhcp_end_raw = management_dhcp_range.split("-", 1)
+                dhcp_start = ipaddress.ip_address(dhcp_start_raw.strip())
+                dhcp_end = ipaddress.ip_address(dhcp_end_raw.strip())
+            except ValueError as exc:
+                raise ValueError(
+                    "access.automation.management_dhcp_range must be START-END"
+                ) from exc
+            reserved_addresses = {
+                management_network.network_address,
+                management_network.broadcast_address,
+            }
+            if (
+                dhcp_start.version != 4
+                or dhcp_end.version != 4
+                or dhcp_start not in management_network
+                or dhcp_end not in management_network
+                or int(dhcp_start) > int(dhcp_end)
+                or dhcp_start in reserved_addresses
+                or dhcp_end in reserved_addresses
+                or int(dhcp_start) <= int(gateway_address) <= int(dhcp_end)
+            ):
+                raise ValueError(
+                    "access.automation.management_dhcp_range must contain an "
+                    "ordered, usable range inside management_cidr"
+                )
+            lease_file = as_non_empty_string(
+                automation.get("lease_file"),
+                "access.automation.lease_file",
+            )
+            if not lease_file.startswith("/"):
+                raise ValueError("access.automation.lease_file must be an absolute path")
+            local_socks_port = int(automation.get("local_socks_port") or 0)
+            if local_socks_port and not 1 <= local_socks_port <= 65535:
+                raise ValueError(
+                    "access.automation.local_socks_port must be between 1 and 65535"
+                )
+            access["automation"] = {
+                "management_network_label": as_non_empty_string(
+                    automation.get("management_network_label"),
+                    "access.automation.management_network_label",
+                ),
+                "management_cidr": str(management_network),
+                "management_gateway": str(gateway_address),
+                "management_dhcp_range": f"{dhcp_start}-{dhcp_end}",
+                "lease_file": lease_file,
+                "default_user": str(
+                    automation.get("default_user") or "admin"
+                ).strip()
+                or "admin",
+                "local_socks_port": local_socks_port,
+            }
 
     archive_before_destroy: dict[str, Any] = {}
     if spec.get("archive_before_destroy") is not None:

--- a/hyops/blueprint/tests/test_automation_access.py
+++ b/hyops/blueprint/tests/test_automation_access.py
@@ -1,0 +1,236 @@
+"""Tests for private lab-device automation access."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from hyops.blueprint.automation_access import (
+    build_tunnel_ssh_argv,
+    linux_tunnel_plan,
+    parse_dnsmasq_leases,
+    prepare_automation_session,
+)
+from hyops.blueprint.schema import load_blueprint, validate_blueprint
+from hyops.blueprint.command import _device_process_environment
+
+
+class AutomationAccessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.automation = {
+            "management_network_label": "Cloud8",
+            "management_cidr": "172.29.128.0/24",
+            "management_gateway": "172.29.128.1",
+            "management_dhcp_range": "172.29.128.50-172.29.128.200",
+            "lease_file": "/var/lib/misc/hyops.leases",
+            "default_user": "admin",
+            "local_socks_port": 0,
+        }
+
+    def test_dnsmasq_leases_are_scoped_and_named(self) -> None:
+        leases = parse_dnsmasq_leases(
+            "\n".join(
+                [
+                    "1 aa:bb:cc:dd:ee:01 172.29.128.51 r1 *",
+                    "2 aa:bb:cc:dd:ee:02 172.29.128.52 * *",
+                    "3 aa:bb:cc:dd:ee:03 192.0.2.50 outside *",
+                ]
+            ),
+            "172.29.128.0/24",
+            default_user="admin",
+        )
+
+        self.assertEqual([item["name"] for item in leases], ["r1", "device-52"])
+        self.assertEqual(leases[0]["host"], "172.29.128.51")
+        self.assertEqual(leases[0]["source"], "dhcp-lease")
+
+    def test_session_writes_ssh_vscode_and_inventory_material(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            key = root / "gateway-key"
+            key.write_text("test", encoding="utf-8")
+            key.chmod(0o600)
+            paths = SimpleNamespace(root=root, config_dir=root / "config")
+            session = prepare_automation_session(
+                paths=paths,
+                blueprint_ref="gcp/eve-ng@v1",
+                env_name="demo-lab",
+                automation=self.automation,
+                gateway={
+                    "host": "127.0.0.1",
+                    "user": "opsadmin",
+                    "port": 43210,
+                    "identity_file": str(key),
+                    "known_hosts_file": str(root / "gateway_known_hosts"),
+                    "host_key_alias": "hyops-gateway",
+                },
+                socks_port=1080,
+                lease_text="1 aa:bb:cc:dd:ee:01 172.29.128.51 r1 *",
+            )
+
+            self.assertEqual(session["aliases"], ["hyops-demo-lab-r1"])
+            self.assertIn("ProxyJump hyops-demo-lab-gateway", session["ssh_config"].read_text())
+            self.assertIn("r1 ansible_host=hyops-demo-lab-r1", session["inventory"].read_text())
+            self.assertIn("socks5h://127.0.0.1:1080", session["proxy_env"].read_text())
+            nornir_hosts = yaml.safe_load(session["nornir_hosts"].read_text())
+            self.assertEqual(nornir_hosts["r1"]["hostname"], "hyops-demo-lab-r1")
+            session_payload = yaml.safe_load(session["session_file"].read_text())
+            self.assertEqual(session_payload["socks_proxy"], "socks5h://127.0.0.1:1080")
+            environment = _device_process_environment(session)
+            self.assertEqual(environment["ANSIBLE_CONFIG"], str(session["ansible_config"]))
+            self.assertEqual(
+                environment["NORNIR_SSH_CONFIG_FILE"],
+                str(session["ssh_config"]),
+            )
+            self.assertEqual(session["target_file"].stat().st_mode & 0o777, 0o600)
+            target_payload = yaml.safe_load(session["target_file"].read_text())
+            self.assertEqual(target_payload["targets"][0]["host"], "172.29.128.51")
+
+    def test_target_outside_management_network_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            targets = root / "targets.yml"
+            targets.write_text(
+                "targets:\n  - name: r1\n    host: 192.0.2.10\n    user: admin\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "outside 172.29.128.0/24"):
+                prepare_automation_session(
+                    paths=SimpleNamespace(root=root, config_dir=root / "config"),
+                    blueprint_ref="gcp/eve-ng@v1",
+                    env_name="demo-lab",
+                    automation=self.automation,
+                    gateway={
+                        "host": "127.0.0.1",
+                        "user": "opsadmin",
+                        "port": 22,
+                        "identity_file": str(root / "key"),
+                        "known_hosts_file": str(root / "known_hosts"),
+                    },
+                    socks_port=1080,
+                    target_file_override=str(targets),
+                )
+
+    def test_dhcp_refresh_updates_address_and_preserves_operator_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            key = root / "gateway-key"
+            key.write_text("test", encoding="utf-8")
+            paths = SimpleNamespace(root=root, config_dir=root / "config")
+            gateway = {
+                "host": "127.0.0.1",
+                "user": "opsadmin",
+                "port": 43210,
+                "identity_file": str(key),
+                "known_hosts_file": str(root / "gateway_known_hosts"),
+            }
+            first = prepare_automation_session(
+                paths=paths,
+                blueprint_ref="gcp/eve-ng@v1",
+                env_name="demo-lab",
+                automation=self.automation,
+                gateway=gateway,
+                socks_port=1080,
+                lease_text="1 aa:bb:cc:dd:ee:01 172.29.128.51 r1 *",
+            )
+            payload = yaml.safe_load(first["target_file"].read_text())
+            payload["targets"][0]["name"] = "edge-router"
+            payload["targets"][0]["user"] = "netops"
+            payload["targets"][0]["platform"] = "ios"
+            payload["targets"].append(
+                {
+                    "name": "static-fw",
+                    "host": "172.29.128.80",
+                    "user": "admin",
+                }
+            )
+            first["target_file"].write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+            refreshed = prepare_automation_session(
+                paths=paths,
+                blueprint_ref="gcp/eve-ng@v1",
+                env_name="demo-lab",
+                automation=self.automation,
+                gateway=gateway,
+                socks_port=1080,
+                lease_text="\n".join(
+                    [
+                        "2 aa:bb:cc:dd:ee:01 172.29.128.61 r1 *",
+                        "2 aa:bb:cc:dd:ee:02 172.29.128.62 r2 *",
+                    ]
+                ),
+            )
+
+            by_name = {item["name"]: item for item in refreshed["targets"]}
+            self.assertEqual(by_name["edge-router"]["host"], "172.29.128.61")
+            self.assertEqual(by_name["edge-router"]["user"], "netops")
+            self.assertEqual(by_name["edge-router"]["platform"], "ios")
+            self.assertEqual(by_name["static-fw"]["host"], "172.29.128.80")
+            self.assertEqual(by_name["r2"]["source"], "dhcp-lease")
+            self.assertEqual(refreshed["new_targets"], ["r2"])
+
+    def test_route_command_uses_existing_ssh_boundary(self) -> None:
+        plan = linux_tunnel_plan("demo-lab:gcp/eve-ng@v1")
+        argv = build_tunnel_ssh_argv(
+            gateway={
+                "host": "127.0.0.1",
+                "user": "opsadmin",
+                "ssh_command": ["/usr/bin/ssh", "-p", "40222", "-i", "/tmp/key"],
+            },
+            plan=plan,
+            remote_helper="/usr/local/sbin/hybridops-lab-route",
+        )
+
+        self.assertEqual(argv[0], "/usr/bin/ssh")
+        self.assertIn("Tunnel=point-to-point", argv)
+        self.assertEqual(argv[argv.index("-w") + 1], f"{plan['tunnel_id']}:{plan['tunnel_id']}")
+        self.assertIn("opsadmin@127.0.0.1", argv)
+        self.assertIn("/usr/local/sbin/hybridops-lab-route", argv[-1])
+        self.assertIn(plan["remote_cidr"], argv[-1])
+
+    def test_tunnel_plan_is_stable_and_link_local(self) -> None:
+        first = linux_tunnel_plan("demo-lab:gcp/eve-ng@v1")
+        second = linux_tunnel_plan("demo-lab:gcp/eve-ng@v1")
+
+        self.assertEqual(first, second)
+        self.assertGreaterEqual(first["tunnel_id"], 100)
+        self.assertLessEqual(first["tunnel_id"], 899)
+        self.assertTrue(first["local_ip"].startswith("169.254."))
+        self.assertTrue(first["remote_ip"].startswith("169.254."))
+
+    def test_schema_rejects_gateway_outside_management_network(self) -> None:
+        root = Path(__file__).resolve().parents[3]
+        path = root / "blueprints" / "gcp" / "eve-ng@v1" / "blueprint.yml"
+        payload = load_blueprint(path)
+        payload["access"]["automation"]["management_gateway"] = "192.0.2.1"
+
+        with self.assertRaisesRegex(ValueError, "must be inside management_cidr"):
+            validate_blueprint(payload, path)
+
+    def test_schema_requires_absolute_remote_lease_path(self) -> None:
+        root = Path(__file__).resolve().parents[3]
+        path = root / "blueprints" / "gcp" / "eve-ng@v1" / "blueprint.yml"
+        payload = load_blueprint(path)
+        payload["access"]["automation"]["lease_file"] = "dnsmasq.leases"
+
+        with self.assertRaisesRegex(ValueError, "must be an absolute path"):
+            validate_blueprint(payload, path)
+
+    def test_schema_rejects_management_dhcp_range_outside_network(self) -> None:
+        root = Path(__file__).resolve().parents[3]
+        path = root / "blueprints" / "gcp" / "eve-ng@v1" / "blueprint.yml"
+        payload = load_blueprint(path)
+        payload["access"]["automation"]["management_dhcp_range"] = (
+            "192.0.2.50-192.0.2.100"
+        )
+
+        with self.assertRaisesRegex(ValueError, "usable range inside"):
+            validate_blueprint(payload, path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hyops/blueprint/tests/test_gcp_eve_ng.py
+++ b/hyops/blueprint/tests/test_gcp_eve_ng.py
@@ -14,6 +14,14 @@ class GcpEveNgBlueprintTest(TestCase):
 
         self.assertTrue(validated["access"]["offer_destroy_on_close"])
         self.assertEqual(
+            validated["access"]["automation"]["management_network_label"],
+            "Cloud8",
+        )
+        self.assertEqual(
+            validated["access"]["automation"]["management_cidr"],
+            "172.29.128.0/24",
+        )
+        self.assertEqual(
             validated["metadata"]["ready_message"],
             "EVE-NG network emulation lab ready",
         )
@@ -40,6 +48,11 @@ class GcpEveNgBlueprintTest(TestCase):
         self.assertTrue(by_id["gcp_eve_ng_vm"]["inputs"]["zone_from_init_region"])
         self.assertTrue(
             by_id["gcp_eve_ng_config"]["inputs"]["eveng_guest_nat_enabled"]
+        )
+        self.assertTrue(
+            by_id["gcp_eve_ng_config"]["inputs"][
+                "eveng_management_access_enabled"
+            ]
         )
         self.assertEqual(
             len(by_id["gcp_eve_ng_images"]["inputs"]["eveng_images_list"]), 4

--- a/hyops/blueprint/tests/test_gcp_gns3.py
+++ b/hyops/blueprint/tests/test_gcp_gns3.py
@@ -36,11 +36,23 @@ class GCPGNS3BlueprintTest(TestCase):
         self.assertEqual(access["remote_port"], 3080)
         self.assertEqual(access["local_port"], 3080)
         self.assertFalse(access["open_browser"])
+        self.assertEqual(
+            access["automation"]["management_cidr"],
+            "172.29.130.0/24",
+        )
+        self.assertEqual(
+            access["automation"]["management_network_label"],
+            "hyops-mgmt0",
+        )
 
     def test_required_health_stage_is_deep(self) -> None:
         health = self.blueprint["steps"][5]
         self.assertEqual(health["requires"], ["gcp_gns3_starter_lab"])
         self.assertTrue(health["inputs"]["gns3_healthcheck_deep"])
+
+    def test_server_builds_private_management_bridge(self) -> None:
+        server = self.blueprint["steps"][2]
+        self.assertTrue(server["inputs"]["gns3_server_management_access_enabled"])
 
     def test_destroy_protects_gns3_project_state(self) -> None:
         archive = self.blueprint["archive_before_destroy"]

--- a/hyops/blueprint/tests/test_onprem_eve_ng.py
+++ b/hyops/blueprint/tests/test_onprem_eve_ng.py
@@ -16,6 +16,10 @@ class OnPremEveNgBlueprintTest(TestCase):
         self.assertEqual(validated["policy"]["ipam_authority"], "none")
         self.assertTrue(validated["access"]["offer_destroy_on_close"])
         self.assertEqual(
+            validated["access"]["automation"]["management_cidr"],
+            "172.29.128.0/24",
+        )
+        self.assertEqual(
             validated["archive_before_destroy"]["module_ref"],
             "platform/linux/eve-ng-lab-archive",
         )
@@ -34,6 +38,9 @@ class OnPremEveNgBlueprintTest(TestCase):
             step for step in validated["steps"] if step["id"] == "eve_ng_config"
         )
         self.assertTrue(config_step["inputs"]["eveng_guest_nat_enabled"])
+        self.assertTrue(
+            config_step["inputs"]["eveng_management_access_enabled"]
+        )
         health_step = next(
             step for step in validated["steps"] if step["id"] == "eve_ng_healthcheck"
         )

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -50,6 +50,10 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(access["state_ref"], "platform/onprem/platform-vm#gns3_vm")
         self.assertEqual(access["remote_port"], 3080)
         self.assertEqual(access["local_port"], 3080)
+        self.assertEqual(
+            access["automation"]["management_cidr"],
+            "172.29.130.0/24",
+        )
 
     def test_template_is_retained_during_blueprint_destroy(self) -> None:
         template_step = self.blueprint["steps"][0]

--- a/hyops/blueprint/tests/test_overlay_resolution.py
+++ b/hyops/blueprint/tests/test_overlay_resolution.py
@@ -1,0 +1,140 @@
+"""Tests for environment-scoped blueprint overlay selection."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from hyops.blueprint.command import _resolve_and_validate
+
+
+class BlueprintOverlayResolutionTests(unittest.TestCase):
+    @staticmethod
+    def _write_blueprint(path: Path, blueprint_ref: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "api_version": "hybridops/v1",
+                    "kind": "BlueprintSpec",
+                    "blueprint_ref": blueprint_ref,
+                    "mode": "hybrid",
+                    "steps": [
+                        {
+                            "id": "step1",
+                            "module_ref": "test/sample-module",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _namespace(*, root: Path, blueprints_root: Path, file_path: str = ""):
+        return SimpleNamespace(
+            ref="test/sample@v1",
+            file=file_path,
+            blueprints_root=str(blueprints_root),
+            root=str(root),
+            env=None,
+        )
+
+    def test_environment_overlay_is_preferred_for_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            catalog = root / "catalog"
+            shipped = catalog / "test" / "sample@v1" / "blueprint.yml"
+            overlay = root / "runtime" / "config" / "blueprints" / "sample.yml"
+            self._write_blueprint(shipped, "test/sample@v1")
+            self._write_blueprint(overlay, "test/sample@v1")
+
+            payload = _resolve_and_validate(
+                self._namespace(
+                    root=root / "runtime",
+                    blueprints_root=catalog,
+                )
+            )
+
+            self.assertEqual(Path(payload["path"]), overlay.resolve())
+
+    def test_shipped_blueprint_is_used_when_overlay_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            catalog = root / "catalog"
+            shipped = catalog / "test" / "sample@v1" / "blueprint.yml"
+            self._write_blueprint(shipped, "test/sample@v1")
+
+            payload = _resolve_and_validate(
+                self._namespace(
+                    root=root / "runtime",
+                    blueprints_root=catalog,
+                )
+            )
+
+            self.assertEqual(Path(payload["path"]), shipped.resolve())
+
+    def test_explicit_file_overrides_environment_overlay(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            catalog = root / "catalog"
+            shipped = catalog / "test" / "sample@v1" / "blueprint.yml"
+            overlay = root / "runtime" / "config" / "blueprints" / "sample.yml"
+            explicit = root / "runtime" / "config" / "blueprints" / "alternative.yml"
+            self._write_blueprint(shipped, "test/sample@v1")
+            self._write_blueprint(overlay, "test/sample@v1")
+            self._write_blueprint(explicit, "test/sample@v1")
+
+            payload = _resolve_and_validate(
+                self._namespace(
+                    root=root / "runtime",
+                    blueprints_root=catalog,
+                    file_path=str(explicit),
+                )
+            )
+
+            self.assertEqual(Path(payload["path"]), explicit.resolve())
+
+    def test_init_resolution_ignores_existing_environment_overlay(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            catalog = root / "catalog"
+            shipped = catalog / "test" / "sample@v1" / "blueprint.yml"
+            overlay = root / "runtime" / "config" / "blueprints" / "sample.yml"
+            self._write_blueprint(shipped, "test/sample@v1")
+            self._write_blueprint(overlay, "test/sample@v1")
+
+            payload = _resolve_and_validate(
+                self._namespace(
+                    root=root / "runtime",
+                    blueprints_root=catalog,
+                ),
+                allow_runtime_overlay=False,
+            )
+
+            self.assertEqual(Path(payload["path"]), shipped.resolve())
+
+    def test_overlay_reference_mismatch_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            catalog = root / "catalog"
+            shipped = catalog / "test" / "sample@v1" / "blueprint.yml"
+            overlay = root / "runtime" / "config" / "blueprints" / "sample.yml"
+            self._write_blueprint(shipped, "test/sample@v1")
+            self._write_blueprint(overlay, "test/other@v1")
+
+            with self.assertRaisesRegex(ValueError, "initialized blueprint ref mismatch"):
+                _resolve_and_validate(
+                    self._namespace(
+                        root=root / "runtime",
+                        blueprints_root=catalog,
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hyops/tests/test_blueprint_edit.py
+++ b/hyops/tests/test_blueprint_edit.py
@@ -1,0 +1,80 @@
+"""Tests for `hyops blueprint edit`."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.blueprint.command import _editor_argv, _resolve_edit_target, run_edit
+from hyops.runtime.exitcodes import OPERATOR_ERROR
+
+
+class BlueprintEditTests(TestCase):
+    def test_editor_argv_uses_cli_override(self) -> None:
+        ns = SimpleNamespace(editor="cat", file="", ref="", root="", env="")
+        argv = _editor_argv(ns)
+        self.assertEqual(argv, ["cat"])
+
+    def test_resolve_edit_target_requires_init_when_no_explicit_file(self) -> None:
+        with tempfile.TemporaryDirectory() as root_dir:
+            ns = SimpleNamespace(root=root_dir, env=None, ref="gcp/eve-ng@v1", file="", editor="")
+            with self.assertRaises(FileNotFoundError):
+                _resolve_edit_target(ns)
+
+    def test_resolve_edit_target_uses_explicit_file_under_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as root_dir:
+            config_dir = Path(root_dir) / "config" / "blueprints"
+            config_dir.mkdir(parents=True)
+            explicit = config_dir / "custom.yml"
+            explicit.write_text("blueprint_ref: gcp/eve-ng@v1\n", encoding="utf-8")
+
+            ns = SimpleNamespace(root=root_dir, env=None, ref="", file=str(explicit), editor="")
+            resolved = _resolve_edit_target(ns)
+            self.assertEqual(resolved, explicit)
+
+    def test_run_edit_invokes_editor(self) -> None:
+        with tempfile.TemporaryDirectory() as root_dir:
+            config_dir = Path(root_dir) / "config" / "blueprints"
+            config_dir.mkdir(parents=True)
+            blueprint = config_dir / "eve-ng.yml"
+            blueprint.write_text("blueprint_ref: gcp/eve-ng@v1\n", encoding="utf-8")
+
+            ns = SimpleNamespace(
+                root=root_dir,
+                env=None,
+                ref="gcp/eve-ng@v1",
+                file="",
+                editor="",
+            )
+
+            with patch("hyops.blueprint.command.subprocess.run") as run:
+                run.return_value.returncode = 0
+                rc = run_edit(ns)
+                self.assertEqual(rc, 0)
+                run.assert_called_once()
+
+    def test_run_edit_fails_when_editor_missing(self) -> None:
+        ns = SimpleNamespace(root="", env="", ref="", file="", editor="")
+        with tempfile.TemporaryDirectory() as root_dir:
+            ns.root = root_dir
+            config_dir = Path(root_dir) / "config" / "blueprints"
+            config_dir.mkdir(parents=True)
+            blueprint = config_dir / "custom.yml"
+            blueprint.write_text("blueprint_ref: gcp/eve-ng@v1\n", encoding="utf-8")
+            ns.file = str(blueprint)
+
+            with patch.dict(os.environ, {"PATH": ""}, clear=True):
+                with patch("hyops.blueprint.command.shutil.which", return_value=None) as which:
+                    rc = run_edit(ns)
+                    self.assertEqual(rc, OPERATOR_ERROR)
+                    which.assert_called()
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -98,6 +98,11 @@ class CliRoutingTests(unittest.TestCase):
                 self.assertEqual(result.returncode, 0, result.stderr)
                 self.assertIn(f"hyops {command}", result.stdout)
 
+    def test_blueprint_help_includes_edit(self) -> None:
+        result = run_cli("blueprint", "--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("edit", result.stdout)
+
     def test_unknown_command_returns_parser_error(self) -> None:
         result = run_cli("not-a-command")
         self.assertEqual(result.returncode, 2)

--- a/hyops/tests/test_gns3_images_module.py
+++ b/hyops/tests/test_gns3_images_module.py
@@ -24,5 +24,6 @@ class GNS3ImagesModuleTest(TestCase):
                 "gns3_images_requested_count",
                 "gns3_images_installed_count",
                 "gns3_images_template_names",
+                "gns3_images_iou_license_ready",
             ],
         )

--- a/hyops/validators/platform/linux/eve_ng_images.py
+++ b/hyops/validators/platform/linux/eve_ng_images.py
@@ -78,7 +78,20 @@ def validate(inputs: dict[str, Any]) -> None:
 
     if data.get("required_env_destroy") is not None:
         require_str_list(data.get("required_env_destroy"), "inputs.required_env_destroy")
-    normalize_required_env(data.get("required_env"), "inputs.required_env")
+    required_env = normalize_required_env(data.get("required_env"), "inputs.required_env")
+    iol_license_env = require_non_empty_str(
+        data.get("eveng_images_iol_license_env"),
+        "inputs.eveng_images_iol_license_env",
+    )
+    iol_license_required = require_bool(
+        data.get("eveng_images_iol_license_required"),
+        "inputs.eveng_images_iol_license_required",
+    )
+    if iol_license_required and iol_license_env not in required_env:
+        raise ValueError(
+            "inputs.required_env must include inputs.eveng_images_iol_license_env "
+            "when an IOL licence is required"
+        )
 
     if source == "url":
         _validate_image_list(data.get("eveng_images_list"))

--- a/hyops/validators/platform/linux/gns3_images.py
+++ b/hyops/validators/platform/linux/gns3_images.py
@@ -49,12 +49,31 @@ def _validate_template(value: Any, label: str) -> None:
         raise ValueError(f"{label}.linked_clone must be a boolean")
 
 
-def _validate_images(value: Any) -> None:
+def _validate_iou_template(value: Any, label: str) -> None:
+    template = require_mapping(value, label)
+    for key in ("ram", "nvram", "ethernet_adapters"):
+        if key in template:
+            _positive_int(template[key], f"{label}.{key}")
+    if "serial_adapters" in template:
+        value = template["serial_adapters"]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"{label}.serial_adapters must be an integer >= 0")
+    for key in ("category", "console_type", "symbol"):
+        if key in template:
+            require_non_empty_str(template[key], f"{label}.{key}")
+    if "use_default_iou_values" in template and not isinstance(
+        template["use_default_iou_values"], bool
+    ):
+        raise ValueError(f"{label}.use_default_iou_values must be a boolean")
+
+
+def _validate_images(value: Any) -> bool:
     if not isinstance(value, list) or not value:
         raise ValueError("inputs.gns3_images_items must be a non-empty list")
 
     names: set[str] = set()
     filenames: set[str] = set()
+    iou_requested = False
     for index, raw in enumerate(value, start=1):
         label = f"inputs.gns3_images_items[{index}]"
         item = require_mapping(raw, label)
@@ -62,9 +81,9 @@ def _validate_images(value: Any) -> None:
         url = require_non_empty_str(item.get("url"), f"{label}.url")
         filename = require_non_empty_str(item.get("filename"), f"{label}.filename")
         checksum = require_non_empty_str(item.get("checksum"), f"{label}.checksum")
-        disk_type = require_non_empty_str(
-            item.get("disk_type", "hda"), f"{label}.disk_type"
-        ).lower()
+        image_type = require_non_empty_str(
+            item.get("type", "qemu"), f"{label}.type"
+        )
 
         parsed = urlparse(url)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
@@ -73,8 +92,29 @@ def _validate_images(value: Any) -> None:
             raise ValueError(f"{label}.filename must be a safe basename")
         if not _SHA256_RE.fullmatch(checksum):
             raise ValueError(f"{label}.checksum must use sha256:<64 hex characters>")
-        if disk_type not in {"hda", "cdrom"}:
-            raise ValueError(f"{label}.disk_type must be hda or cdrom")
+        if image_type not in {"qemu", "iou"}:
+            raise ValueError(f"{label}.type must be qemu or iou")
+        if image_type == "qemu":
+            disk_type = require_non_empty_str(
+                item.get("disk_type", "hda"), f"{label}.disk_type"
+            ).lower()
+            if disk_type not in {"hda", "cdrom"}:
+                raise ValueError(f"{label}.disk_type must be hda or cdrom")
+        else:
+            iou_requested = True
+            if not filename.endswith(".bin"):
+                raise ValueError(f"{label}.filename must end with .bin for IOU")
+            if "disk_type" in item:
+                raise ValueError(f"{label}.disk_type is not valid for IOU")
+            architecture = require_non_empty_str(
+                item.get(
+                    "architecture",
+                    "i386" if filename.lower().startswith("i86bi") else "x86_64",
+                ),
+                f"{label}.architecture",
+            )
+            if architecture not in {"i386", "x86_64"}:
+                raise ValueError(f"{label}.architecture must be i386 or x86_64")
         if name in names:
             raise ValueError(f"{label}.name duplicates an earlier declaration")
         if filename in filenames:
@@ -85,7 +125,11 @@ def _validate_images(value: Any) -> None:
         if item.get("timeout") is not None:
             _positive_int(item["timeout"], f"{label}.timeout")
         if item.get("template") is not None:
-            _validate_template(item["template"], f"{label}.template")
+            if image_type == "iou":
+                _validate_iou_template(item["template"], f"{label}.template")
+            else:
+                _validate_template(item["template"], f"{label}.template")
+    return iou_requested
 
 
 def validate(inputs: dict[str, Any]) -> None:
@@ -102,7 +146,16 @@ def validate(inputs: dict[str, Any]) -> None:
     require_non_empty_str(
         data.get("gns3_images_password_env"), "inputs.gns3_images_password_env"
     )
-    normalize_required_env(data.get("required_env"), "inputs.required_env")
+    iou_license_env = require_non_empty_str(
+        data.get("gns3_images_iou_license_env"),
+        "inputs.gns3_images_iou_license_env",
+    )
+    required_env = normalize_required_env(data.get("required_env"), "inputs.required_env")
     if data.get("required_env_destroy") is not None:
         require_str_list(data.get("required_env_destroy"), "inputs.required_env_destroy")
-    _validate_images(data.get("gns3_images_items"))
+    iou_requested = _validate_images(data.get("gns3_images_items"))
+    if iou_requested and iou_license_env not in required_env:
+        raise ValueError(
+            "inputs.required_env must include inputs.gns3_images_iou_license_env "
+            "when an IOU image is declared"
+        )

--- a/hyops/validators/platform/linux/tests/test_eve_ng_images.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_images.py
@@ -1,0 +1,56 @@
+"""Tests for the EVE-NG image module validator."""
+
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+import yaml
+
+from hyops.validators.platform.linux.eve_ng_images import validate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MODULE_ROOT = REPO_ROOT / "modules" / "platform" / "linux" / "eve-ng-images"
+
+
+def valid_inputs() -> dict:
+    spec = yaml.safe_load((MODULE_ROOT / "spec.yml").read_text(encoding="utf-8"))
+    inputs = deepcopy(spec["inputs"]["defaults"])
+    inputs.update(
+        {
+            "target_host": "127.0.0.1",
+            "eveng_images_list": [
+                {
+                    "url": "https://example.test/iol.bin",
+                    "name": "iol.bin",
+                    "type": "iol",
+                }
+            ],
+        }
+    )
+    return inputs
+
+
+class EVENGImagesValidatorTests(unittest.TestCase):
+    def test_optional_iol_license_is_valid(self) -> None:
+        validate(valid_inputs())
+
+    def test_required_iol_license_must_be_preflighted(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_images_iol_license_required"] = True
+
+        with self.assertRaisesRegex(ValueError, "required_env must include"):
+            validate(inputs)
+
+        inputs["required_env"] = ["EVENG_IOL_LICENSE"]
+        validate(inputs)
+
+    def test_iol_license_environment_name_must_not_be_empty(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_images_iol_license_env"] = ""
+        with self.assertRaises(ValueError):
+            validate(inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hyops/validators/platform/linux/tests/test_gns3_images.py
+++ b/hyops/validators/platform/linux/tests/test_gns3_images.py
@@ -76,6 +76,77 @@ class GNS3ImagesValidatorTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     validate(inputs)
 
+    def test_iou_image_requires_a_preflighted_license(self) -> None:
+        inputs = valid_inputs()
+        inputs["gns3_images_items"] = [
+            {
+                "name": "Authorised IOU router",
+                "type": "iou",
+                "url": "https://example.test/router.bin",
+                "filename": "router.bin",
+                "checksum": "sha256:" + "a" * 64,
+                "template": {
+                    "ethernet_adapters": 4,
+                    "serial_adapters": 0,
+                },
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "required_env must include"):
+            validate(inputs)
+
+        inputs["required_env"].append("GNS3_IOU_LICENSE")
+        validate(inputs)
+
+    def test_iou_image_rejects_qemu_disk_fields(self) -> None:
+        inputs = valid_inputs()
+        inputs["required_env"].append("GNS3_IOU_LICENSE")
+        inputs["gns3_images_items"] = [
+            {
+                "name": "Authorised IOU router",
+                "type": "iou",
+                "url": "https://example.test/router.bin",
+                "filename": "router.bin",
+                "checksum": "sha256:" + "a" * 64,
+                "disk_type": "hda",
+            }
+        ]
+        with self.assertRaisesRegex(ValueError, "disk_type is not valid for IOU"):
+            validate(inputs)
+
+    def test_iou_image_accepts_explicit_i386_runtime(self) -> None:
+        inputs = valid_inputs()
+        inputs["required_env"].append("GNS3_IOU_LICENSE")
+        inputs["gns3_images_items"] = [
+            {
+                "name": "Authorised IOU router",
+                "type": "iou",
+                "url": "https://example.test/i86bi-router.bin",
+                "filename": "i86bi-router.bin",
+                "checksum": "sha256:" + "a" * 64,
+                "architecture": "i386",
+            }
+        ]
+        validate(inputs)
+
+    def test_iou_image_requires_canonical_type_and_architecture(self) -> None:
+        for key, value in (("type", "IOU"), ("architecture", "I386")):
+            with self.subTest(key=key):
+                inputs = valid_inputs()
+                inputs["required_env"].append("GNS3_IOU_LICENSE")
+                image = {
+                    "name": "Authorised IOU router",
+                    "type": "iou",
+                    "url": "https://example.test/i86bi-router.bin",
+                    "filename": "i86bi-router.bin",
+                    "checksum": "sha256:" + "a" * 64,
+                    "architecture": "i386",
+                }
+                image[key] = value
+                inputs["gns3_images_items"] = [image]
+                with self.assertRaises(ValueError):
+                    validate(inputs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/modules/platform/linux/eve-ng-images/README.md
+++ b/modules/platform/linux/eve-ng-images/README.md
@@ -24,6 +24,20 @@ The module supports the same target resolution and SSH access patterns as `platf
 - GCP IAP
 - state-driven target resolution from a VM module
 
+## IOL licence material
+
+IOL binaries and their host-bound licence are separate inputs. Store an
+authorised `iourc` without exposing it on the command line:
+
+```bash
+hyops secrets set --env <env> --from-file EVENG_IOL_LICENSE=/path/to/iourc
+```
+
+Then set `load_vault_env: true`, add `EVENG_IOL_LICENSE` to `required_env`,
+and enable `eveng_images_iol_license_required`. Deployment places the licence
+in the EVE-NG IOL directory and publishes only its readiness state. HybridOps
+does not download, generate, log, or archive the licence material.
+
 ## Destroy behaviour
 
 Destroy is conservative.

--- a/modules/platform/linux/eve-ng-images/examples/inputs.min.yml
+++ b/modules/platform/linux/eve-ng-images/examples/inputs.min.yml
@@ -3,6 +3,10 @@ target_user: "opsadmin"
 ssh_private_key_file: "~/.ssh/id_ed25519"
 
 eveng_images_source: "url"
+# Optional for authorised IOL images on EVE-NG Community Edition:
+# load_vault_env: true
+# required_env: ["EVENG_IOL_LICENSE"]
+# eveng_images_iol_license_required: true
 eveng_images_list:
   - url: "https://example.invalid/images/router-image.tgz"
     name: "router-image.tgz"

--- a/modules/platform/linux/eve-ng-images/spec.yml
+++ b/modules/platform/linux/eve-ng-images/spec.yml
@@ -49,6 +49,8 @@ inputs:
     eveng_images_keep_cache: false
     eveng_images_raw_qemu_layout: "foldered"
     eveng_images_raw_qemu_disk_name: "virtioa.qcow2"
+    eveng_images_iol_license_env: "EVENG_IOL_LICENSE"
+    eveng_images_iol_license_required: false
     eveng_images_fail_on_corrupt: true
     eveng_images_logging_enabled: false
     eveng_images_log_dir_controller: "{{ playbook_dir | default('.', true) }}/var/log/hybridops/eveng-images"
@@ -73,6 +75,7 @@ outputs:
     - cap.lab.eveng.images
     - eveng_images_source
     - eveng_images_requested_count
+    - eveng_images_iol_license_ready
 
 probes: []
 constraints: []

--- a/modules/platform/linux/eve-ng/spec.yml
+++ b/modules/platform/linux/eve-ng/spec.yml
@@ -56,6 +56,14 @@ inputs:
     eveng_guest_nat_subnet: "172.29.129.0/24"
     eveng_guest_nat_dhcp_start: "172.29.129.50"
     eveng_guest_nat_dhcp_end: "172.29.129.200"
+    eveng_management_access_enabled: false
+    eveng_management_bridge: "pnet8"
+    eveng_management_cidr: "172.29.128.1/24"
+    eveng_management_subnet: "172.29.128.0/24"
+    eveng_management_dhcp_start: "172.29.128.50"
+    eveng_management_dhcp_end: "172.29.128.200"
+    eveng_management_lease_file: "/var/lib/misc/dnsmasq.leases"
+    eveng_management_access_ssh_user: "opsadmin"
     eveng_root_password_env: "EVENG_ROOT_PASSWORD"
     eveng_admin_password_env: "EVENG_ADMIN_PASSWORD"
 

--- a/modules/platform/linux/gns3-images/README.md
+++ b/modules/platform/linux/gns3-images/README.md
@@ -1,8 +1,9 @@
 # platform/linux/gns3-images
 
-Install declared QEMU images and register them as templates on an authenticated
-GNS3 server. Every URL requires a SHA-256 checksum. Existing matching templates
-are retained; conflicting template names fail without replacement.
+Install declared QEMU or IOU images and register them as templates on an
+authenticated GNS3 server. Every URL requires a SHA-256 checksum. Existing
+matching templates are retained; conflicting template names fail without
+replacement.
 
 ```bash
 hyops apply --env lab \
@@ -12,3 +13,15 @@ hyops apply --env lab \
 
 No proprietary image is bundled. Operators remain responsible for image
 licensing and distribution rights.
+
+For an authorised IOU image, store its licence separately:
+
+```bash
+hyops secrets set --env <env> --from-file GNS3_IOU_LICENSE=/path/to/iourc
+```
+
+Set `load_vault_env: true`, include both `GNS3_SERVER_PASSWORD` and
+`GNS3_IOU_LICENSE` in `required_env`, and declare the image with `type: iou`.
+The runtime installs IOU support, places the image, retains GNS3 licence
+checking, and registers the template. It does not generate or archive licence
+material. Licences activated inside QEMU guests remain guest-level state.

--- a/modules/platform/linux/gns3-images/examples/inputs.min.yml
+++ b/modules/platform/linux/gns3-images/examples/inputs.min.yml
@@ -3,6 +3,10 @@ inventory_vm_groups:
   targets:
     - "gns3-01"
 target_user: "opsadmin"
+# For an authorised IOU image, also set:
+# load_vault_env: true
+# required_env: ["GNS3_SERVER_PASSWORD", "GNS3_IOU_LICENSE"]
+# gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
 gns3_images_items:
   - name: "Alpine Linux 3.24"
     url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"

--- a/modules/platform/linux/gns3-images/spec.yml
+++ b/modules/platform/linux/gns3-images/spec.yml
@@ -46,6 +46,7 @@ inputs:
     gns3_images_port: 3080
     gns3_images_username: "gns3"
     gns3_images_password_env: "GNS3_SERVER_PASSWORD"
+    gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
     gns3_images_items: []
 
 execution:
@@ -60,6 +61,7 @@ outputs:
     - gns3_images_requested_count
     - gns3_images_installed_count
     - gns3_images_template_names
+    - gns3_images_iou_license_ready
 
 probes: []
 constraints: []

--- a/modules/platform/linux/gns3-server/spec.yml
+++ b/modules/platform/linux/gns3-server/spec.yml
@@ -52,6 +52,14 @@ inputs:
     gns3_server_enable_kvm: true
     gns3_server_require_kvm: false
     gns3_server_install_emulators: true
+    gns3_server_management_access_enabled: false
+    gns3_server_management_bridge: "hyops-mgmt0"
+    gns3_server_management_cidr: "172.29.130.1/24"
+    gns3_server_management_subnet: "172.29.130.0/24"
+    gns3_server_management_dhcp_start: "172.29.130.50"
+    gns3_server_management_dhcp_end: "172.29.130.200"
+    gns3_server_management_lease_file: "/var/lib/misc/dnsmasq.hybridops-gns3-management.leases"
+    gns3_server_management_access_ssh_user: "opsadmin"
 
 execution:
   driver: "config/ansible"

--- a/packs/config/ansible/linux/common/platform/40-eve-ng@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/40-eve-ng@v1.0/stack/playbook.yml
@@ -17,6 +17,15 @@
     _hyops_input_eveng_guest_nat_subnet: "{{ eveng_guest_nat_subnet | default('172.29.129.0/24') }}"
     _hyops_input_eveng_guest_nat_dhcp_start: "{{ eveng_guest_nat_dhcp_start | default('172.29.129.50') }}"
     _hyops_input_eveng_guest_nat_dhcp_end: "{{ eveng_guest_nat_dhcp_end | default('172.29.129.200') }}"
+    _hyops_input_eveng_management_access_enabled: "{{ eveng_management_access_enabled | default(false) | bool }}"
+    _hyops_input_eveng_management_bridge: "{{ eveng_management_bridge | default('pnet8') }}"
+    _hyops_input_eveng_management_cidr: "{{ eveng_management_cidr | default('172.29.128.1/24') }}"
+    _hyops_input_eveng_management_subnet: "{{ eveng_management_subnet | default('172.29.128.0/24') }}"
+    _hyops_input_eveng_management_dhcp_start: "{{ eveng_management_dhcp_start | default('172.29.128.50') }}"
+    _hyops_input_eveng_management_dhcp_end: "{{ eveng_management_dhcp_end | default('172.29.128.200') }}"
+    _hyops_input_eveng_management_lease_file: "{{ eveng_management_lease_file | default('/var/lib/misc/dnsmasq.leases') }}"
+    _hyops_input_eveng_management_access_ssh_user: >-
+      {{ eveng_management_access_ssh_user | default(target_user | default('opsadmin')) }}
     _hyops_input_eveng_root_password: "{{ lookup('env', eveng_root_password_env | default('EVENG_ROOT_PASSWORD')) }}"
     _hyops_input_eveng_admin_password: "{{ lookup('env', eveng_admin_password_env | default('EVENG_ADMIN_PASSWORD')) }}"
 
@@ -36,6 +45,15 @@
         eveng_guest_nat_subnet: "{{ _hyops_input_eveng_guest_nat_subnet }}"
         eveng_guest_nat_dhcp_start: "{{ _hyops_input_eveng_guest_nat_dhcp_start }}"
         eveng_guest_nat_dhcp_end: "{{ _hyops_input_eveng_guest_nat_dhcp_end }}"
+        eveng_management_access_enabled: "{{ _hyops_input_eveng_management_access_enabled }}"
+        eveng_management_bridge: "{{ _hyops_input_eveng_management_bridge }}"
+        eveng_management_cidr: "{{ _hyops_input_eveng_management_cidr }}"
+        eveng_management_subnet: "{{ _hyops_input_eveng_management_subnet }}"
+        eveng_management_dhcp_start: "{{ _hyops_input_eveng_management_dhcp_start }}"
+        eveng_management_dhcp_end: "{{ _hyops_input_eveng_management_dhcp_end }}"
+        eveng_management_lease_file: "{{ _hyops_input_eveng_management_lease_file }}"
+        eveng_management_access_ssh_user: >-
+          {{ _hyops_input_eveng_management_access_ssh_user }}
         eveng_root_password: "{{ _hyops_input_eveng_root_password }}"
         eveng_admin_password: "{{ _hyops_input_eveng_admin_password }}"
 

--- a/packs/config/ansible/linux/common/platform/41-eve-ng-images@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/41-eve-ng-images@v1.0/stack/playbook.yml
@@ -13,6 +13,10 @@
     _hyops_input_eveng_images_keep_cache: "{{ vars.get('eveng_images_keep_cache', false) | bool }}"
     _hyops_input_eveng_images_raw_qemu_layout: "{{ vars.get('eveng_images_raw_qemu_layout', 'foldered') | string }}"
     _hyops_input_eveng_images_raw_qemu_disk_name: "{{ vars.get('eveng_images_raw_qemu_disk_name', 'virtioa.qcow2') | string }}"
+    _hyops_input_eveng_images_iol_license_env: "{{ vars.get('eveng_images_iol_license_env', 'EVENG_IOL_LICENSE') | string }}"
+    _hyops_input_eveng_images_iol_license_required: "{{ vars.get('eveng_images_iol_license_required', false) | bool }}"
+    _hyops_input_eveng_images_iol_license_content: >-
+      {{ lookup('env', _hyops_input_eveng_images_iol_license_env) | default('', true) }}
     _hyops_input_eveng_images_fail_on_corrupt: "{{ vars.get('eveng_images_fail_on_corrupt', true) | bool }}"
     _hyops_input_eveng_images_logging_enabled: "{{ vars.get('eveng_images_logging_enabled', false) | bool }}"
     _hyops_input_eveng_images_log_dir_controller: "{{ vars.get('eveng_images_log_dir_controller', playbook_dir ~ '/var/log/hybridops/eveng-images') | string }}"
@@ -43,6 +47,8 @@
         eveng_images_keep_cache: "{{ _hyops_input_eveng_images_keep_cache }}"
         eveng_images_raw_qemu_layout: "{{ _hyops_input_eveng_images_raw_qemu_layout }}"
         eveng_images_raw_qemu_disk_name: "{{ _hyops_input_eveng_images_raw_qemu_disk_name }}"
+        eveng_images_iol_license_content: "{{ _hyops_input_eveng_images_iol_license_content }}"
+        eveng_images_iol_license_required: "{{ _hyops_input_eveng_images_iol_license_required }}"
         eveng_images_fail_on_corrupt: "{{ _hyops_input_eveng_images_fail_on_corrupt }}"
         eveng_images_logging_enabled: "{{ _hyops_input_eveng_images_logging_enabled }}"
         eveng_images_log_dir_controller: "{{ _hyops_input_eveng_images_log_dir_controller }}"
@@ -66,5 +72,8 @@
           {{ {
             'cap.lab.eveng.images': 'ready',
             'eveng_images_source': (eveng_images_source | default('url')),
-            'eveng_images_requested_count': ((eveng_images_list | default([])) | length)
+            'eveng_images_requested_count': ((eveng_images_list | default([])) | length),
+            'eveng_images_iol_license_ready': (
+              eveng_images_iol_license_ready | default(false) | bool
+            )
           } | to_json }}

--- a/packs/config/ansible/linux/common/platform/44-gns3-server@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/44-gns3-server@v1.0/stack/playbook.yml
@@ -18,6 +18,22 @@
     _hyops_gns3_require_kvm: "{{ gns3_server_require_kvm | default(false) | bool }}"
     _hyops_gns3_install_emulators: >-
       {{ gns3_server_install_emulators | default(true) | bool }}
+    _hyops_gns3_management_access_enabled: >-
+      {{ gns3_server_management_access_enabled | default(false) | bool }}
+    _hyops_gns3_management_bridge: >-
+      {{ gns3_server_management_bridge | default('hyops-mgmt0') }}
+    _hyops_gns3_management_cidr: >-
+      {{ gns3_server_management_cidr | default('172.29.130.1/24') }}
+    _hyops_gns3_management_subnet: >-
+      {{ gns3_server_management_subnet | default('172.29.130.0/24') }}
+    _hyops_gns3_management_dhcp_start: >-
+      {{ gns3_server_management_dhcp_start | default('172.29.130.50') }}
+    _hyops_gns3_management_dhcp_end: >-
+      {{ gns3_server_management_dhcp_end | default('172.29.130.200') }}
+    _hyops_gns3_management_lease_file: >-
+      {{ gns3_server_management_lease_file | default('/var/lib/misc/dnsmasq.hybridops-gns3-management.leases') }}
+    _hyops_gns3_management_access_ssh_user: >-
+      {{ gns3_server_management_access_ssh_user | default(target_user | default('opsadmin')) }}
 
   tasks:
     - name: Install and configure GNS3 server
@@ -32,6 +48,15 @@
         gns3_server_enable_kvm: "{{ _hyops_gns3_enable_kvm }}"
         gns3_server_require_kvm: "{{ _hyops_gns3_require_kvm }}"
         gns3_server_install_emulators: "{{ _hyops_gns3_install_emulators }}"
+        gns3_server_management_access_enabled: "{{ _hyops_gns3_management_access_enabled }}"
+        gns3_server_management_bridge: "{{ _hyops_gns3_management_bridge }}"
+        gns3_server_management_cidr: "{{ _hyops_gns3_management_cidr }}"
+        gns3_server_management_subnet: "{{ _hyops_gns3_management_subnet }}"
+        gns3_server_management_dhcp_start: "{{ _hyops_gns3_management_dhcp_start }}"
+        gns3_server_management_dhcp_end: "{{ _hyops_gns3_management_dhcp_end }}"
+        gns3_server_management_lease_file: "{{ _hyops_gns3_management_lease_file }}"
+        gns3_server_management_access_ssh_user: >-
+          {{ _hyops_gns3_management_access_ssh_user }}
 
   post_tasks:
     - name: Write HyOps outputs

--- a/packs/config/ansible/linux/common/platform/47-gns3-images@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/47-gns3-images@v1.0/stack/playbook.yml
@@ -7,6 +7,8 @@
   vars:
     _hyops_gns3_images_password: >-
       {{ lookup('env', gns3_images_password_env | default('GNS3_SERVER_PASSWORD')) }}
+    _hyops_gns3_images_iourc_content: >-
+      {{ lookup('env', gns3_images_iou_license_env | default('GNS3_IOU_LICENSE')) | default('', true) }}
 
   tasks:
     - name: Install GNS3 images and templates
@@ -14,6 +16,7 @@
         name: "{{ gns3_images_role_fqcn }}"
       vars:
         gns3_images_password: "{{ _hyops_gns3_images_password }}"
+        gns3_images_iourc_content: "{{ _hyops_gns3_images_iourc_content }}"
 
   post_tasks:
     - name: Write HyOps outputs
@@ -27,5 +30,6 @@
             'cap.lab.gns3.images': 'ready',
             'gns3_images_requested_count': gns3_images_results.requested_count,
             'gns3_images_installed_count': gns3_images_results.installed_count,
-            'gns3_images_template_names': gns3_images_results.template_names
+            'gns3_images_template_names': gns3_images_results.template_names,
+            'gns3_images_iou_license_ready': gns3_images_results.iou_license_ready
           } | to_json }}

--- a/tools/ci/check-install.sh
+++ b/tools/ci/check-install.sh
@@ -139,6 +139,15 @@ grep -Fq 'Python 3.11 or newer' "${HYOPS_REPO_ROOT}/pkg/macos/preinstall"
 grep -Fq 'macOS 13 or newer' "${HYOPS_REPO_ROOT}/pkg/macos/preinstall"
 grep -Fq 'hybridops-core/discussions' "${HYOPS_REPO_ROOT}/pkg/macos/preinstall"
 grep -Fq 'HYOPS_RELEASE_VERSION=' "${HYOPS_REPO_ROOT}/pkg/build_release.sh"
+if grep -Fq 'HYOPS_RELEASE_VERSION="0.0.${GITHUB_RUN_NUMBER}"' \
+  "${HYOPS_REPO_ROOT}/.github/workflows/ci.yml"; then
+  echo "ERR: macOS CI packages use a synthetic version instead of the Core release version" >&2
+  exit 1
+fi
+grep -Fq 'tomllib.load(open("pyproject.toml", "rb"))["project"]["version"]' \
+  "${HYOPS_REPO_ROOT}/.github/workflows/ci.yml"
+grep -Fq 'test "$(/usr/local/bin/hyops --version)" = "${HYOPS_RELEASE_VERSION}"' \
+  "${HYOPS_REPO_ROOT}/.github/workflows/ci.yml"
 grep -Fq 'does not match release version' "${HYOPS_REPO_ROOT}/pkg/verify_release.sh"
 grep -Fq 'HybridOps.Core macOS package launcher' "${HYOPS_REPO_ROOT}/pkg/macos/postinstall"
 grep -Fq '/Library/Logs/HybridOps' "${HYOPS_REPO_ROOT}/pkg/macos/postinstall"


### PR DESCRIPTION
Adds the Device Automation Core path for private EVE-NG and GNS3 management access, runtime blueprint editing and lookup, image handling, and related validation.

This PR is limited to the existing Device Automation feature work. Containerlab will be rebased onto main after this lands.