### PR TITLE
feat(containerlab): add disposable GCP lab lifecycle

### DIFF
--- a/blueprints/gcp/containerlab@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/containerlab@v1/ARCHITECTURE.md
@@ -1,0 +1,132 @@
+# Containerlab on disposable GCP compute
+
+## Problem
+
+Some Containerlab labs need a large VM for only part of the day. Keeping that VM running only to preserve lab state is expensive.
+
+Containerlab already owns topology, deployment, and the recovery features it supports. Before HybridOps removes the execution host, it must verify that the recovery data selected by policy has been copied somewhere that will survive that host.
+
+## Ownership
+
+### Containerlab
+
+Containerlab remains responsible for:
+
+- `.clab.yml` topology semantics
+- nodes and links
+- startup configuration handling
+- topology validation
+- deploy and convergence
+- native `save`
+- supported vrnetlab snapshot and restore
+- lab inspection and generated runtime state
+- supported local or remote startup-config and licence references
+
+### HybridOps
+
+HybridOps is responsible for:
+
+- private GCP infrastructure
+- nested virtualisation and KVM readiness
+- Containerlab version and package verification
+- image reachability checks without distributing vendor images
+- VM lifetime and cost context
+- recovery policy
+- off-host recovery retention and checksum verification
+- destroy and rebuild order
+- handing recovery data back to Containerlab
+- recording the run result
+
+```text
+.clab.yml and native recovery data
+                |
+                v
+          Containerlab
+ topology / nodes / links / convergence / native recovery
+                |
+---------------- ownership boundary ----------------
+                |
+            HybridOps
+ readiness / off-host copy / GCP rebuild / verification
+                |
+                v
+        disposable GCP compute
+```
+
+## Native Containerlab behaviour used by HybridOps
+
+HybridOps targets Containerlab `0.78.0` and uses native `validate`, `deploy`, `inspect`, `save`, `destroy`, and supported snapshot commands. HybridOps does not reproduce Containerlab topology or convergence logic.
+
+Containerlab normally creates `clab-*` data beside the topology. HybridOps sets native `CLAB_LABDIR_BASE` to:
+
+```text
+/var/lib/hybridops/containerlab/labdirs
+```
+
+This keeps generated Containerlab data separate from the operator source tree. It does not create a new HybridOps lab-state format.
+
+Containerlab can also use supported remote startup-config and licence references. Those assets should stay at their existing authoritative location. HybridOps only preserves local source material that would otherwise disappear with the disposable VM.
+
+## What HybridOps does not do
+
+HybridOps does not act as:
+
+- a second topology engine
+- a node or link reconciler
+- a vendor configuration renderer
+- a Containerlab snapshot implementation
+- a Clabernetes replacement
+- a proprietary NOS image repository
+- a remote startup-config service
+- a general backup product
+
+## Recovery flow
+
+The reference blueprint uses a private `n2-highmem-8` VM with nested virtualisation.
+
+Lab deployment, health checks, and recovery operations use the same `CLAB_LABDIR_BASE` value. The recovery step also checks that the managed source directory and generated labdir are different paths.
+
+The recovery step is last in deploy order. Blueprint destroy runs in reverse order, so recovery runs before lab, runtime, and VM teardown.
+
+During destroy, HybridOps:
+
+1. asks Containerlab for native save output and, in `snapshot` mode, supported vrnetlab snapshots
+2. creates a timestamped archive
+3. copies that archive to the HybridOps controller
+4. verifies its SHA-256 there
+5. restricts the retained archive permissions
+6. updates the latest pointer, checksum, and metadata
+7. allows teardown to continue only after the off-host check succeeds
+
+The timestamped archive is the retained object. `latest.tar.gz` is only a symlink to it, with checksum and metadata stored alongside the link.
+
+The controller filesystem is the first retention target. That proves the recovery copy survives deletion of the GCP VM, but the controller still needs its own backup policy.
+
+## Rebuild flow
+
+On a fresh host, HybridOps:
+
+1. verifies the latest pointer, checksum, and metadata
+2. verifies the immutable archive
+3. checks topology identity when source matching is enabled
+4. clears any stale import workspace
+5. imports the archive
+6. restores the source tree to the managed path
+7. passes supported snapshots back to Containerlab
+8. runs one native Containerlab deploy
+9. runs the independent health check
+
+There is no preliminary deploy that is destroyed before the real restore deploy.
+
+## Recovery modes
+
+`rebuild` keeps the source tree and supported native configuration-save output. Automatic reuse of saved configuration depends on how the topology is written.
+
+`snapshot` also keeps Containerlab-supported vrnetlab snapshots. Unsupported node kinds may still start fresh.
+
+`ephemeral` keeps source intent only.
+
+## Questions for upstream review
+
+1. If the Containerlab execution host is disposable, is it reasonable for HybridOps to retain Containerlab-native recovery data off-host before deleting that host, provided Containerlab still creates and restores the data?
+2. Should HybridOps treat those recovery files as opaque and always hand restore back to Containerlab rather than interpreting them?

--- a/blueprints/gcp/containerlab@v1/MAINTAINER_REVIEW_DRAFT.md
+++ b/blueprints/gcp/containerlab@v1/MAINTAINER_REVIEW_DRAFT.md
@@ -1,0 +1,32 @@
+# DRAFT, DO NOT PUBLISH
+
+Suggested issue title:
+
+`Where should off-host recovery sit when the Containerlab host is disposable?`
+
+## Draft body
+
+I am integrating Containerlab with a GCP host lifecycle where the execution VM can be created for a lab run and removed afterwards.
+
+Containerlab still owns the lab itself: `.clab.yml`, validation, nodes and links, deploy and convergence, native config save, supported vrnetlab snapshot and restore, generated lab data, and supported startup-config or licence handling.
+
+HybridOps manages the host around it. Before deleting that host, HybridOps can require the selected Containerlab recovery data to be copied off-host and checksum-verified. On rebuild, the retained data is handed back to Containerlab rather than interpreted by HybridOps.
+
+The integration also uses Containerlab's own `CLAB_LABDIR_BASE` so generated `clab-*` data stays separate from the operator topology and source tree.
+
+```text
+Containerlab: topology / validation / convergence / native recovery
+                         |
+---------------- ownership boundary ----------------
+                         |
+HybridOps: GCP host / readiness / off-host copy / rebuild / verification
+```
+
+I would value a view on two points:
+
+1. If the Containerlab host is disposable, is it reasonable for HybridOps to require Containerlab-native recovery data to be retained off-host before that host is deleted?
+2. Should HybridOps treat those recovery files as opaque and always hand restore back to Containerlab?
+
+A short correction or counterexample is enough. There is no need to review the whole HybridOps repository.
+
+Implementation references will be added only after the real GCP preserve, destroy, and fresh-host recovery test has passed.

--- a/blueprints/gcp/containerlab@v1/README.md
+++ b/blueprints/gcp/containerlab@v1/README.md
@@ -1,0 +1,158 @@
+# GCP Containerlab v1
+
+This blueprint runs Containerlab on private GCP compute that HybridOps can remove after the selected recovery state has been copied off-host and verified.
+
+## Responsibilities
+
+Containerlab remains responsible for:
+
+- `.clab.yml` topology semantics
+- nodes and links
+- topology validation and convergence
+- native configuration save
+- supported vrnetlab snapshot and restore
+- generated lab runtime state
+- supported startup-config and licence handling
+
+HybridOps manages the GCP host around it: private infrastructure, KVM readiness, Containerlab version verification, recovery policy, off-host retention, teardown and rebuild order, cost context, and run evidence.
+
+HybridOps does not rewrite the topology or replace Containerlab recovery behaviour.
+
+## Feature status
+
+This capability is under pre-release validation. For environment acceptance, use the installable candidate produced by the current pull request CI run. A candidate is a test build, not a release.
+
+## Prepare the runtime blueprint
+
+Create and edit the environment copy:
+
+```bash
+ref=gcp/containerlab@v1
+hyops blueprint init --env <env> --ref "$ref"
+hyops blueprint edit --env <env> --ref "$ref"
+```
+
+Set:
+
+```text
+gcp_containerlab_lab.inputs.containerlab_lab_source_dir
+```
+
+to an absolute controller-side directory containing `lab.clab.yml` and any relative local files it uses.
+
+HybridOps copies the source tree without converting it to another topology format.
+
+Containerlab-generated `clab-*` data stays outside that source tree using native `CLAB_LABDIR_BASE`:
+
+```text
+/var/lib/hybridops/containerlab/labdirs
+```
+
+If the topology uses proprietary or VM-backed NOS images, provide them from an image source the operator is authorised to use and that the managed host can reach. HybridOps does not distribute those images.
+
+Remote startup-config or licence assets already supported by Containerlab should remain at their existing authoritative location and be referenced natively.
+
+## Reference host
+
+The shipped profile uses:
+
+- `n2-highmem-8`
+- 8 vCPU
+- 64 GB RAM
+- Ubuntu 22.04
+- 128 GB boot disk
+- private IP
+- nested virtualisation
+- IAP/SSH access
+
+This is a reference profile, not a sizing recommendation for every lab.
+
+Containerlab `0.78.0` is pinned. HybridOps verifies the package against an explicit digest, a known pinned digest when available, or the release checksum file, then records the actual downloaded SHA-256.
+
+## Deploy and rebuild flow
+
+The deploy order is:
+
+1. private GCP network
+2. private GCP VM
+3. Containerlab runtime and KVM check
+4. native Containerlab deploy
+5. independent health check
+6. recovery check
+
+The recovery check is last in deploy order, so reverse-order destroy reaches it before the lab, runtime, or VM is removed.
+
+During destroy or rebuild HybridOps:
+
+1. asks Containerlab for the native save output required by the selected policy
+2. creates an immutable recovery archive
+3. copies the archive to the HybridOps controller
+4. verifies the SHA-256 off-host
+5. writes the latest pointer, checksum, and metadata
+6. allows Containerlab cleanup and GCP teardown only after verification passes
+
+On a fresh host, HybridOps verifies the latest recovery metadata, imports the archive, restores the managed source path, and then runs one native Containerlab deploy. Supported vrnetlab snapshots are handed back through `containerlab deploy --restore-all`.
+
+There is no fresh deploy followed by destroy and a second restore deploy.
+
+## Recovery modes
+
+### `rebuild`
+
+Default. Keeps the source tree and supported native `save --copy` output.
+
+Saved configuration is automatically reused only where the topology is already written to consume that native output. HybridOps does not rewrite startup-config references.
+
+### `snapshot`
+
+Also requests supported vrnetlab snapshots. Runtime-state recovery applies only to node kinds that Containerlab supports for this operation.
+
+### `ephemeral`
+
+Keeps source intent only. It does not preserve runtime state.
+
+These modes are not a universal Containerlab backup mechanism.
+
+## Off-host storage
+
+Recovery archives are stored under the HybridOps runtime on the controller, outside the disposable GCP VM. This proves separation from the host being deleted, but it is not a separate backup service. Protect the controller storage according to the environment's own backup policy.
+
+The timestamped archive is the retained object. `latest.tar.gz` is a symlink with matching checksum and metadata, so the archive bytes are not duplicated just to maintain a stable pointer.
+
+Recovery archives may contain configuration or licence material and should remain private.
+
+## Cost visibility
+
+The blueprint shows the estimated fixed VM and boot-disk cost, resource age, access-session cost context, and the effect of teardown on declared resources.
+
+The estimate does not include every usage charge, discount, credit, tax, or external service. GCP billing is authoritative for actual spend.
+
+Removing the VM does not imply zero idle cost. Retained recovery storage, registries, or other resources may still be billable.
+
+## Private host access
+
+`hyops blueprint access` opens an IAP-backed local SSH forward. The default local endpoint is:
+
+```text
+127.0.0.1:2222
+```
+
+## Validation status
+
+The feature is still unmerged.
+
+Completed before the real GCP run:
+
+- repository quality and regression checks
+- installable candidate build and installation checks
+- native non-GCP Containerlab 0.78.0 lifecycle smoke
+
+Still required before an end-to-end GCP lifecycle claim:
+
+- private GCP VM and IAP access
+- KVM readiness
+- native Containerlab deploy and health check
+- off-host recovery verification before original VM deletion
+- fresh VM with a different resource identity
+- recovery import and one native Containerlab deploy
+- final health check and cleanup

