### PR TITLE
release: pin hybridops.helper 0.1.9

### DIFF
--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -3,7 +3,7 @@ collections:
     version: "0.1.6"
 
   - name: hybridops.helper
-    version: "0.1.8"
+    version: "0.1.9"
 
   - name: hybridops.app
     version: "0.1.9"

--- a/tools/setup/requirements/ansible.hybridops.git.json
+++ b/tools/setup/requirements/ansible.hybridops.git.json
@@ -8,7 +8,7 @@
     {
       "name": "hybridops.helper",
       "repo": "git@github.com:hybridops-tech/ansible-collection-helper.git",
-      "ref": "85dbfddceecab888850b72dc2918e55a54c9793e"
+      "ref": "bcdbef964788584b1e1867b9abc057f8557646b1"
     },
     {
       "name": "hybridops.app",


### PR DESCRIPTION
## Summary

Pin the published Helper 0.1.9 collection.

## Pins

- stable setup: hybridops.helper 0.1.9
- development setup: Helper merge commit bcdbef964788584b1e1867b9abc057f8557646b1

The released collection provides protected EVE-NG IOL licence placement and archive validation.