### PR TITLE
docs: document candidate acceptance workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,8 @@
 
 <!-- List the checks or commands you ran. -->
 
+<!-- If this needed candidate or environment acceptance, record the workflow run, artifact/provenance, environment, result, and cleanup. -->
+
 ## Scope
 
 - [ ] This pull request is focused on one change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Useful contributions include:
 - bug fixes and regression tests
 - clearer CLI behaviour and validation errors
 - module, blueprint, driver, and pack improvements
-- Terraform, Ansible, Packer, and shell quality fixes
+- execution, packaging, and infrastructure quality fixes
 - preflight checks, probes, and run-record improvements
 - accurate examples and operator documentation
 
@@ -30,8 +30,8 @@ python -m pip install --upgrade pip
 python -m pip install -e .
 ```
 
-Tool dependencies vary by change. Install only the tools needed for the area
-you are working on, such as Terraform, Ansible, Packer, or ShellCheck.
+Dependencies vary by change. Install only what the area you are working on
+requires. The repository checks below show the expected validation paths.
 
 ## Scope and conventions
 
@@ -39,8 +39,9 @@ you are working on, such as Terraform, Ansible, Packer, or ShellCheck.
 - Do not include credentials, tokens, private addresses, customer data, or
   unredacted run records.
 - Read the local `README.md` before changing a module or blueprint.
-- Keep tool-specific implementation in the selected driver and pack. A module
-  should describe intent, inputs, validation, execution selection, and outputs.
+- Keep implementation-specific details in the selected driver and pack. A
+  module should describe intent, inputs, validation, execution selection, and
+  outputs.
 - Keep shipped blueprints reusable. Do not hard-code private repository
   layouts, customer environments, credentials, or application-specific flows.
 - Avoid broad formatting-only or unrelated refactors in a functional change.
@@ -80,8 +81,37 @@ bash tools/ci/lint-ansible.sh
 bash tools/ci/check-terraform.sh
 ```
 
-The GitHub Actions suite is the final check. In the pull request, state which
-commands you ran and call out anything you could not run locally.
+GitHub Actions is the repository gate. In the pull request, state which checks
+you ran locally and call out anything you could not run.
+
+## Candidate validation
+
+After the quality jobs pass, CI builds temporary installable candidates. A pull
+request candidate is built from the prospective merge with `main`, so the
+package is tied to the exact tree accepted by that CI run.
+
+Use the candidate, rather than a source checkout, when a change needs acceptance
+testing in a real environment. This is especially important for installation,
+packaging, provider lifecycle, host integration, recovery, and other behaviour
+that cannot be established by repository checks alone.
+
+Before an acceptance run:
+
+- download the candidate from the exact pull request run
+- verify its checksum
+- record the artifact name, workflow run, source SHA, and provenance
+- install it through the normal product installation path
+
+During the run, record the environment assumptions, the observed result, and
+cleanup. Do not edit the installed payload to make a test pass. If the test uses
+a development dependency, record its exact commit rather than only a branch
+name.
+
+Candidate artifacts are short-lived test outputs. They are not releases and
+must not be presented or promoted as releases. Permanent distribution still
+comes from the tagged release path. When a claim depends on the released
+installation path, repeat the relevant acceptance check against the published
+release before making that claim.
 
 ## Pull request description
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -14,9 +14,8 @@ Python wheel because operators need the runtime payload as shipped:
 - `tools/`
 - `install.sh`
 
-HybridOps Ansible collection source is not part of the public bundle contract.
-Operators install the pinned released `hybridops.*` collection artifacts through
-`hyops setup galaxy`.
+Runtime dependency source is not part of the public bundle contract. Operators
+install pinned dependencies through the normal `hyops setup <target>` path.
 
 ## Public Product Boundary
 
@@ -139,8 +138,8 @@ TMPDIR=/dev/shm ./pkg/verify_release.sh dist/releases/hybridops-core-<label>.tar
 - `install.sh` can install the bundle into an isolated runtime root
 - installed `hyops` runs without relying on the source checkout
 - the installed runtime resolves its shipped packs without wrapper environment variables
-- the bundle and installed payload do not include vendored HybridOps collection source
-- installed `hyops` exposes `setup galaxy` and the compatible `setup ansible` path
+- the bundle and installed payload do not include vendored runtime dependency source
+- installed `hyops` exposes the required setup paths
 - the installed payload matches the shipped checksum manifest
 - the temporary filesystem has enough free space before extraction begins
 
@@ -152,5 +151,6 @@ current source payload, with a `TMPDIR` hint instead of failing late and
 silently.
 
 GitHub Actions also runs the reusable quality workflow before bundle build and
-publication. The blocking checks are Python compile/import integrity, Ansible
-playbook syntax and pack-surface lint, and Terraform `fmt`/`validate`/`tflint`.
+publication. Blocking checks cover Python integrity, configuration syntax and
+lint, infrastructure definition validation, shell quality, and install/package
+verification.


### PR DESCRIPTION
## Summary

Document how contributors validate CI-built candidate packages against real environments.

## Scope

- distinguish candidate artifacts from releases
- record checksums, provenance, environment results, and cleanup
- align contribution guidance with the current Core CI workflow