--- a/blueprints/gcp/containerlab@v1/blueprint.yml
+++ b/blueprints/gcp/containerlab@v1/blueprint.yml
@@ -1,0 +1,222 @@
+api_version: hybridops/v1
+kind: BlueprintSpec
+
+blueprint_ref: "gcp/containerlab@v1"
+mode: "hybrid"
+
+metadata:
+  title: "GCP Disposable Containerlab Lab"
+  description: "Provision private high-resource Containerlab compute on demand and require a verified off-host recovery set before managed-host teardown."
+  outcome: "A private Containerlab host runs the operator's unchanged topology, and HybridOps verifies off-host recovery state before the host can be removed."
+  ready_message: "Containerlab cloud lab ready"
+
+policy:
+  fail_fast: true
+  evidence_required: true
+  ipam_authority: "none"
+
+access:
+  type: "gcp-iap-ssh-forward"
+  state_ref: "platform/gcp/platform-vm#gcp_containerlab_vm"
+  remote_port: 22
+  local_port: 2222
+  open_browser: false
+  ssh_user: "opsadmin"
+  ssh_key_file: "~/.ssh/id_ed25519"
+  offer_destroy_on_close: true
+
+steps:
+  - id: gcp_containerlab_network
+    module_ref: "platform/gcp/lab-network"
+    execution_profile: "gcp-local@v1.0"
+    state_instance: "gcp_containerlab_network"
+    action: "deploy"
+    phase: "bootstrap"
+    with_deps: false
+    skip_if_state_ok: true
+    verify_state_on_skip: true
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      name_prefix: "platform"
+      context_id: "containerlab"
+      subnetwork_cidr: "10.80.70.0/24"
+
+  - id: gcp_containerlab_vm
+    module_ref: "platform/gcp/platform-vm"
+    execution_profile: "gcp-local@v1.0"
+    state_instance: "gcp_containerlab_vm"
+    action: "deploy"
+    phase: "bootstrap"
+    requires:
+      - gcp_containerlab_network
+    with_deps: true
+    skip_if_state_ok: true
+    verify_state_on_skip: true
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      name_prefix: "platform"
+      context_id: "containerlab"
+      network_state_ref: "platform/gcp/lab-network#gcp_containerlab_network"
+      subnetwork_output_key: "subnetwork_name"
+      zone: ""
+      zone_from_init_region: true
+      machine_type: "n2-highmem-8"
+      boot_disk_size_gb: 128
+      boot_disk_type: "pd-standard"
+      source_image_project: "ubuntu-os-cloud"
+      source_image_family: "ubuntu-2204-lts"
+      assign_public_ip: false
+      enable_nested_virtualization: true
+      ssh_username: "opsadmin"
+      ssh_keys_from_init: true
+      post_apply_ssh_readiness:
+        enabled: true
+        required: true
+        target_user: "opsadmin"
+        connectivity_wait_s: 90
+      tags:
+        - "platform"
+        - "gcp"
+        - "containerlab"
+        - "lab"
+        - "allow-iap-ssh"
+      labels:
+        role: "containerlab"
+        workload: "network-lab"
+        lifecycle: "disposable"
+      vms:
+        containerlab-01:
+          role: "containerlab"
+
+  - id: gcp_containerlab_runtime
+    module_ref: "platform/linux/containerlab"
+    state_instance: "gcp_containerlab_runtime"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_containerlab_vm
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_containerlab_vm"
+      inventory_vm_groups:
+        targets:
+          - "containerlab-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      containerlab_version: "0.78.0"
+      containerlab_install_docker: true
+      containerlab_operator_user: "opsadmin"
+      # Empty means HybridOps verifies against the official pinned-release
+      # checksums.txt manifest and records the actual downloaded SHA-256.
+      containerlab_package_checksum: ""
+      containerlab_require_kvm: true
+
+  - id: gcp_containerlab_lab
+    module_ref: "platform/linux/containerlab-lab"
+    state_instance: "gcp_containerlab_lab"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_containerlab_runtime
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_containerlab_vm"
+      inventory_vm_groups:
+        targets:
+          - "containerlab-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      # Set in a runtime overlay for a first deployment. On a later deployment,
+      # a verified latest recovery bundle can supply the archived source tree.
+      containerlab_lab_source_dir: ""
+      containerlab_lab_topology_relpath: "lab.clab.yml"
+      containerlab_lab_remote_dir: "/var/lib/hybridops/containerlab/labs/gcp-containerlab"
+      # Native Containerlab-generated clab-* runtime artifacts stay outside the
+      # authoritative source tree so source preservation does not absorb them.
+      containerlab_lab_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+      containerlab_lab_required_images: []
+      containerlab_lab_pull_missing_images: false
+      containerlab_lab_restore_latest: true
+      containerlab_lab_restore_require_source_match: true
+
+  - id: gcp_containerlab_healthcheck
+    module_ref: "platform/linux/containerlab-healthcheck"
+    state_instance: "gcp_containerlab_healthcheck"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_containerlab_lab
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_containerlab_vm"
+      inventory_vm_groups:
+        targets:
+          - "containerlab-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      containerlab_healthcheck_expected_version: "0.78.0"
+      containerlab_healthcheck_require_kvm: true
+      containerlab_healthcheck_topology_path: "/var/lib/hybridops/containerlab/labs/gcp-containerlab/lab.clab.yml"
+      containerlab_healthcheck_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+      containerlab_healthcheck_require_deployed_lab: true
+
+  - id: gcp_containerlab_recovery_guard
+    module_ref: "platform/linux/containerlab-recovery"
+    state_instance: "gcp_containerlab_recovery_guard"
+    action: "deploy"
+    phase: "operations"
+    requires:
+      - gcp_containerlab_healthcheck
+    with_deps: false
+    skip_if_state_ok: false
+    contracts:
+      addressing_mode: "static"
+    inputs:
+      inventory_state_ref: "platform/gcp/platform-vm#gcp_containerlab_vm"
+      inventory_vm_groups:
+        targets:
+          - "containerlab-01"
+      target_user: "opsadmin"
+      target_port: 22
+      ssh_private_key_file: "~/.ssh/id_ed25519"
+      ssh_access_mode: "gcp-iap"
+      connectivity_wait_s: 90
+      become: true
+      become_user: "root"
+      containerlab_recovery_action: "arm"
+      # rebuild retains the declared source tree plus supported config-save
+      # output. snapshot additionally requests supported vrnetlab snapshots.
+      containerlab_recovery_mode: "rebuild"
+      containerlab_recovery_source_root: "/var/lib/hybridops/containerlab/labs/gcp-containerlab"
+      containerlab_recovery_topology_relpath: "lab.clab.yml"
+      containerlab_recovery_image_refs: []
+      containerlab_recovery_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+      containerlab_recovery_save_configs: true
+      containerlab_recovery_save_configs_required: false
+      containerlab_recovery_include_lab_dir: false

--- a/blueprints/gcp/containerlab@v1/examples/two-node-linux/lab.clab.yml
+++ b/blueprints/gcp/containerlab@v1/examples/two-node-linux/lab.clab.yml
@@ -1,0 +1,14 @@
+name: hyops-two-node
+
+topology:
+  nodes:
+    leaf1:
+      kind: linux
+      image: alpine:3.21
+    leaf2:
+      kind: linux
+      image: alpine:3.21
+  links:
+    - endpoints:
+        - "leaf1:eth1"
+        - "leaf2:eth1"

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -3528,7 +3528,7 @@ def run_rebuild(ns) -> int:
             "json": False,
             "execute": True,
             "archive_before_destroy": False,
-            "skip_archive": True,
+            "skip_archive": bool(payload.get("archive_before_destroy")),
         }
     )
     print("rebuild_phase=destroy status=running")

--- a/hyops/blueprint/tests/test_gcp_containerlab.py
+++ b/hyops/blueprint/tests/test_gcp_containerlab.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+from unittest import TestCase
+
+from hyops.blueprint.schema import load_blueprint, validate_blueprint
+
+
+class GCPContainerlabBlueprintTest(TestCase):
+    def setUp(self) -> None:
+        root = Path(__file__).resolve().parents[3]
+        path = root / "blueprints" / "gcp" / "containerlab@v1" / "blueprint.yml"
+        self.blueprint = validate_blueprint(load_blueprint(path), path)
+
+    def test_private_six_stage_chain(self) -> None:
+        self.assertEqual(
+            [step["id"] for step in self.blueprint["steps"]],
+            [
+                "gcp_containerlab_network",
+                "gcp_containerlab_vm",
+                "gcp_containerlab_runtime",
+                "gcp_containerlab_lab",
+                "gcp_containerlab_healthcheck",
+                "gcp_containerlab_recovery_guard",
+            ],
+        )
+        vm_inputs = self.blueprint["steps"][1]["inputs"]
+        self.assertFalse(vm_inputs["assign_public_ip"])
+        self.assertTrue(vm_inputs["enable_nested_virtualization"])
+        self.assertEqual(vm_inputs["machine_type"], "n2-highmem-8")
+
+    def test_operations_use_iap(self) -> None:
+        for step in self.blueprint["steps"][2:]:
+            self.assertEqual(step["inputs"]["ssh_access_mode"], "gcp-iap")
+
+    def test_containerlab_remains_native_topology_boundary(self) -> None:
+        lab_step = self.blueprint["steps"][3]
+        lab = lab_step["inputs"]
+        self.assertEqual(lab_step["action"], "deploy")
+        self.assertEqual(lab["containerlab_lab_topology_relpath"], "lab.clab.yml")
+        self.assertEqual(lab["containerlab_lab_required_images"], [])
+        self.assertFalse(lab["containerlab_lab_pull_missing_images"])
+        self.assertTrue(lab["containerlab_lab_restore_latest"])
+
+    def test_source_tree_is_separate_from_native_generated_labdir(self) -> None:
+        lab = self.blueprint["steps"][3]["inputs"]
+        health = self.blueprint["steps"][4]["inputs"]
+        recovery = self.blueprint["steps"][5]["inputs"]
+
+        source_root = lab["containerlab_lab_remote_dir"]
+        labdir_base = lab["containerlab_lab_labdir_base"]
+        self.assertNotEqual(source_root.rstrip("/"), labdir_base.rstrip("/"))
+        self.assertEqual(
+            labdir_base,
+            "/var/lib/hybridops/containerlab/labdirs",
+        )
+        self.assertEqual(
+            health["containerlab_healthcheck_labdir_base"],
+            labdir_base,
+        )
+        self.assertEqual(
+            recovery["containerlab_recovery_labdir_base"],
+            labdir_base,
+        )
+
+    def test_recovery_guard_is_last_and_automatic(self) -> None:
+        self.assertFalse(self.blueprint["archive_before_destroy"])
+        recovery = self.blueprint["steps"][5]
+        inputs = recovery["inputs"]
+        self.assertEqual(recovery["requires"], ["gcp_containerlab_healthcheck"])
+        self.assertEqual(inputs["containerlab_recovery_action"], "arm")
+        self.assertEqual(inputs["containerlab_recovery_mode"], "rebuild")
+        self.assertEqual(
+            inputs["containerlab_recovery_source_root"],
+            "/var/lib/hybridops/containerlab/labs/gcp-containerlab",
+        )
+        self.assertFalse(inputs["containerlab_recovery_include_lab_dir"])
+
+    def test_runtime_and_recovery_require_kvm_capable_host(self) -> None:
+        runtime = self.blueprint["steps"][2]["inputs"]
+        health = self.blueprint["steps"][4]["inputs"]
+        self.assertEqual(runtime["containerlab_version"], "0.78.0")
+        self.assertEqual(runtime["containerlab_package_checksum"], "")
+        self.assertTrue(runtime["containerlab_require_kvm"])
+        self.assertEqual(health["containerlab_healthcheck_expected_version"], "0.78.0")
+        self.assertTrue(health["containerlab_healthcheck_require_kvm"])
+
+    def test_access_is_private_ssh_endpoint_with_destroy_offer(self) -> None:
+        access = self.blueprint["access"]
+        self.assertEqual(access["type"], "gcp-iap-ssh-forward")
+        self.assertEqual(access["remote_port"], 22)
+        self.assertFalse(access["open_browser"])
+        self.assertTrue(access["offer_destroy_on_close"])

--- a/hyops/blueprint/tests/test_rebuild_archive_mode.py
+++ b/hyops/blueprint/tests/test_rebuild_archive_mode.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.blueprint.command import run_rebuild
+
+
+class BlueprintRebuildArchiveModeTest(TestCase):
+    def test_rebuild_without_generic_archive_does_not_set_skip_archive(self) -> None:
+        payload = {
+            "blueprint_ref": "gcp/containerlab@v1",
+            "mode": "hybrid",
+            "order": [],
+            "steps": [],
+            "archive_before_destroy": {},
+        }
+        ns = SimpleNamespace(
+            execute=True,
+            json=False,
+            yes=True,
+            root=None,
+            env="containerlab-test",
+            ref="gcp/containerlab@v1",
+            file="",
+            blueprints_root="blueprints",
+            module_root="modules",
+            out_dir=None,
+            deps_inputs_dir=None,
+            deps_force=False,
+            skip_preflight=False,
+        )
+
+        runtime_paths = SimpleNamespace(
+            root=Path("/tmp/hyops-containerlab-test"),
+            logs_dir=Path("/tmp/hyops-containerlab-test/logs"),
+        )
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=payload),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=runtime_paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command.new_run_id", return_value="rebuild-test"),
+            patch("hyops.blueprint.command.run_destroy", return_value=0) as destroy,
+            patch("hyops.blueprint.command.run_deploy", return_value=0),
+        ):
+            rc = run_rebuild(ns)
+
+        self.assertEqual(rc, 0)
+        destroy_ns = destroy.call_args.args[0]
+        self.assertFalse(destroy_ns.skip_archive)
+
+    def test_rebuild_with_generic_archive_keeps_skip_archive(self) -> None:
+        payload = {
+            "blueprint_ref": "gcp/gns3@v1",
+            "mode": "hybrid",
+            "order": [],
+            "steps": [],
+            "archive_before_destroy": {
+                "module_ref": "platform/linux/gns3-lab-archive",
+                "state_instance": "gns3_archive",
+            },
+        }
+        ns = SimpleNamespace(
+            execute=True,
+            json=False,
+            yes=True,
+            root=None,
+            env="gns3-test",
+            ref="gcp/gns3@v1",
+            file="",
+            blueprints_root="blueprints",
+            module_root="modules",
+            out_dir=None,
+            deps_inputs_dir=None,
+            deps_force=False,
+            skip_preflight=False,
+        )
+
+        runtime_paths = SimpleNamespace(
+            root=Path("/tmp/hyops-gns3-test"),
+            logs_dir=Path("/tmp/hyops-gns3-test/logs"),
+        )
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=payload),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=runtime_paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command.new_run_id", return_value="rebuild-test"),
+            patch("hyops.blueprint.command.run_destroy", return_value=0) as destroy,
+            patch("hyops.blueprint.command.run_deploy", return_value=0),
+        ):
+            rc = run_rebuild(ns)
+
+        self.assertEqual(rc, 0)
+        destroy_ns = destroy.call_args.args[0]
+        self.assertTrue(destroy_ns.skip_archive)

--- a/hyops/tests/test_containerlab_modules.py
+++ b/hyops/tests/test_containerlab_modules.py
@@ -79,6 +79,44 @@ class ContainerlabModuleContractTest(TestCase):
         )
         self.assertTrue(path.is_file())
 
+    def test_destroy_wrappers_use_private_lifecycle_actions(self) -> None:
+        stack_root = (
+            self.root
+            / "packs"
+            / "config"
+            / "ansible"
+            / "linux"
+            / "common"
+            / "platform"
+        )
+        recovery_destroy = (
+            stack_root
+            / "63-containerlab-recovery@v1.0"
+            / "stack"
+            / "destroy.playbook.yml"
+        ).read_text(encoding="utf-8")
+        lab_destroy = (
+            stack_root
+            / "61-containerlab-lab@v1.0"
+            / "stack"
+            / "destroy.playbook.yml"
+        ).read_text(encoding="utf-8")
+        lab_apply = (
+            stack_root
+            / "61-containerlab-lab@v1.0"
+            / "stack"
+            / "playbook.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("_containerlab_recovery_action: export", recovery_destroy)
+        self.assertIn("_containerlab_recovery_topology_path:", recovery_destroy)
+        self.assertIn("_containerlab_recovery_controller_dir:", recovery_destroy)
+        self.assertNotIn("\n        containerlab_recovery_action: export", recovery_destroy)
+        self.assertIn("_containerlab_lab_action: destroy", lab_destroy)
+        self.assertIn("_containerlab_lab_destroy_all: true", lab_destroy)
+        self.assertNotIn("\n            containerlab_lab_action: destroy", lab_destroy)
+        self.assertIn("_containerlab_recovery_action: import", lab_apply)
+
     def test_containerlab_pack_role_bindings_are_not_self_recursive(self) -> None:
         stack_paths = [
             self.root
@@ -117,4 +155,4 @@ class ContainerlabModuleContractTest(TestCase):
         path = self.root / "tools" / "setup" / "requirements" / "ansible.hybridops.git.json"
         payload = json.loads(path.read_text(encoding="utf-8"))
         app = next(item for item in payload["collections"] if item["name"] == "hybridops.app")
-        self.assertEqual(app["ref"], "22863037fe3de85c0fd7d82f0af1ac5416f346f9")
+        self.assertEqual(app["ref"], "d34f53bb1e3f2960ea718b53f6eb45853dea2ef0")

--- a/hyops/tests/test_containerlab_modules.py
+++ b/hyops/tests/test_containerlab_modules.py
@@ -1,0 +1,120 @@
+import json
+import re
+from pathlib import Path
+from unittest import TestCase
+
+import yaml
+
+
+class ContainerlabModuleContractTest(TestCase):
+    def setUp(self) -> None:
+        self.root = Path(__file__).resolve().parents[2]
+
+    def _spec(self, name: str) -> dict:
+        path = self.root / "modules" / "platform" / "linux" / name / "spec.yml"
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    def test_runtime_delegates_to_app_collection(self) -> None:
+        spec = self._spec("containerlab")
+        defaults = spec["inputs"]["defaults"]
+        self.assertEqual(spec["execution"]["driver"], "config/ansible")
+        self.assertEqual(defaults["containerlab_role_fqcn"], "hybridops.app.containerlab")
+        self.assertEqual(defaults["containerlab_version"], "0.78.0")
+        self.assertTrue(defaults["containerlab_require_kvm"])
+
+    def test_healthcheck_tracks_same_pinned_runtime(self) -> None:
+        spec = self._spec("containerlab-healthcheck")
+        defaults = spec["inputs"]["defaults"]
+        self.assertEqual(defaults["containerlab_healthcheck_expected_version"], "0.78.0")
+
+    def test_native_labdir_contract_is_shared_and_separate_from_source(self) -> None:
+        lab = self._spec("containerlab-lab")["inputs"]["defaults"]
+        health = self._spec("containerlab-healthcheck")["inputs"]["defaults"]
+        recovery = self._spec("containerlab-recovery")["inputs"]["defaults"]
+
+        labdir_base = lab["containerlab_lab_labdir_base"]
+        self.assertEqual(labdir_base, "/var/lib/hybridops/containerlab/labdirs")
+        self.assertNotEqual(
+            lab["containerlab_lab_remote_dir"].rstrip("/"),
+            labdir_base.rstrip("/"),
+        )
+        self.assertEqual(health["containerlab_healthcheck_labdir_base"], labdir_base)
+        self.assertEqual(recovery["containerlab_recovery_labdir_base"], labdir_base)
+
+    def test_lab_keeps_native_source_and_restore_contract(self) -> None:
+        spec = self._spec("containerlab-lab")
+        defaults = spec["inputs"]["defaults"]
+        self.assertEqual(defaults["containerlab_lab_topology_relpath"], "lab.clab.yml")
+        self.assertEqual(defaults["containerlab_lab_required_images"], [])
+        self.assertFalse(defaults["containerlab_lab_pull_missing_images"])
+        self.assertFalse(defaults["containerlab_lab_restore_latest"])
+        self.assertEqual(
+            defaults["containerlab_lab_recovery_role_fqcn"],
+            "hybridops.app.containerlab_recovery",
+        )
+
+    def test_recovery_publishes_destroy_gate(self) -> None:
+        spec = self._spec("containerlab-recovery")
+        outputs = set(spec["outputs"]["publish"])
+        defaults = spec["inputs"]["defaults"]
+        self.assertEqual(defaults["containerlab_recovery_action"], "arm")
+        self.assertEqual(defaults["containerlab_recovery_mode"], "rebuild")
+        self.assertIn("containerlab_recovery_latest_path", outputs)
+        self.assertIn("containerlab_recovery_safe_for_host_destroy", outputs)
+        self.assertIn("containerlab_recovery_labdir_base", outputs)
+        self.assertFalse(defaults["containerlab_recovery_include_lab_dir"])
+
+    def test_recovery_pack_has_destroy_gate_entrypoint(self) -> None:
+        path = (
+            self.root
+            / "packs"
+            / "config"
+            / "ansible"
+            / "linux"
+            / "common"
+            / "platform"
+            / "63-containerlab-recovery@v1.0"
+            / "stack"
+            / "destroy.playbook.yml"
+        )
+        self.assertTrue(path.is_file())
+
+    def test_containerlab_pack_role_bindings_are_not_self_recursive(self) -> None:
+        stack_paths = [
+            self.root
+            / "packs"
+            / "config"
+            / "ansible"
+            / "linux"
+            / "common"
+            / "platform"
+            / pack
+            / "stack"
+            / filename
+            for pack, filename in (
+                ("60-containerlab-runtime@v1.0", "playbook.yml"),
+                ("61-containerlab-lab@v1.0", "playbook.yml"),
+                ("61-containerlab-lab@v1.0", "destroy.playbook.yml"),
+                ("62-containerlab-healthcheck@v1.0", "playbook.yml"),
+                ("63-containerlab-recovery@v1.0", "playbook.yml"),
+                ("63-containerlab-recovery@v1.0", "destroy.playbook.yml"),
+            )
+        ]
+        direct_self_binding = re.compile(
+            r"(?m)^\s+(containerlab_[a-z0-9_]+):\s+"
+            r"[\"']?\{\{\s*\1(?:\s*\|[^}]*)?\s*\}\}[\"']?\s*$"
+        )
+
+        violations: list[str] = []
+        for path in stack_paths:
+            text = path.read_text(encoding="utf-8")
+            for match in direct_self_binding.finditer(text):
+                violations.append(f"{path.relative_to(self.root)}: {match.group(0).strip()}")
+
+        self.assertEqual(violations, [])
+
+    def test_development_pin_targets_current_containerlab_collection_commit(self) -> None:
+        path = self.root / "tools" / "setup" / "requirements" / "ansible.hybridops.git.json"
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        app = next(item for item in payload["collections"] if item["name"] == "hybridops.app")
+        self.assertEqual(app["ref"], "22863037fe3de85c0fd7d82f0af1ac5416f346f9")

--- a/hyops/tests/test_containerlab_modules.py
+++ b/hyops/tests/test_containerlab_modules.py
@@ -155,4 +155,4 @@ class ContainerlabModuleContractTest(TestCase):
         path = self.root / "tools" / "setup" / "requirements" / "ansible.hybridops.git.json"
         payload = json.loads(path.read_text(encoding="utf-8"))
         app = next(item for item in payload["collections"] if item["name"] == "hybridops.app")
-        self.assertEqual(app["ref"], "d34f53bb1e3f2960ea718b53f6eb45853dea2ef0")
+        self.assertEqual(app["ref"], "1ca8d662f574ffa69c0d24043af058cbe5833f27")

--- a/modules/platform/linux/containerlab-healthcheck/README.md
+++ b/modules/platform/linux/containerlab-healthcheck/README.md
@@ -1,0 +1,5 @@
+# platform/linux/containerlab-healthcheck
+
+Checks the Containerlab runtime, pinned version, KVM when required, declared image references, topology validation, and the deployed lab state.
+
+The module verifies that the expected lab is actually running without replacing Containerlab's own convergence or node-health behaviour.

--- a/modules/platform/linux/containerlab-healthcheck/examples/inputs.min.yml
+++ b/modules/platform/linux/containerlab-healthcheck/examples/inputs.min.yml
@@ -1,0 +1,9 @@
+# Minimal Containerlab healthcheck example for a deployed lab.
+
+target_host: "10.80.70.10"
+target_user: "opsadmin"
+containerlab_healthcheck_expected_version: "0.78.0"
+containerlab_healthcheck_require_kvm: true
+containerlab_healthcheck_topology_path: "/var/lib/hybridops/containerlab/labs/example/lab.clab.yml"
+containerlab_healthcheck_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+containerlab_healthcheck_require_deployed_lab: true

--- a/modules/platform/linux/containerlab-healthcheck/spec.yml
+++ b/modules/platform/linux/containerlab-healthcheck/spec.yml
@@ -1,0 +1,64 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/containerlab-healthcheck"
+
+metadata:
+  title: "Linux Containerlab Healthcheck"
+  description: "Verify the execution envelope and inspect a deployed Containerlab lab using native commands."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+    required_env: []
+    required_env_destroy: []
+    load_vault_env: false
+    containerlab_healthcheck_role_fqcn: "hybridops.app.containerlab_healthcheck"
+    containerlab_healthcheck_expected_version: "0.78.0"
+    containerlab_healthcheck_require_kvm: true
+    containerlab_healthcheck_topology_path: ""
+    containerlab_healthcheck_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+    containerlab_healthcheck_require_deployed_lab: true
+    containerlab_healthcheck_required_images: []
+    containerlab_healthcheck_pull_missing_images: false
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/62-containerlab-healthcheck@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.containerlab.health
+    - containerlab_health_status
+    - containerlab_version
+    - containerlab_kvm_status
+    - containerlab_health_labdir_base
+
+probes: []
+constraints: []

--- a/modules/platform/linux/containerlab-lab/README.md
+++ b/modules/platform/linux/containerlab-lab/README.md
@@ -1,0 +1,7 @@
+# platform/linux/containerlab-lab
+
+Stages a user-owned Containerlab source directory on the managed host and runs the requested lab action through Containerlab.
+
+The `.clab.yml` file remains authoritative and is copied unchanged with any relative local files it references. HybridOps does not convert it into a second topology format.
+
+`containerlab_lab_source_dir` is a controller-side path and should be set in the runtime blueprint. Proprietary NOS images should stay out of public HybridOps source and be supplied from an image source the operator is authorised to use.

--- a/modules/platform/linux/containerlab-lab/examples/inputs.min.yml
+++ b/modules/platform/linux/containerlab-lab/examples/inputs.min.yml
@@ -1,0 +1,8 @@
+# Minimal Containerlab lab example for an existing managed host.
+
+target_host: "10.80.70.10"
+target_user: "opsadmin"
+containerlab_lab_source_dir: "/srv/labs/example"
+containerlab_lab_topology_relpath: "lab.clab.yml"
+containerlab_lab_remote_dir: "/var/lib/hybridops/containerlab/labs/example"
+containerlab_lab_labdir_base: "/var/lib/hybridops/containerlab/labdirs"

--- a/modules/platform/linux/containerlab-lab/spec.yml
+++ b/modules/platform/linux/containerlab-lab/spec.yml
@@ -1,0 +1,74 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/containerlab-lab"
+
+metadata:
+  title: "Linux Containerlab Lab"
+  description: "Stage an unchanged Containerlab lab source tree and delegate native lab operations to Containerlab."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+    required_env: []
+    required_env_destroy: []
+    load_vault_env: false
+    containerlab_lab_role_fqcn: "hybridops.app.containerlab_lab"
+    containerlab_lab_recovery_role_fqcn: "hybridops.app.containerlab_recovery"
+    containerlab_lab_action: "deploy"
+    containerlab_lab_source_dir: ""
+    containerlab_lab_topology_relpath: "lab.clab.yml"
+    containerlab_lab_remote_dir: "/var/lib/hybridops/containerlab/labs/gcp-containerlab"
+    containerlab_lab_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+    containerlab_lab_topology_path: ""
+    containerlab_lab_restore_all_dir: ""
+    containerlab_lab_cleanup: false
+    containerlab_lab_required_images: []
+    containerlab_lab_pull_missing_images: false
+    containerlab_lab_restore_latest: false
+    containerlab_lab_restore_latest_path: ""
+    containerlab_lab_restore_require_source_match: true
+    containerlab_lab_recovery_remote_root: "/var/lib/hybridops/containerlab/recovery"
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/61-containerlab-lab@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.containerlab
+    - containerlab_lab_action
+    - containerlab_lab_topology_path
+    - containerlab_lab_source_staged
+    - containerlab_lab_labdir_base
+    - containerlab_lab_restore_all_dir
+    - containerlab_lab_restored_from_latest
+
+probes: []
+constraints: []

--- a/modules/platform/linux/containerlab-recovery/README.md
+++ b/modules/platform/linux/containerlab-recovery/README.md
@@ -1,0 +1,9 @@
+# platform/linux/containerlab-recovery
+
+Controls the recovery check that runs before a disposable Containerlab host is removed.
+
+During destroy, HybridOps asks Containerlab for the native save output required by the selected policy, creates an archive, copies it off-host, verifies the checksum, and only then allows host teardown to continue.
+
+On a later deploy or rebuild, HybridOps imports the latest verified archive before the final Containerlab deploy. If the archive contains supported vrnetlab snapshots, they are passed back through `containerlab deploy --restore-all`. HybridOps does not interpret or rebuild the snapshot contents.
+
+The GCP reference blueprint uses `rebuild` mode by default. `snapshot` and `ephemeral` retain different sets of state.

--- a/modules/platform/linux/containerlab-recovery/examples/inputs.min.yml
+++ b/modules/platform/linux/containerlab-recovery/examples/inputs.min.yml
@@ -1,0 +1,9 @@
+# Minimal recovery-guard example for a disposable Containerlab host.
+
+target_host: "10.80.70.10"
+target_user: "opsadmin"
+containerlab_recovery_action: "arm"
+containerlab_recovery_mode: "rebuild"
+containerlab_recovery_source_root: "/var/lib/hybridops/containerlab/labs/example"
+containerlab_recovery_topology_relpath: "lab.clab.yml"
+containerlab_recovery_labdir_base: "/var/lib/hybridops/containerlab/labdirs"

--- a/modules/platform/linux/containerlab-recovery/spec.yml
+++ b/modules/platform/linux/containerlab-recovery/spec.yml
@@ -1,0 +1,87 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/containerlab-recovery"
+
+metadata:
+  title: "Linux Containerlab Recovery Guard"
+  description: "Guard disposable-host teardown on verified off-host retention of a declared Containerlab-native recovery set."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+    required_env: []
+    required_env_destroy: []
+    load_vault_env: false
+    containerlab_recovery_role_fqcn: "hybridops.app.containerlab_recovery"
+    containerlab_recovery_action: "arm"
+    containerlab_recovery_mode: "rebuild"
+    containerlab_recovery_topology_path: ""
+    containerlab_recovery_source_root: ""
+    containerlab_recovery_topology_relpath: ""
+    containerlab_recovery_image_refs: []
+    containerlab_recovery_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+    containerlab_recovery_controller_dir: ""
+    containerlab_recovery_latest_path: ""
+    containerlab_recovery_path: ""
+    containerlab_recovery_archive_path: ""
+    containerlab_recovery_expected_sha256: ""
+    containerlab_recovery_overwrite: false
+    containerlab_recovery_save_configs: true
+    containerlab_recovery_save_configs_required: false
+    containerlab_recovery_snapshot_timeout: "5m"
+    containerlab_recovery_snapshot_node_filter: ""
+    containerlab_recovery_include_lab_dir: false
+    containerlab_recovery_lab_dir: ""
+    containerlab_recovery_additional_paths: []
+    containerlab_recovery_disable_version_check: true
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/63-containerlab-recovery@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.containerlab.recovery
+    - containerlab_recovery_action
+    - containerlab_recovery_mode
+    - containerlab_recovery_path
+    - containerlab_recovery_sha256
+    - containerlab_recovery_topology_sha256
+    - containerlab_recovery_latest_path
+    - containerlab_recovery_safe_for_host_destroy
+    - containerlab_recovery_labdir_base
+    - containerlab_recovery_topology_path
+    - containerlab_recovery_source_root
+    - containerlab_recovery_snapshot_dir
+    - containerlab_recovery_manifest_path
+    - containerlab_recovery_image_refs
+
+probes: []
+constraints: []

--- a/modules/platform/linux/containerlab/README.md
+++ b/modules/platform/linux/containerlab/README.md
@@ -1,0 +1,5 @@
+# platform/linux/containerlab
+
+Prepares a Containerlab execution host and verifies the runtime capabilities required by the declared lab.
+
+The module does not define or interpret Containerlab topology. The GCP reference blueprint enables nested virtualisation and requires KVM by default so VM-backed and vrnetlab workloads can run when the topology needs them.

--- a/modules/platform/linux/containerlab/examples/inputs.min.yml
+++ b/modules/platform/linux/containerlab/examples/inputs.min.yml
@@ -1,0 +1,6 @@
+# Minimal Containerlab runtime example for an existing Ubuntu host.
+
+target_host: "10.80.70.10"
+target_user: "opsadmin"
+containerlab_version: "0.78.0"
+containerlab_require_kvm: true

--- a/modules/platform/linux/containerlab/spec.yml
+++ b/modules/platform/linux/containerlab/spec.yml
@@ -1,0 +1,62 @@
+api_version: hybridops/v1
+kind: ModuleSpec
+
+module_ref: "platform/linux/containerlab"
+
+metadata:
+  title: "Linux Containerlab Runtime"
+  description: "Install and verify a pinned Containerlab runtime on an existing Ubuntu host."
+
+requirements:
+  credentials: []
+
+inputs:
+  defaults:
+    target_host: ""
+    target_state_ref: ""
+    target_vm_key: ""
+    inventory_groups: {}
+    inventory_state_ref: ""
+    inventory_vm_groups: {}
+    target_user: "opsadmin"
+    target_port: 22
+    ssh_private_key_file: ""
+    ssh_access_mode: "direct"
+    ssh_proxy_jump_auto: false
+    ssh_proxy_jump_host: ""
+    ssh_proxy_jump_user: "opsadmin"
+    ssh_proxy_jump_port: 22
+    gcp_iap_instance: ""
+    gcp_iap_project_id: ""
+    gcp_iap_zone: ""
+    become: true
+    become_user: "root"
+    connectivity_check: true
+    connectivity_timeout_s: 5
+    connectivity_wait_s: 0
+    required_env: []
+    required_env_destroy: []
+    load_vault_env: false
+    containerlab_role_fqcn: "hybridops.app.containerlab"
+    containerlab_version: "0.78.0"
+    containerlab_install_docker: true
+    containerlab_operator_user: "opsadmin"
+    containerlab_package_checksum: ""
+    containerlab_require_kvm: true
+
+execution:
+  driver: "config/ansible"
+  profile: "onprem-linux@v1.0"
+  pack_ref:
+    id: "linux/common/platform/60-containerlab-runtime@v1.0"
+
+outputs:
+  publish:
+    - cap.lab.containerlab.runtime
+    - containerlab_runtime_status
+    - containerlab_version
+    - containerlab_package_checksum
+    - containerlab_kvm_status
+
+probes: []
+constraints: []

--- a/packs/config/ansible/linux/common/platform/60-containerlab-runtime@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/60-containerlab-runtime@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,24 @@
+---
+- name: Destroy platform/linux/containerlab
+  hosts: targets
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Remove Containerlab package
+      ansible.builtin.apt:
+        name: containerlab
+        state: absent
+        purge: true
+      failed_when: false
+      when: ansible_os_family == "Debian"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {'cap.lab.containerlab.runtime': 'absent'} | to_json }}

--- a/packs/config/ansible/linux/common/platform/60-containerlab-runtime@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/60-containerlab-runtime@v1.0/stack/playbook.yml
@@ -1,0 +1,26 @@
+---
+- name: platform/linux/containerlab
+  hosts: targets
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: Install and verify Containerlab runtime
+      ansible.builtin.include_role:
+        name: "{{ containerlab_role_fqcn }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.containerlab.runtime': 'ready',
+            'containerlab_runtime_status': containerlab_runtime_result.status,
+            'containerlab_version': containerlab_runtime_result.version,
+            'containerlab_package_checksum': containerlab_runtime_result.package_checksum,
+            'containerlab_kvm_status': containerlab_runtime_result.kvm
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,60 @@
+---
+- name: Destroy platform/linux/containerlab-lab
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_remote_dir: >-
+      {{
+        containerlab_lab_remote_dir
+        | default('/var/lib/hybridops/containerlab/labs/gcp-containerlab')
+        | regex_replace('/+$', '')
+      }}
+
+  tasks:
+    - name: Initialize native cleanup status
+      ansible.builtin.set_fact:
+        _hyops_containerlab_cleanup_status: "ok"
+
+    - name: Ask Containerlab to clean the dedicated disposable host
+      block:
+        - name: Delegate dedicated-host lab destruction to Containerlab
+          ansible.builtin.include_role:
+            name: "{{ containerlab_lab_role_fqcn }}"
+          vars:
+            containerlab_lab_action: destroy
+            containerlab_lab_destroy_all: true
+      rescue:
+        - name: Record best-effort native cleanup failure
+          ansible.builtin.set_fact:
+            _hyops_containerlab_cleanup_status: "failed"
+
+        - name: Report best-effort native cleanup failure
+          ansible.builtin.debug:
+            msg: >-
+              Containerlab native cleanup failed after the recovery gate passed.
+              HybridOps will continue toward disposal of the dedicated managed
+              execution host rather than keep cloud compute alive solely for
+              container cleanup.
+
+    - name: Remove staged Containerlab source tree
+      ansible.builtin.file:
+        path: "{{ _hyops_remote_dir }}"
+        state: absent
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.containerlab': (
+              'absent'
+              if _hyops_containerlab_cleanup_status == 'ok'
+              else 'cleanup-failed-host-disposal-pending'
+            )
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/destroy.playbook.yml
@@ -23,8 +23,8 @@
           ansible.builtin.include_role:
             name: "{{ containerlab_lab_role_fqcn }}"
           vars:
-            containerlab_lab_action: destroy
-            containerlab_lab_destroy_all: true
+            _containerlab_lab_action: destroy
+            _containerlab_lab_destroy_all: true
       rescue:
         - name: Record best-effort native cleanup failure
           ansible.builtin.set_fact:

--- a/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/playbook.yml
@@ -1,0 +1,264 @@
+---
+- name: platform/linux/containerlab-lab
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_runtime_root: "{{ lookup('env', 'HYOPS_RUNTIME_ROOT') | default('', true) | trim }}"
+    _hyops_latest_path: >-
+      {{
+        (containerlab_lab_restore_latest_path | default('') | trim)
+        if (containerlab_lab_restore_latest_path | default('') | trim | length > 0)
+        else (_hyops_runtime_root ~ '/artifacts/containerlab/recovery/latest.tar.gz')
+      }}
+    _hyops_latest_sha_path: "{{ _hyops_latest_path }}.sha256"
+    _hyops_latest_metadata_path: "{{ _hyops_latest_path }}.json"
+
+  pre_tasks:
+    - name: Require runtime root for default recovery path
+      ansible.builtin.assert:
+        that:
+          - >-
+            not (containerlab_lab_restore_latest | bool) or
+            (containerlab_lab_restore_latest_path | default('') | trim | length > 0) or
+            (_hyops_runtime_root | length > 0)
+        fail_msg: >-
+          HYOPS_RUNTIME_ROOT or containerlab_lab_restore_latest_path is required
+          when automatic latest recovery is enabled.
+
+    - name: Read latest recovery archive state
+      ansible.builtin.stat:
+        path: "{{ _hyops_latest_path }}"
+        checksum_algorithm: sha256
+        follow: true
+      register: _hyops_latest_archive_stat
+      delegate_to: localhost
+      become: false
+      when: containerlab_lab_restore_latest | bool
+
+    - name: Read latest recovery checksum state
+      ansible.builtin.stat:
+        path: "{{ _hyops_latest_sha_path }}"
+      register: _hyops_latest_sha_stat
+      delegate_to: localhost
+      become: false
+      when: containerlab_lab_restore_latest | bool
+
+    - name: Read latest recovery metadata state
+      ansible.builtin.stat:
+        path: "{{ _hyops_latest_metadata_path }}"
+      register: _hyops_latest_metadata_stat
+      delegate_to: localhost
+      become: false
+      when: containerlab_lab_restore_latest | bool
+
+    - name: Resolve latest recovery availability
+      ansible.builtin.set_fact:
+        _hyops_restore_available: >-
+          {{
+            (_hyops_latest_archive_stat.stat.exists | default(false)) and
+            (_hyops_latest_sha_stat.stat.exists | default(false)) and
+            (_hyops_latest_metadata_stat.stat.exists | default(false))
+          }}
+        _hyops_any_restore_marker: >-
+          {{
+            (_hyops_latest_archive_stat.stat.exists | default(false)) or
+            (_hyops_latest_sha_stat.stat.exists | default(false)) or
+            (_hyops_latest_metadata_stat.stat.exists | default(false))
+          }}
+      when: containerlab_lab_restore_latest | bool
+
+    - name: Resolve disabled latest recovery state
+      ansible.builtin.set_fact:
+        _hyops_restore_available: false
+        _hyops_any_restore_marker: false
+      when: not (containerlab_lab_restore_latest | bool)
+
+    - name: Reject incomplete recovery markers
+      ansible.builtin.assert:
+        that:
+          - not _hyops_any_restore_marker or _hyops_restore_available
+        fail_msg: >-
+          Latest Containerlab recovery markers are incomplete; refusing an
+          ambiguous restore. Repair or remove the latest recovery set.
+      when: containerlab_lab_restore_latest | bool
+
+    - name: Read latest recovery checksum
+      ansible.builtin.slurp:
+        src: "{{ _hyops_latest_sha_path }}"
+      register: _hyops_latest_sha_raw
+      delegate_to: localhost
+      become: false
+      when: _hyops_restore_available | bool
+
+    - name: Read latest recovery metadata
+      ansible.builtin.slurp:
+        src: "{{ _hyops_latest_metadata_path }}"
+      register: _hyops_latest_metadata_raw
+      delegate_to: localhost
+      become: false
+      when: _hyops_restore_available | bool
+
+    - name: Resolve latest recovery metadata
+      ansible.builtin.set_fact:
+        _hyops_latest_sha256: "{{ _hyops_latest_sha_raw.content | b64decode | trim }}"
+        _hyops_latest_metadata: "{{ _hyops_latest_metadata_raw.content | b64decode | from_json }}"
+      when: _hyops_restore_available | bool
+
+    - name: Validate latest recovery checksum metadata
+      ansible.builtin.assert:
+        that:
+          - _hyops_latest_sha256 is match('^[0-9a-f]{64}$')
+          - _hyops_latest_archive_stat.stat.checksum == _hyops_latest_sha256
+          - _hyops_latest_metadata.archive_sha256 == _hyops_latest_sha256
+          - _hyops_latest_metadata.timestamp_archive | default('') | length > 0
+        fail_msg: >-
+          Latest Containerlab recovery archive or checksum metadata is invalid.
+      when: _hyops_restore_available | bool
+
+    - name: Verify immutable recovery archive referenced by metadata
+      ansible.builtin.stat:
+        path: "{{ _hyops_latest_metadata.timestamp_archive }}"
+        checksum_algorithm: sha256
+      register: _hyops_timestamp_archive_stat
+      delegate_to: localhost
+      become: false
+      when: _hyops_restore_available | bool
+
+    - name: Require immutable recovery archive identity to match latest pointer
+      ansible.builtin.assert:
+        that:
+          - _hyops_timestamp_archive_stat.stat.exists
+          - _hyops_timestamp_archive_stat.stat.isreg
+          - _hyops_timestamp_archive_stat.stat.checksum == _hyops_latest_sha256
+        fail_msg: >-
+          Latest recovery metadata does not resolve to the verified immutable
+          Containerlab recovery archive.
+      when: _hyops_restore_available | bool
+
+    - name: Read current source topology identity
+      ansible.builtin.stat:
+        path: >-
+          {{ (containerlab_lab_source_dir | regex_replace('/+$', '')) ~ '/' ~ containerlab_lab_topology_relpath }}
+        checksum_algorithm: sha256
+      register: _hyops_current_source_topology
+      delegate_to: localhost
+      become: false
+      when:
+        - _hyops_restore_available | bool
+        - containerlab_lab_restore_require_source_match | bool
+        - containerlab_lab_source_dir | length > 0
+
+    - name: Reject stale recovery bundle for changed topology
+      ansible.builtin.assert:
+        that:
+          - _hyops_current_source_topology.stat.exists
+          - _hyops_current_source_topology.stat.isreg
+          - _hyops_current_source_topology.stat.checksum == _hyops_latest_metadata.topology_sha256
+        fail_msg: >-
+          The latest recovery bundle belongs to a different topology revision.
+          Disable source matching only when deliberately restoring the archived
+          topology instead of the current controller source.
+      when:
+        - _hyops_restore_available | bool
+        - containerlab_lab_restore_require_source_match | bool
+        - containerlab_lab_source_dir | length > 0
+
+  tasks:
+    - name: Reset fresh-host recovery import workspace
+      ansible.builtin.file:
+        path: "{{ containerlab_lab_recovery_remote_root }}/import"
+        state: absent
+      when: _hyops_restore_available | bool
+
+    - name: Import verified immutable recovery bundle onto fresh managed host
+      ansible.builtin.include_role:
+        name: "{{ containerlab_lab_recovery_role_fqcn }}"
+      vars:
+        containerlab_recovery_action: import
+        containerlab_recovery_archive_path: "{{ _hyops_latest_metadata.timestamp_archive }}"
+        containerlab_recovery_expected_sha256: "{{ _hyops_latest_sha256 }}"
+        containerlab_recovery_remote_root: "{{ containerlab_lab_recovery_remote_root }}"
+        containerlab_recovery_labdir_base: "{{ containerlab_lab_labdir_base }}"
+        containerlab_recovery_overwrite: true
+      when: _hyops_restore_available | bool
+
+    - name: Verify recovered native labdir contract
+      ansible.builtin.assert:
+        that:
+          - containerlab_recovery_result.labdir_base == containerlab_lab_labdir_base
+        fail_msg: >-
+          The retained recovery bundle was created with a different native
+          Containerlab labdir base; refusing an ambiguous restore.
+      when: _hyops_restore_available | bool
+
+    - name: Reset stable managed source directory before recovery restore
+      ansible.builtin.file:
+        path: "{{ containerlab_lab_remote_dir }}"
+        state: absent
+      when: _hyops_restore_available | bool
+
+    - name: Recreate stable managed source directory
+      ansible.builtin.file:
+        path: "{{ containerlab_lab_remote_dir }}"
+        state: directory
+        mode: "0750"
+      when: _hyops_restore_available | bool
+
+    - name: Stage recovered source tree at stable managed path
+      ansible.builtin.copy:
+        src: "{{ containerlab_recovery_result.source_root | regex_replace('/+$', '') }}/"
+        dest: "{{ containerlab_lab_remote_dir | regex_replace('/+$', '') }}/"
+        remote_src: true
+        mode: preserve
+      when: _hyops_restore_available | bool
+
+    - name: Resolve fresh deployment inputs
+      ansible.builtin.set_fact:
+        _hyops_effective_source_dir: "{{ containerlab_lab_source_dir }}"
+        _hyops_effective_topology_path: "{{ containerlab_lab_topology_path }}"
+        _hyops_effective_restore_dir: ""
+        _hyops_effective_required_images: "{{ containerlab_lab_required_images }}"
+      when: not (_hyops_restore_available | bool)
+
+    - name: Resolve recovered deployment inputs
+      ansible.builtin.set_fact:
+        _hyops_effective_source_dir: ""
+        _hyops_effective_topology_path: >-
+          {{ (containerlab_lab_remote_dir | regex_replace('/+$', '')) ~ '/' ~ containerlab_lab_topology_relpath }}
+        _hyops_effective_restore_dir: "{{ containerlab_recovery_result.snapshot_dir | default('') }}"
+        _hyops_effective_required_images: >-
+          {{
+            containerlab_recovery_result.image_refs
+            if containerlab_recovery_result.image_refs | default([]) | length > 0
+            else containerlab_lab_required_images
+          }}
+      when: _hyops_restore_available | bool
+
+    - name: Delegate final lab deployment to Containerlab
+      ansible.builtin.include_role:
+        name: "{{ containerlab_lab_role_fqcn }}"
+      vars:
+        containerlab_lab_source_dir: "{{ _hyops_effective_source_dir }}"
+        containerlab_lab_topology_path: "{{ _hyops_effective_topology_path }}"
+        containerlab_lab_restore_all_dir: "{{ _hyops_effective_restore_dir }}"
+        containerlab_lab_required_images: "{{ _hyops_effective_required_images }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.containerlab': 'ready',
+            'containerlab_lab_action': containerlab_lab_result.action,
+            'containerlab_lab_topology_path': containerlab_lab_result.topology,
+            'containerlab_lab_source_staged': containerlab_lab_result.source_staged | default(false),
+            'containerlab_lab_labdir_base': containerlab_lab_result.labdir_base,
+            'containerlab_lab_restore_all_dir': containerlab_lab_result.restore_all_dir | default(''),
+            'containerlab_lab_restored_from_latest': (_hyops_restore_available | bool)
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/61-containerlab-lab@v1.0/stack/playbook.yml
@@ -176,7 +176,7 @@
       ansible.builtin.include_role:
         name: "{{ containerlab_lab_recovery_role_fqcn }}"
       vars:
-        containerlab_recovery_action: import
+        _containerlab_recovery_action: import
         containerlab_recovery_archive_path: "{{ _hyops_latest_metadata.timestamp_archive }}"
         containerlab_recovery_expected_sha256: "{{ _hyops_latest_sha256 }}"
         containerlab_recovery_remote_root: "{{ containerlab_lab_recovery_remote_root }}"

--- a/packs/config/ansible/linux/common/platform/62-containerlab-healthcheck@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/62-containerlab-healthcheck@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,19 @@
+---
+- name: Destroy platform/linux/containerlab-healthcheck
+  hosts: targets
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Healthcheck has no owned remote resources
+      ansible.builtin.debug:
+        msg: "Containerlab healthcheck state cleared; no remote resources are owned."
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {'cap.lab.containerlab.health': 'absent'} | to_json }}

--- a/packs/config/ansible/linux/common/platform/62-containerlab-healthcheck@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/62-containerlab-healthcheck@v1.0/stack/playbook.yml
@@ -1,0 +1,26 @@
+---
+- name: platform/linux/containerlab-healthcheck
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Verify Containerlab execution envelope
+      ansible.builtin.include_role:
+        name: "{{ containerlab_healthcheck_role_fqcn }}"
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.containerlab.health': 'ready',
+            'containerlab_health_status': containerlab_healthcheck_results.status,
+            'containerlab_version': containerlab_healthcheck_results.version,
+            'containerlab_kvm_status': containerlab_healthcheck_results.kvm,
+            'containerlab_health_labdir_base': containerlab_healthcheck_results.labdir_base
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/63-containerlab-recovery@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/63-containerlab-recovery@v1.0/stack/destroy.playbook.yml
@@ -49,9 +49,9 @@
       ansible.builtin.include_role:
         name: "{{ containerlab_recovery_role_fqcn }}"
       vars:
-        containerlab_recovery_action: export
-        containerlab_recovery_topology_path: "{{ _hyops_effective_topology_path }}"
-        containerlab_recovery_controller_dir: "{{ _hyops_effective_controller_dir }}"
+        _containerlab_recovery_action: export
+        _containerlab_recovery_topology_path: "{{ _hyops_effective_topology_path }}"
+        _containerlab_recovery_controller_dir: "{{ _hyops_effective_controller_dir }}"
 
     - name: Ensure stable recovery pointer directory exists
       ansible.builtin.file:

--- a/packs/config/ansible/linux/common/platform/63-containerlab-recovery@v1.0/stack/destroy.playbook.yml
+++ b/packs/config/ansible/linux/common/platform/63-containerlab-recovery@v1.0/stack/destroy.playbook.yml
@@ -1,0 +1,152 @@
+---
+- name: Preserve Containerlab recovery set before disposable-host teardown
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  vars:
+    _hyops_runtime_root: "{{ lookup('env', 'HYOPS_RUNTIME_ROOT') | default('', true) | trim }}"
+    _hyops_controller_dir: >-
+      {{
+        (containerlab_recovery_controller_dir | default('') | trim)
+        if (containerlab_recovery_controller_dir | default('') | trim | length > 0)
+        else (_hyops_runtime_root ~ '/artifacts/containerlab/recovery')
+      }}
+    _hyops_latest_path: >-
+      {{
+        (containerlab_recovery_latest_path | default('') | trim)
+        if (containerlab_recovery_latest_path | default('') | trim | length > 0)
+        else (_hyops_controller_dir ~ '/latest.tar.gz')
+      }}
+    _hyops_latest_sha_path: "{{ _hyops_latest_path }}.sha256"
+    _hyops_latest_metadata_path: "{{ _hyops_latest_path }}.json"
+    _hyops_topology_path: >-
+      {{ (containerlab_recovery_source_root | regex_replace('/+$', '')) ~ '/' ~ containerlab_recovery_topology_relpath }}
+
+  pre_tasks:
+    - name: Materialize recovery destroy wrapper inputs before role delegation
+      ansible.builtin.set_fact:
+        _hyops_effective_controller_dir: "{{ _hyops_controller_dir }}"
+        _hyops_effective_topology_path: "{{ _hyops_topology_path }}"
+
+    - name: Require controller recovery storage before compute teardown
+      ansible.builtin.assert:
+        that:
+          - containerlab_recovery_source_root | trim | length > 0
+          - containerlab_recovery_topology_relpath | trim | length > 0
+          - containerlab_recovery_labdir_base | trim | length > 0
+          - containerlab_recovery_source_root | regex_replace('/+$', '') != containerlab_recovery_labdir_base | regex_replace('/+$', '')
+          - >-
+            (containerlab_recovery_controller_dir | default('') | trim | length > 0)
+            or (_hyops_runtime_root | length > 0)
+        fail_msg: >-
+          A managed source root, separate native labdir base, topology relative
+          path and durable controller recovery location are required before
+          disposable compute can be destroyed.
+
+  tasks:
+    - name: Export declared recovery set using Containerlab-native facilities
+      ansible.builtin.include_role:
+        name: "{{ containerlab_recovery_role_fqcn }}"
+      vars:
+        containerlab_recovery_action: export
+        containerlab_recovery_topology_path: "{{ _hyops_effective_topology_path }}"
+        containerlab_recovery_controller_dir: "{{ _hyops_effective_controller_dir }}"
+
+    - name: Ensure stable recovery pointer directory exists
+      ansible.builtin.file:
+        path: "{{ _hyops_latest_path | dirname }}"
+        state: directory
+        mode: "0700"
+      delegate_to: localhost
+      become: false
+
+    - name: Restrict immutable recovery archive permissions
+      ansible.builtin.file:
+        path: "{{ containerlab_recovery_result.controller_archive }}"
+        state: file
+        mode: "0600"
+      delegate_to: localhost
+      become: false
+
+    - name: Update stable latest recovery pointer without duplicating archive bytes
+      ansible.builtin.file:
+        src: "{{ containerlab_recovery_result.controller_archive }}"
+        dest: "{{ _hyops_latest_path }}"
+        state: link
+        force: true
+      delegate_to: localhost
+      become: false
+
+    - name: Record stable latest recovery checksum
+      ansible.builtin.copy:
+        dest: "{{ _hyops_latest_sha_path }}"
+        mode: "0600"
+        content: "{{ containerlab_recovery_result.sha256 }}\n"
+      delegate_to: localhost
+      become: false
+
+    - name: Record stable latest recovery metadata
+      ansible.builtin.copy:
+        dest: "{{ _hyops_latest_metadata_path }}"
+        mode: "0600"
+        content: >-
+          {{ {
+            'schema': 'hybridops.containerlab.latest/v1',
+            'archive_sha256': containerlab_recovery_result.sha256,
+            'topology_sha256': containerlab_recovery_result.topology_sha256,
+            'mode': containerlab_recovery_result.mode,
+            'image_refs': containerlab_recovery_result.image_refs,
+            'labdir_base': containerlab_recovery_result.labdir_base,
+            'timestamp_archive': containerlab_recovery_result.controller_archive
+          } | to_nice_json }}
+      delegate_to: localhost
+      become: false
+
+    - name: Verify stable latest recovery pointer target
+      ansible.builtin.stat:
+        path: "{{ _hyops_latest_path }}"
+        checksum_algorithm: sha256
+        follow: true
+      register: _hyops_latest_archive_stat
+      delegate_to: localhost
+      become: false
+
+    - name: Gate managed-host destruction on verified off-host recovery
+      ansible.builtin.assert:
+        that:
+          - containerlab_recovery_result.safe_for_host_destroy | bool
+          - containerlab_recovery_result.labdir_base == containerlab_recovery_labdir_base
+          - _hyops_latest_archive_stat.stat.exists
+          - _hyops_latest_archive_stat.stat.checksum == containerlab_recovery_result.sha256
+        fail_msg: >-
+          Containerlab recovery retention did not verify off-host against the
+          declared native labdir base; refusing to advance managed-host
+          destruction.
+      delegate_to: localhost
+      become: false
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.containerlab.recovery': 'retained',
+            'containerlab_recovery_action': 'export',
+            'containerlab_recovery_mode': containerlab_recovery_result.mode,
+            'containerlab_recovery_path': containerlab_recovery_result.controller_archive,
+            'containerlab_recovery_sha256': containerlab_recovery_result.sha256,
+            'containerlab_recovery_topology_sha256': containerlab_recovery_result.topology_sha256,
+            'containerlab_recovery_latest_path': _hyops_latest_path,
+            'containerlab_recovery_safe_for_host_destroy': true,
+            'containerlab_recovery_labdir_base': containerlab_recovery_result.labdir_base,
+            'containerlab_recovery_topology_path': '',
+            'containerlab_recovery_source_root': '',
+            'containerlab_recovery_snapshot_dir': '',
+            'containerlab_recovery_manifest_path': '',
+            'containerlab_recovery_image_refs': containerlab_recovery_result.image_refs
+          } | to_json }}

--- a/packs/config/ansible/linux/common/platform/63-containerlab-recovery@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/63-containerlab-recovery@v1.0/stack/playbook.yml
@@ -1,0 +1,67 @@
+---
+- name: platform/linux/containerlab-recovery
+  hosts: targets
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Materialize recovery wrapper inputs before role delegation
+      ansible.builtin.set_fact:
+        _hyops_requested_action: "{{ containerlab_recovery_action | default('arm') | trim }}"
+        _hyops_recovery_archive_path: >-
+          {{ containerlab_recovery_archive_path | default(containerlab_recovery_path, true) }}
+
+    - name: Validate recovery guard action
+      ansible.builtin.assert:
+        that:
+          - _hyops_requested_action in ['arm', 'export', 'import']
+          - containerlab_recovery_labdir_base | trim | length > 0
+        fail_msg: >-
+          containerlab_recovery_action must be arm, export or import and the
+          native Containerlab labdir base must be declared.
+
+    - name: Delegate explicit recovery export/import to collection role
+      ansible.builtin.include_role:
+        name: "{{ containerlab_recovery_role_fqcn }}"
+      vars:
+        containerlab_recovery_action: "{{ _hyops_requested_action }}"
+        containerlab_recovery_archive_path: "{{ _hyops_recovery_archive_path }}"
+      when: _hyops_requested_action in ['export', 'import']
+
+  post_tasks:
+    - name: Write HyOps outputs
+      delegate_to: localhost
+      become: false
+      ansible.builtin.copy:
+        dest: "{{ hyops_outputs_file }}"
+        mode: "0600"
+        content: |
+          {{ {
+            'cap.lab.containerlab.recovery': ('armed' if _hyops_requested_action == 'arm' else 'ready'),
+            'containerlab_recovery_action': _hyops_requested_action,
+            'containerlab_recovery_mode': containerlab_recovery_mode,
+            'containerlab_recovery_path':
+              (containerlab_recovery_result.controller_archive | default(containerlab_recovery_result.topology_path | default('')))
+              if _hyops_requested_action != 'arm' else '',
+            'containerlab_recovery_sha256':
+              (containerlab_recovery_result.sha256 | default('')) if _hyops_requested_action != 'arm' else '',
+            'containerlab_recovery_topology_sha256':
+              (containerlab_recovery_result.topology_sha256 | default('')) if _hyops_requested_action != 'arm' else '',
+            'containerlab_recovery_latest_path': '',
+            'containerlab_recovery_safe_for_host_destroy':
+              (containerlab_recovery_result.safe_for_host_destroy | default(false))
+              if _hyops_requested_action != 'arm' else false,
+            'containerlab_recovery_labdir_base':
+              (containerlab_recovery_result.labdir_base | default(containerlab_recovery_labdir_base))
+              if _hyops_requested_action != 'arm' else containerlab_recovery_labdir_base,
+            'containerlab_recovery_topology_path':
+              (containerlab_recovery_result.topology_path | default('')) if _hyops_requested_action != 'arm' else '',
+            'containerlab_recovery_source_root':
+              (containerlab_recovery_result.source_root | default('')) if _hyops_requested_action != 'arm' else '',
+            'containerlab_recovery_snapshot_dir':
+              (containerlab_recovery_result.snapshot_dir | default('')) if _hyops_requested_action != 'arm' else '',
+            'containerlab_recovery_manifest_path':
+              (containerlab_recovery_result.manifest_path | default('')) if _hyops_requested_action != 'arm' else '',
+            'containerlab_recovery_image_refs':
+              (containerlab_recovery_result.image_refs | default([])) if _hyops_requested_action != 'arm' else []
+          } | to_json }}

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -6,7 +6,7 @@ collections:
     version: "0.1.8"
 
   - name: hybridops.app
-    version: "0.1.8"
+    version: "0.1.9"
 
   - name: ansible.posix
     version: "1.6.2"

--- a/tools/setup/requirements/ansible.hybridops.git.json
+++ b/tools/setup/requirements/ansible.hybridops.git.json
@@ -13,7 +13,7 @@
     {
       "name": "hybridops.app",
       "repo": "git@github.com:hybridops-tech/ansible-collection-app.git",
-      "ref": "d34f53bb1e3f2960ea718b53f6eb45853dea2ef0"
+      "ref": "1ca8d662f574ffa69c0d24043af058cbe5833f27"
     }
   ]
 }

--- a/tools/setup/requirements/ansible.hybridops.git.json
+++ b/tools/setup/requirements/ansible.hybridops.git.json
@@ -13,7 +13,7 @@
     {
       "name": "hybridops.app",
       "repo": "git@github.com:hybridops-tech/ansible-collection-app.git",
-      "ref": "22863037fe3de85c0fd7d82f0af1ac5416f346f9"
+      "ref": "d34f53bb1e3f2960ea718b53f6eb45853dea2ef0"
     }
   ]
 }

--- a/tools/setup/requirements/ansible.hybridops.git.json
+++ b/tools/setup/requirements/ansible.hybridops.git.json
@@ -13,7 +13,7 @@
     {
       "name": "hybridops.app",
       "repo": "git@github.com:hybridops-tech/ansible-collection-app.git",
-      "ref": "d6bdc013c147d0e40428a8b8a03a424ad52f1388"
+      "ref": "22863037fe3de85c0fd7d82f0af1ac5416f346f9"
     }
   ]
 }


### PR DESCRIPTION
Adds the validated GCP Containerlab lifecycle around disposable private compute.

HybridOps creates the execution host, verifies runtime readiness, deploys the supplied topology through Containerlab, requires the selected recovery state to be copied and checksum-verified off-host before compute release, and reconstructs the lab on fresh compute by handing recovery back through Containerlab's native lifecycle.

Containerlab remains authoritative for `.clab.yml`, nodes and links, convergence, native save, snapshot and restore behaviour, and generated lab state. HybridOps governs the surrounding GCP execution lifecycle: readiness, recovery policy, off-host verification, compute release, fresh-host reconstruction, cost context, and run evidence.

Validation completed before merge:

- final Core head: `0645a7aa4440189cbb65a17c75512e276b467ce6`
- final Core CI: run `32416371036`, passed
- released `hybridops.app` dependency pinned to `0.1.9`
- private GCP execution host created and reached through the intended IAP/SSH path
- nested virtualisation and KVM readiness verified
- Containerlab `0.78.0` installed and verified
- supplied topology deployed through native Containerlab and passed independent health verification
- selected recovery state copied off-host and checksum-verified before the original VM was deleted
- original execution VM removed only after the recovery gate passed
- replacement VM created with a different resource identity
- retained recovery state verified and imported on the fresh host
- reconstruction completed through one native Containerlab deployment
- final lab health passed
- final declared GCP compute was removed

The implementation establishes a complete GCP continuity lifecycle around Containerlab while preserving Containerlab as the authority for topology and native recovery semantics. Recovery fidelity is selected by policy and delivered through the native capabilities of the topology and node types in use.

Merged to `main` as `ec80a2b1e51d3c9233f9057f81bb7262fe3d7149`.