### PR TITLE
docs(platform-lifecycle): document continuity, access and compute-release architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 <table align="center">
   <tr>
-    <td align="center"><strong>80</strong><br><sub>runtime modules</sub></td>
-    <td align="center"><strong>28</strong><br><sub>reference blueprints</sub></td>
+    <td align="center"><strong>84</strong><br><sub>runtime modules</sub></td>
+    <td align="center"><strong>29</strong><br><sub>reference blueprints</sub></td>
     <td align="center"><strong>52</strong><br><sub>public decision records</sub></td>
     <td align="center"><strong>8</strong><br><sub>supported targets</sub></td>
   </tr>

--- a/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
@@ -1,0 +1,119 @@
+# EVE-NG lifecycle architecture
+
+The EVE-NG implementation separates the lab platform from the execution-host lifecycle. EVE-NG owns topology and node behavior. HybridOps governs the surrounding capacity, readiness, private access, continuity preservation, reconstruction and run evidence.
+
+The same EVE-NG capability modules are used by the Google Cloud and Proxmox blueprints. The execution-host layer changes; the lab-platform contract remains stable.
+
+## Lifecycle
+
+```text
+execution capacity
+      |
+      v
+EVE-NG configuration
+      |
+      v
+authorised images
+      |
+      v
+health verification
+      |
+      +------------------------------+
+      |                              |
+      v                              v
+private UI access             topology-node automation
+      |                              |
+      +--------------+---------------+
+                     |
+                     v
+                  lab use
+                     |
+                     v
+      preserve selected continuity state
+                     |
+                     v
+          verify retained archives
+                     |
+                     v
+             release execution host
+                     |
+                     v
+          recreate execution capacity
+                     |
+                     v
+        restore verified retained state
+                     |
+                     v
+             health verification
+```
+
+## Capability layers
+
+| Layer | Responsibility |
+| --- | --- |
+| Execution host | Provider or virtualisation-specific capacity and private connectivity |
+| EVE-NG platform | EVE-NG installation, services, topology and node execution |
+| Image layer | Declared authorised image acquisition and placement |
+| Health layer | Service, database, API and KVM readiness |
+| Access layer | Private EVE-NG UI path plus session-scoped topology-node management access |
+| Continuity layer | Lab definitions and selected stopped-QEMU overlay state, retained away from the execution host |
+| Runtime evidence | Module state, checksums, health results, resource state and lifecycle records |
+
+## Private access and device automation
+
+The EVE-NG host remains private. HybridOps resolves the current host from runtime state and establishes the access path for the session.
+
+For topology-node automation, EVE-NG `Cloud8` is the management network. HybridOps discovers current DHCP leases and generates scoped SSH configuration and automation inventory for the operator workstation. The node's own SSH, NETCONF/RESTCONF, gNMI, HTTPS or other management service remains the protocol endpoint.
+
+Live management addresses are session state. Durable role, platform, grouping and credential references can remain under operator or source-of-truth authority while the current endpoint is rediscovered after reconstruction.
+
+## Continuity model
+
+The blueprint configures `platform/linux/eve-ng-lab-archive` before destructive lifecycle actions.
+
+The primary archive retains EVE-NG lab definitions from `/opt/unetlab/labs`. The node-state companion path captures stopped QEMU overlays when node-state preservation is selected. The lifecycle stops running QEMU nodes before capture, validates the overlays and records a separate SHA-256 for the companion archive.
+
+```text
+EVE-NG lab definitions --------------------+
+                                            |
+stopped QEMU overlays, when selected -------+--> controller-side retained set
+                                            |        |
+                                            |        v
+                                            |   SHA-256 verification
+                                            |        |
+                                            +--------+
+                                                     |
+                                                     v
+                                               compute release
+```
+
+Vendor or base images remain separately managed. Restored overlays are paired with the matching installed base images. This keeps the retained continuity set focused on lab-owned mutable state.
+
+## Restore path
+
+`--restore-labs` selects the latest verified archive state recorded for the environment. The runtime verifies the primary archive checksum and, when present, the node-state companion checksum before invoking the archive module in restore mode.
+
+Existing lab content is protected by default. Replacement requires the explicit overwrite option.
+
+The restore path therefore reconstructs the surrounding execution environment while returning EVE-NG definitions and selected QEMU state to EVE-NG rather than translating them into another lab format.
+
+## Cross-target consistency
+
+The GCP and Proxmox blueprints both declare:
+
+- `platform/linux/eve-ng`
+- `platform/linux/eve-ng-images`
+- `platform/linux/eve-ng-healthcheck`
+- `platform/linux/eve-ng-lab-archive`
+- the same `Cloud8` management subnet contract
+- the same `Cloud9` guest-NAT contract
+- archive-before-release with stopped-node capture enabled
+
+The provider-specific difference is the host and access transport. The EVE-NG lifecycle, health, management and continuity contracts remain shared.
+
+## Implementation references
+
+- [Blueprint contract](blueprint.yml)
+- [EVE-NG module](../../../modules/platform/linux/eve-ng)
+- [EVE-NG archive module](../../../modules/platform/linux/eve-ng-lab-archive)
+- [Proxmox EVE-NG blueprint](../../onprem/eve-ng@v1)

--- a/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
@@ -57,7 +57,21 @@ private UI access             topology-node automation
 | Health layer | Service, database, API and KVM readiness |
 | Access layer | Private EVE-NG UI path plus session-scoped topology-node management access |
 | Continuity layer | Lab definitions and selected stopped-QEMU overlay state, retained away from the execution host |
+| Cost context | Resource age, fixed-resource estimate and retained-resource visibility for cloud execution |
 | Runtime evidence | Module state, checksums, health results, resource state and lifecycle records |
+
+## Operating control points
+
+The implementation crosses several operational disciplines, but each one resolves through the same lifecycle record.
+
+| Control point | Decision | Evidence |
+| --- | --- | --- |
+| Readiness | Is execution capacity and EVE-NG usable? | Provider state, preflight, service/database/API/KVM health |
+| Private access | Can the operator and automation clients reach the required control surfaces? | Resolved runtime target, access session and generated client material |
+| Continuity | What state must survive this session? | Lab archive, optional stopped-QEMU overlay archive, manifests and SHA-256 values |
+| Compute release | Is the high-resource execution host still required? | Verified retained recovery set and terminal resource state |
+| Reconstruction | Has the lab returned to a usable state? | Verified restore followed by the normal EVE-NG health path |
+| Cost context | Which cost-bearing resources are active or deliberately retained? | Resource age, fixed-resource estimate, terminal compute state and retained-resource reporting |
 
 ## Private access and device automation
 
@@ -95,7 +109,15 @@ Vendor or base images remain separately managed. Restored overlays are paired wi
 
 Existing lab content is protected by default. Replacement requires the explicit overwrite option.
 
-The restore path therefore reconstructs the surrounding execution environment while returning EVE-NG definitions and selected QEMU state to EVE-NG rather than translating them into another lab format.
+The restore path reconstructs the surrounding execution environment while returning EVE-NG definitions and selected QEMU state to EVE-NG rather than translating them into another lab format.
+
+## Compute lifetime and cost boundary
+
+Access closure and compute release are separate lifecycle events. Ending a browser, console or SSH session leaves the execution host unchanged; the host becomes eligible for release when the selected continuity state has been preserved and verified.
+
+For the GCP path, HybridOps surfaces resource age and fixed-resource cost context alongside the lifecycle. Provider billing remains authoritative for realised spend. After execution compute is released, retained archives, image sources, shared networking or other deliberately retained resources remain visible as separate state rather than being folded into the compute result.
+
+This makes the cost decision operational rather than timer-based: continuity determines when high-resource compute can end, while the terminal resource record shows what still exists afterward. The Proxmox path uses the same continuity and terminal-state contract without the GCP billing context.
 
 ## Cross-target consistency
 

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -1,223 +1,111 @@
-# GCP EVE-NG Host
+# EVE-NG network lab
 
-Build a private EVE-NG host on Google Cloud using a nested-virtualization-capable Compute Engine VM.
+`gcp/eve-ng@v1` delivers a private EVE-NG execution environment with governed access, health verification, device automation access, continuity preservation, rebuild and compute release.
 
-This blueprint provisions the VM, connects to it over GCP IAP, configures EVE-NG, loads a small starter image set, and runs a health check so the host proves it is reachable. It is the cloud-friendly EVE-NG path for users who want a reproducible training or network-simulation host but do not have a Proxmox environment.
+The blueprint uses shared EVE-NG capability modules that are also used by the Proxmox path. Provider-specific infrastructure supplies the execution host; EVE-NG remains authoritative for topology and node behavior.
 
-Use this when you want the EVE-NG host lifecycle to be rebuildable from infrastructure code instead of manually creating and patching a long-lived server.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the lifecycle and ownership model.
 
-## What This Delivers
+## What it delivers
 
-- a private GCP Compute Engine VM for EVE-NG
-- an isolated VPC, subnet, IAP SSH rule, router, and subnet-scoped Cloud NAT
-- nested virtualization enabled for KVM-backed network simulation workloads
-- no public IP by default
-- SSH access through GCP IAP
-- VM provisioning through `platform/gcp/platform-vm`
+- private nested-virtualization-capable execution compute with no public VM address
 - EVE-NG installation and configuration through `platform/linux/eve-ng`
-- a starter image set through `platform/linux/eve-ng-images`
-- a guest NAT network with DHCP for lab nodes that need outbound internet access
-- a basic EVE-NG health check through `platform/linux/eve-ng-healthcheck`
-- structured run records for each module step
+- declared starter images through `platform/linux/eve-ng-images`
+- guest internet access through the EVE-NG `Cloud9` network
+- private topology-node management through `Cloud8`
+- service, database, API and KVM health verification
+- archive-before-release through `platform/linux/eve-ng-lab-archive`
+- verified restoration of lab definitions and selected stopped-QEMU overlay state
+- structured run records and resource-age/cost context
 
-## Execution Chain
+## Execution chain
 
 ```text
-platform/gcp/lab-network
-  -> platform/gcp/platform-vm
-  -> platform/linux/eve-ng
-  -> platform/linux/eve-ng-images
-  -> platform/linux/eve-ng-healthcheck
+private network
+  -> execution host
+  -> EVE-NG configuration
+  -> lab images
+  -> EVE-NG health verification
 ```
 
-The blueprint file is [blueprint.yml](blueprint.yml).
+The executable contract is [blueprint.yml](blueprint.yml).
 
-## Documentation
-
-- [Deploy EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
-- [Reusable EVE-NG training environment reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/)
-
-## Prerequisites
-
-This blueprint creates its own lab network. It assumes the GCP account and
-target environment are ready:
-
-- `hyops init gcp --env <env>` has been run.
-- A GCP project is selected for the environment.
-- Billing is enabled on the selected project. `hyops init gcp` and GCP module
-  preflight stop when billing is disabled or cannot be confirmed. The deployment
-  and running VM can consume free-trial credit or incur charges.
-- The operator can create Compute Engine networks, firewall rules, routers,
-  NAT configuration, and instances.
-- EVE-NG secrets are seeded for the target environment.
-- The VM zone is derived from the initialized GCP region. An environment
-  overlay may select another zone in the same region when quota or capacity
-  requires it; a zone from a different region is rejected before apply.
-
-Seed the EVE-NG secrets before deployment:
+## Prepare and deploy
 
 ```bash
+hyops setup gcp
+hyops init gcp --env <env>
 hyops secrets ensure --env <env> EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
+
+ref=gcp/eve-ng@v1
+hyops blueprint init --env <env> --ref "$ref"
+hyops blueprint validate --env <env> --ref "$ref"
+hyops blueprint plan --env <env> --ref "$ref"
+hyops blueprint preflight --env <env> --ref "$ref"
+hyops blueprint deploy --env <env> --ref "$ref" --execute
 ```
 
-## Usage
+The shipped host profile uses an `n2-standard-8` VM with 32 GB RAM, a 256 GB disk, Ubuntu 22.04 and nested virtualization. It is a reference profile that can be adjusted through the environment blueprint.
 
-Validate the blueprint:
+## Private access
 
-```bash
-hyops blueprint validate \
-  --ref gcp/eve-ng@v1 \
-  --blueprints-root blueprints
-```
-
-Run preflight:
-
-```bash
-hyops blueprint preflight \
-  --env <env> \
-  --ref gcp/eve-ng@v1 \
-  --blueprints-root blueprints
-```
-
-Open the private EVE-NG UI after deployment:
+Open the EVE-NG interface through the managed private path:
 
 ```bash
 hyops blueprint access --env <env> --ref gcp/eve-ng@v1
 ```
 
-HybridOps resolves the VM, project, and zone from module state, forwards HTTP
-through the existing IAP SSH path with the declared HybridOps key, opens the
-browser, and keeps access active until `Ctrl-C`. Port 80 remains closed at the
-GCP firewall. Use `--no-browser` when only the printed local URL is required.
+The access session resolves the current host from HybridOps state and forwards the EVE-NG interface through IAP. The VM and EVE-NG HTTP service remain private.
 
-For workstation automation, connect a device management interface to `Cloud8`
-and run:
+For direct automation of topology nodes, connect a management interface to `Cloud8` and run:
 
 ```bash
 hyops blueprint access --env <env> --ref gcp/eve-ng@v1 --automation
 ```
 
-The command keeps the UI private, discovers management leases and writes a
-scoped SSH configuration and automation inventory. Use the printed SSH config
-from a second terminal or VS Code while the access session remains open.
-DHCP supplies the management gateway; static devices must use `172.29.128.1`.
-On Linux or WSL, `--route-lab` additionally creates a temporary layer-3 route
-and verifies the management gateway when `172.29.128.0/24` does not conflict
-locally. Windows and macOS applications can use the generated SSH configuration
-or local proxy.
+HybridOps discovers management leases and produces session-scoped SSH configuration and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
 
-After an interactive access session closes, the blueprint reports billing
-status and resource-state age, provides the project-specific GCP Billing link
-for trial, credit and spend details, then offers to keep the environment,
-export its lab definitions before teardown, or destroy without an export.
-Destruction requires the operator to type `destroy <environment>`.
+## Continuity and compute release
 
-Automation must state the intended archive behaviour:
+The blueprint declares `platform/linux/eve-ng-lab-archive` as its archive-before-release contract.
+
+The retained set can contain:
+
+- learner-created lab definitions under `/opt/unetlab/labs`; and
+- stopped QEMU overlay state when node-state preservation is selected by the blueprint.
+
+Before overlay capture, running QEMU nodes are stopped. Each retained archive is checksummed on the controller. Base images remain separately managed, so restored QEMU overlays reconnect to matching installed base images rather than copying those bases into the checkpoint.
+
+For an explicit protected destroy:
 
 ```bash
 hyops blueprint destroy --env <env> --ref gcp/eve-ng@v1 --execute --yes \
   --archive-before-destroy
 ```
 
-Use `--skip-archive` only when the current lab definitions are disposable.
-
-Deploy:
+A later deployment can restore the latest verified set:
 
 ```bash
-hyops blueprint deploy \
-  --env <env> \
-  --ref gcp/eve-ng@v1 \
-  --blueprints-root blueprints \
-  --execute
+hyops blueprint deploy --env <env> --ref gcp/eve-ng@v1 --execute --restore-labs
 ```
 
-When a verified lab archive exists for the environment, an interactive deploy
-offers to restore it after the host is ready. For non-interactive recovery:
+Restore verifies the lab archive and any node-state companion checksum before applying retained state. Existing content remains protected unless replacement is explicitly authorised.
+
+## Rebuild
 
 ```bash
-hyops blueprint deploy \
-  --env <env> \
-  --ref gcp/eve-ng@v1 \
-  --execute \
-  --restore-labs
+hyops blueprint rebuild --env <env> --ref gcp/eve-ng@v1 --execute
 ```
 
-The restore verifies the recorded checksum and protects existing lab
-definitions. Add `--overwrite-labs` only when replacing existing definitions
-is intentional.
+Rebuild applies the same lifecycle boundary: preserve the selected continuity state, release the current execution resources, recreate the host, restore verified state and return the lab through the normal EVE-NG readiness path.
 
-Rebuild the blueprint-managed resources:
+## Shared implementation
 
-```bash
-hyops blueprint rebuild \
-  --env <env> \
-  --ref gcp/eve-ng@v1 \
-  --execute
-```
+The lab-platform layer is composed from:
 
-The command shows the destroy and deploy order and requests confirmation before
-the first destroy step.
+- [EVE-NG configuration](../../../modules/platform/linux/eve-ng)
+- [EVE-NG images](../../../modules/platform/linux/eve-ng-images)
+- [EVE-NG health check](../../../modules/platform/linux/eve-ng-healthcheck)
+- [EVE-NG lab archive](../../../modules/platform/linux/eve-ng-lab-archive)
 
-## Default Shape
-
-The shipped blueprint provisions one VM:
-
-- logical name: `eve-ng-01`
-- role: `eve-ng`
-- machine type: `n2-standard-8`
-- boot disk: `256` GB `pd-standard`
-- source image: Ubuntu 22.04 LTS
-- public IP: disabled
-- nested virtualization: enabled
-- SSH user: `opsadmin`
-- network tag: `allow-iap-ssh`
-
-The VM is placed on the private subnet created by the blueprint's lab-network
-step.
-
-The starter image set contains Alpine Linux, NETem, Tiny Core Linux, and Ubuntu
-Server. Additional public image entries are retained as commented choices in
-the blueprint. They are not downloaded unless an operator enables them. This
-keeps the first deployment relatively small and avoids filling the VM disk with
-desktop, security, and legacy images that a lab does not need.
-
-The blueprint downloads enabled images from their upstream links at deployment
-time. HybridOps does not include the image archives in its release package.
-
-## Guest Internet Access
-
-The EVE-NG host provides a guest NAT network labelled `Cloud9`. Connect a lab
-node interface to `Cloud9` and configure that interface for DHCP. The node
-receives an address from `172.29.129.50-172.29.129.200`, uses
-`172.29.129.1` as its gateway, and reaches the internet through the EVE-NG
-host's private GCP connection.
-
-DHCP is supplied by the EVE-NG host, not by GCP. GCP provides the upstream
-network path. No additional public IP is assigned to the lab node.
-
-## Why This Exists
-
-Not every networking learner or platform operator has a Proxmox cluster available. A cloud-hosted EVE-NG path makes the host lifecycle easier to reproduce from a clean state while still keeping access private and controlled.
-
-This blueprint turns the EVE-NG host into a normal platform outcome:
-
-- the VM is provisioned from a declared contract
-- nested virtualization is explicitly enabled
-- access goes through IAP instead of exposing SSH publicly
-- EVE-NG configuration is a module step, not a manual shell session
-- the declared starter images are installed before validation
-- the final health check records whether the EVE-NG host is reachable
-
-That makes the EVE-NG host disposable enough to rebuild and predictable enough to share as part of a training or network-emulation workflow.
-
-## Related Modules
-
-- [platform/gcp/lab-network](../../../modules/platform/gcp/lab-network)
-- [platform/gcp/platform-vm](../../../modules/platform/gcp/platform-vm)
-- [platform/linux/eve-ng](../../../modules/platform/linux/eve-ng)
-- [platform/linux/eve-ng-images](../../../modules/platform/linux/eve-ng-images)
-- [platform/linux/eve-ng-healthcheck](../../../modules/platform/linux/eve-ng-healthcheck)
-
-## On-Prem Alternative
-
-If you run Proxmox, the sibling [onprem/eve-ng@v1](../../onprem/eve-ng@v1) blueprint builds EVE-NG from a Proxmox template-image and VM provisioning chain.
+The sibling [Proxmox implementation](../../onprem/eve-ng@v1) uses the same EVE-NG, health, access and archive contracts around a different execution-host lifecycle.

--- a/blueprints/gcp/gns3@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/gns3@v1/ARCHITECTURE.md
@@ -57,7 +57,21 @@ private GNS3 access          topology-node automation
 | Health layer | API, KVM, local-compute and starter-project verification |
 | Access layer | Private GNS3 client path plus session-scoped topology-node management access |
 | Continuity layer | Project directories, controller metadata and writable node disks retained away from the execution host |
+| Cost context | Resource age, fixed-resource estimate and retained-resource visibility for cloud execution |
 | Runtime evidence | Module state, archive checksum, health results, resource state and lifecycle records |
+
+## Operating control points
+
+The implementation crosses several operational disciplines, but each one resolves through the same lifecycle record.
+
+| Control point | Decision | Evidence |
+| --- | --- | --- |
+| Readiness | Is execution capacity and GNS3 usable? | Provider state, preflight, API/KVM/local-compute/starter-project health |
+| Private access | Can the operator and automation clients reach the required control surfaces? | Resolved runtime target, access session and generated client material |
+| Continuity | What project state must survive this session? | Controller/project archive, manifest and SHA-256 value |
+| Compute release | Is the high-resource execution host still required? | Verified retained archive and terminal resource state |
+| Reconstruction | Has the project returned to a usable state? | Verified restore, API return and normal GNS3 health path |
+| Cost context | Which cost-bearing resources are active or deliberately retained? | Resource age, fixed-resource estimate, terminal compute state and retained-resource reporting |
 
 ## Private access and device automation
 
@@ -93,6 +107,14 @@ Base images are independently managed by default and can be reconstructed from t
 `--restore-labs` selects the latest verified archive state recorded for the environment. The runtime verifies the recorded checksum before invoking the GNS3 archive module in restore mode.
 
 The restore operation stops the GNS3 service, applies the retained project and controller state, restores ownership, starts the service and waits for the API to return. The normal blueprint health path then verifies the reconstructed lab environment.
+
+## Compute lifetime and cost boundary
+
+Access closure and compute release are separate lifecycle events. Ending the GNS3 client, UI or SSH session leaves the execution host unchanged; the host becomes eligible for release when the retained project state has been verified under the selected continuity policy.
+
+For the GCP path, HybridOps surfaces resource age and fixed-resource cost context alongside the lifecycle. Provider billing remains authoritative for realised spend. After execution compute is released, retained project archives, image sources, shared networking or other deliberately retained resources remain visible as separate state rather than being folded into the compute result.
+
+This makes the cost decision operational rather than timer-based: continuity determines when high-resource compute can end, while the terminal resource record shows what still exists afterward. The Proxmox path uses the same continuity and terminal-state contract without the GCP billing context.
 
 ## Cross-target consistency
 

--- a/blueprints/gcp/gns3@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/gns3@v1/ARCHITECTURE.md
@@ -1,0 +1,116 @@
+# GNS3 lifecycle architecture
+
+The GNS3 implementation separates the lab platform from the execution-host lifecycle. GNS3 owns projects, topology and node execution. HybridOps governs the surrounding capacity, readiness, private access, continuity preservation, reconstruction and run evidence.
+
+The same GNS3 capability modules are used by the Google Cloud and Proxmox blueprints. The execution-host layer changes; the lab-platform contract remains stable.
+
+## Lifecycle
+
+```text
+execution capacity
+      |
+      v
+GNS3 server
+      |
+      v
+declared images + starter project
+      |
+      v
+deep health verification
+      |
+      +------------------------------+
+      |                              |
+      v                              v
+private GNS3 access          topology-node automation
+      |                              |
+      +--------------+---------------+
+                     |
+                     v
+                  lab use
+                     |
+                     v
+        preserve project state
+                     |
+                     v
+           verify retained archive
+                     |
+                     v
+             release execution host
+                     |
+                     v
+          recreate execution capacity
+                     |
+                     v
+        restore verified project state
+                     |
+                     v
+             health verification
+```
+
+## Capability layers
+
+| Layer | Responsibility |
+| --- | --- |
+| Execution host | Provider or virtualisation-specific capacity and private connectivity |
+| GNS3 platform | Authenticated server, projects, topology and node execution |
+| Image layer | Declared image acquisition and template preparation |
+| Health layer | API, KVM, local-compute and starter-project verification |
+| Access layer | Private GNS3 client path plus session-scoped topology-node management access |
+| Continuity layer | Project directories, controller metadata and writable node disks retained away from the execution host |
+| Runtime evidence | Module state, archive checksum, health results, resource state and lifecycle records |
+
+## Private access and device automation
+
+The GNS3 server remains private. HybridOps resolves the current host from runtime state and establishes the access path for the session.
+
+For topology-node automation, `hyops-mgmt0` is the management network. HybridOps discovers current DHCP leases and generates scoped SSH configuration, target data and automation inventory for the operator workstation. The node's own management service remains the protocol endpoint.
+
+Live management addresses are session state. Durable role, platform, grouping and credential references can remain under operator or source-of-truth authority while the current endpoint is rediscovered after reconstruction.
+
+## Continuity model
+
+The blueprint configures `platform/linux/gns3-lab-archive` before destructive lifecycle actions.
+
+The archive retains GNS3 project directories and controller metadata. Project directories contain topology, project files and writable node disks. The GNS3 service is stopped while controller state is copied or restored, providing a consistent archive boundary, then started again before the archive operation completes.
+
+```text
+GNS3 projects + controller metadata
+                |
+                v
+       controller-side archive
+                |
+                v
+         SHA-256 verification
+                |
+                v
+          compute release
+```
+
+Base images are independently managed by default and can be reconstructed from their declarations. The archive can include the image library when policy explicitly selects that behavior.
+
+## Restore path
+
+`--restore-labs` selects the latest verified archive state recorded for the environment. The runtime verifies the recorded checksum before invoking the GNS3 archive module in restore mode.
+
+The restore operation stops the GNS3 service, applies the retained project and controller state, restores ownership, starts the service and waits for the API to return. The normal blueprint health path then verifies the reconstructed lab environment.
+
+## Cross-target consistency
+
+The GCP and Proxmox blueprints both declare:
+
+- `platform/linux/gns3-server`
+- `platform/linux/gns3-images`
+- `platform/linux/gns3-starter-lab`
+- `platform/linux/gns3-healthcheck`
+- `platform/linux/gns3-lab-archive`
+- the same `hyops-mgmt0` management subnet contract
+- archive-before-release for project and writable node state
+
+The provider-specific difference is the host and access transport. The GNS3 lifecycle, health, management and continuity contracts remain shared.
+
+## Implementation references
+
+- [Blueprint contract](blueprint.yml)
+- [GNS3 server module](../../../modules/platform/linux/gns3-server)
+- [GNS3 archive module](../../../modules/platform/linux/gns3-lab-archive)
+- [Proxmox GNS3 blueprint](../../onprem/gns3@v1)

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -1,77 +1,110 @@
-# GCP GNS3 Teaching Lab
+# GNS3 network lab
 
-Deploy a private GNS3 server and a zero-image starter topology on Google Cloud.
-The VM has no public IP; SSH, Web UI and desktop-client access use IAP.
+`gcp/gns3@v1` delivers a private GNS3 execution environment with governed access, deep health verification, device automation access, project continuity, rebuild and compute release.
+
+The blueprint uses shared GNS3 capability modules that are also used by the Proxmox path. Provider-specific infrastructure supplies the execution host; GNS3 remains authoritative for projects, topology and node execution.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the lifecycle and ownership model.
+
+## What it delivers
+
+- private nested-virtualization-capable execution compute with no public VM address
+- authenticated GNS3 server through `platform/linux/gns3-server`
+- declared image handling through `platform/linux/gns3-images`
+- a starter project through `platform/linux/gns3-starter-lab`
+- deep GNS3, KVM and local-compute health verification
+- private topology-node management through `hyops-mgmt0`
+- archive-before-release through `platform/linux/gns3-lab-archive`
+- verified restoration of projects, controller metadata and writable node disks
+- structured run records and resource-age/cost context
 
 ## Execution chain
 
 ```text
-platform/gcp/lab-network
-  -> platform/gcp/platform-vm
-  -> platform/linux/gns3-server
-  -> platform/linux/gns3-images
-  -> platform/linux/gns3-starter-lab
-  -> platform/linux/gns3-healthcheck
+private network
+  -> execution host
+  -> GNS3 server
+  -> lab images
+  -> starter project
+  -> GNS3 health verification
 ```
 
-## Prerequisites
+The executable contract is [blueprint.yml](blueprint.yml).
 
-Initialise the GCP environment and seed the GNS3 API password:
+## Prepare and deploy
 
 ```bash
-hyops init gcp --env gns3-gcp
-hyops secrets ensure --env gns3-gcp GNS3_SERVER_PASSWORD
+hyops setup gcp
+hyops init gcp --env <env>
+hyops secrets ensure --env <env> GNS3_SERVER_PASSWORD
+
+ref=gcp/gns3@v1
+hyops blueprint init --env <env> --ref "$ref"
+hyops blueprint validate --env <env> --ref "$ref"
+hyops blueprint plan --env <env> --ref "$ref"
+hyops blueprint preflight --env <env> --ref "$ref"
+hyops blueprint deploy --env <env> --ref "$ref" --execute
 ```
 
-GCP initialisation and module preflight confirm project, authentication and
-billing readiness before resources are created.
+The shipped host profile uses an `n2-standard-8` VM with 32 GB RAM, a 128 GB disk, Ubuntu 22.04 and nested virtualization. It is a reference profile that can be adjusted through the environment blueprint.
 
-## Deploy
+## Private access
+
+Open the GNS3 server through the managed private path:
 
 ```bash
-hyops blueprint preflight --env gns3-gcp --ref gcp/gns3@v1
-hyops blueprint deploy --env gns3-gcp --ref gcp/gns3@v1 --execute
+hyops blueprint access --env <env> --ref gcp/gns3@v1
 ```
 
-## Connect to GNS3
+The access session resolves the current host from HybridOps state and forwards the authenticated GNS3 API/UI endpoint through IAP. The VM and GNS3 service remain private.
+
+For direct automation of topology nodes, map a GNS3 Cloud node to `hyops-mgmt0`, connect device management interfaces to it and run:
 
 ```bash
-hyops blueprint access --env gns3-gcp --ref gcp/gns3@v1
+hyops blueprint access --env <env> --ref gcp/gns3@v1 --automation
 ```
 
-For workstation automation, add a GNS3 Cloud node mapped to `hyops-mgmt0`,
-connect device management interfaces to it, and run access with `--automation`.
-HybridOps discovers management leases and writes a scoped SSH config, target
-file and automation inventory. Optional `--route-lab` routing requires
-Linux or WSL with TUN support and a non-conflicting `172.29.130.0/24` local
-route. Windows and macOS applications use the generated SSH configuration or
-local proxy. DHCP supplies the management gateway; static devices must use
-`172.29.130.1`.
+HybridOps discovers management leases and produces session-scoped SSH configuration, target data and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
 
-Keep the command running. Open the printed HTTP endpoint in a browser or
-configure the GNS3 desktop client to use it. The default username is `gns3`.
-Retrieve the password from the environment vault:
+## Continuity and compute release
+
+The blueprint declares `platform/linux/gns3-lab-archive` as its archive-before-release contract.
+
+The retained set contains GNS3 project directories and controller metadata. Project directories carry topology files, project files and writable node disks. The archive role stops the GNS3 server while controller state is copied or restored, then returns the service to its operating state.
+
+Base images are separately managed by default and can be reconstructed from their declarations. The retained project archive therefore carries the mutable project state needed for continuation without coupling that state to the lifetime of the execution host.
+
+For an explicit protected destroy:
 
 ```bash
-hyops secrets show --env gns3-gcp --raw GNS3_SERVER_PASSWORD
+hyops blueprint destroy --env <env> --ref gcp/gns3@v1 --execute --yes \
+  --archive-before-destroy
 ```
 
-## Remove the lab
+A later deployment can restore the latest verified set:
 
 ```bash
-hyops blueprint destroy --env gns3-gcp --ref gcp/gns3@v1 --execute
+hyops blueprint deploy --env <env> --ref gcp/gns3@v1 --execute --restore-labs
 ```
 
-The interactive destroy flow can export and verify GNS3 projects before
-teardown. Project topology, controller metadata and writable node disks are
-preserved; downloadable base images are rebuilt from their declarations.
+Restore verifies the recorded SHA-256 before applying the retained controller and project state.
 
-Restore the latest verified archive during redeployment:
+## Rebuild
 
 ```bash
-hyops blueprint deploy \
-  --env gns3-gcp \
-  --ref gcp/gns3@v1 \
-  --execute \
-  --restore-labs
+hyops blueprint rebuild --env <env> --ref gcp/gns3@v1 --execute
 ```
+
+Rebuild applies the same lifecycle boundary: preserve the project state, release the current execution resources, recreate the host, restore the verified archive and return the lab through the normal GNS3 health path.
+
+## Shared implementation
+
+The lab-platform layer is composed from:
+
+- [GNS3 server](../../../modules/platform/linux/gns3-server)
+- [GNS3 images](../../../modules/platform/linux/gns3-images)
+- [GNS3 starter lab](../../../modules/platform/linux/gns3-starter-lab)
+- [GNS3 health check](../../../modules/platform/linux/gns3-healthcheck)
+- [GNS3 lab archive](../../../modules/platform/linux/gns3-lab-archive)
+
+The sibling [Proxmox implementation](../../onprem/gns3@v1) uses the same GNS3, health, access and archive contracts around a different execution-host lifecycle.

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -1,20 +1,38 @@
 # platform/linux/eve-ng-lab-archive
 
-Export learner-created EVE-NG lab definitions before workload teardown and
-restore them after redeployment. The archive contains topology data under
-`/opt/unetlab/labs`; device images and temporary node runtime data are not
-included.
+Preserves EVE-NG lab continuity independently of the execution host and restores verified state after reconstruction.
 
-When `eveng_lab_archive_path` is empty during export, the archive is written to
-the environment artifact directory:
+The primary archive contains learner-created lab definitions from `/opt/unetlab/labs`. A companion archive can also preserve stopped QEMU overlay state when the selected continuity policy requires writable node state to survive.
+
+## Export
+
+When `eveng_lab_archive_path` is empty, the primary archive is written to the environment artifact directory:
 
 ```text
 artifacts/eveng/labs/eve-ng-labs.tar.gz
 ```
 
-Restore requires the archive path and its recorded SHA-256 checksum. Existing
-lab content is protected unless `eveng_lab_archive_overwrite` is enabled.
+The module publishes the archive path, manifest, creation time and SHA-256.
 
-EVE-NG blueprints use this contract directly. After a protected teardown, run
-the same blueprint deployment with `--restore-labs` to restore the latest
-verified archive for that environment.
+For stopped-QEMU state, enable:
+
+```yaml
+eveng_lab_archive_include_node_state: true
+eveng_lab_archive_stop_running_nodes: true
+```
+
+The archive role stops running QEMU nodes, validates their overlay disks and creates a separately checksummed node-state companion archive. Base images remain independently managed and are paired with the restored overlays on the reconstructed host.
+
+## Restore
+
+Restore verifies the recorded SHA-256 before applying the primary lab archive. When a verified node-state companion is present, the runtime supplies its path and checksum through:
+
+```yaml
+eveng_lab_archive_restore_node_state: true
+eveng_lab_archive_node_state_path: <verified-companion-archive>
+eveng_lab_archive_node_state_expected_sha256: <sha256>
+```
+
+Existing lab content and runtime disks remain protected unless overwrite is explicitly enabled.
+
+EVE-NG blueprints use this contract as their archive-before-release path. A later deployment with `--restore-labs` selects and verifies the retained environment archive before restoration.

--- a/modules/platform/linux/eve-ng/README.md
+++ b/modules/platform/linux/eve-ng/README.md
@@ -1,20 +1,20 @@
 # platform/linux/eve-ng
 
-Install and configure EVE-NG on a single **Ubuntu 22.04 (Jammy)** Linux host.
+Installs and configures EVE-NG on Ubuntu 22.04 and publishes the lab-platform readiness contract used by HybridOps blueprints.
 
-This module is the provider-neutral EVE-NG capability layer used by both on-prem and cloud blueprints. It does **not** provision a VM by itself.
+This is the provider-neutral EVE-NG capability layer. Enclosing blueprints supply the execution host and access transport, allowing the same EVE-NG contract to run across private cloud and on-premises infrastructure.
 
-Supported access modes:
+Supported access transports include:
+
 - direct SSH
-- explicit bastion / jump host
+- explicit bastion or jump host
 - GCP IAP SSH
 
-For new blueprints, prefer `platform/linux/eve-ng`. The older `platform/onprem/eve-ng` module remains for compatibility with existing inputs.
+Password seeding is part of the run contract:
 
-HybridOps now treats password seeding as part of the safe run contract:
 - `load_vault_env` defaults to `true`
-- validate/preflight fail early if `EVENG_ROOT_PASSWORD` and `EVENG_ADMIN_PASSWORD` are not seeded
-- on-prem private targets can use `ssh_proxy_jump_auto: true`, which defers bastion resolution to runtime preflight instead of timing out on direct SSH
+- validate/preflight requires `EVENG_ROOT_PASSWORD` and `EVENG_ADMIN_PASSWORD`
+- private on-premises targets can resolve their bastion dynamically with `ssh_proxy_jump_auto: true`
 
 ## Usage
 
@@ -26,7 +26,7 @@ hyops apply --env dev \
   --inputs modules/platform/linux/eve-ng/examples/inputs.min.yml
 ```
 
-## Required Secrets
+## Required secrets
 
 - `EVENG_ROOT_PASSWORD`
 - `EVENG_ADMIN_PASSWORD`
@@ -36,4 +36,4 @@ hyops apply --env dev \
 - `eveng_url`
 - `cap.lab.eveng = ready`
 
-For the current EVE role, `eveng_url` is published as `http://...` unless you terminate TLS separately in front of the host.
+The enclosing blueprint can combine this readiness contract with image installation, deep health checks, private UI access, topology-node automation and the EVE-NG archive/restore lifecycle.

--- a/modules/platform/linux/gns3-lab-archive/README.md
+++ b/modules/platform/linux/gns3-lab-archive/README.md
@@ -1,12 +1,12 @@
 # platform/linux/gns3-lab-archive
 
-Export GNS3 projects and controller metadata before workload teardown and
-restore them after redeployment. Project directories include topology files
-and writable node disks.
+Preserves GNS3 project continuity independently of the execution host and restores verified controller state after reconstruction.
 
-Base images are excluded by default because the declared image step can
-download them again. Set `gns3_lab_archive_include_images` only when the archive
-must carry the image library.
+The archive contains GNS3 project directories and controller metadata. Project directories carry topology files, project files and writable node disks.
+
+Before export or restore, the archive role stops the GNS3 server so controller state is copied at a consistent lifecycle boundary. The service is started again before the operation completes.
+
+Base images are independently managed by default and can be reconstructed from their declarations. Set `gns3_lab_archive_include_images` when the selected continuity policy also requires the image library in the retained set.
 
 The default controller-side archive path is:
 
@@ -14,5 +14,14 @@ The default controller-side archive path is:
 artifacts/gns3/labs/gns3-labs.tar.gz
 ```
 
-Restore verifies the recorded SHA-256 checksum before replacing the freshly
-generated GNS3 controller state.
+Export publishes the archive path, manifest, creation time, member list and SHA-256.
+
+Restore requires the recorded checksum and verifies it before applying the retained project and controller state:
+
+```yaml
+gns3_lab_archive_action: restore
+gns3_lab_archive_path: <verified-archive>
+gns3_lab_archive_expected_sha256: <sha256>
+```
+
+GNS3 blueprints use this contract as their archive-before-release path. A later deployment with `--restore-labs` selects and verifies the retained environment archive before restoration.

--- a/modules/platform/linux/gns3-server/README.md
+++ b/modules/platform/linux/gns3-server/README.md
@@ -1,11 +1,12 @@
 # platform/linux/gns3-server
 
-Installs and configures an authenticated GNS3 server on an existing Ubuntu
-22.04 or 24.04 x86_64 host. The module is provider-neutral and can use direct
-SSH, a jump host or GCP IAP.
+Installs and configures an authenticated GNS3 server on Ubuntu 22.04 or 24.04 x86_64 and publishes the lab-platform readiness contract used by HybridOps blueprints.
 
-It installs the server and open-source emulator runtime. It does not provision
-the host, install a desktop client or supply proprietary network images.
+This is the provider-neutral GNS3 server layer. Enclosing blueprints supply the execution host and access transport, the image module supplies declared lab images, and operator-side GNS3 clients consume the private server endpoint.
+
+Supported access transports include direct SSH, a jump host and GCP IAP.
+
+The module can enable KVM-backed local compute, install the open-source emulator runtime and configure the private management network used for topology-node automation.
 
 ## Usage
 
@@ -22,3 +23,5 @@ hyops apply --env lab \
 - `gns3_url`
 - `gns3_api_port`
 - `cap.lab.gns3 = ready`
+
+The enclosing blueprint can combine this readiness contract with managed images, starter projects, deep health checks, private client access, topology-node automation and the GNS3 archive/restore lifecycle.


### PR DESCRIPTION
Documents the operating architecture behind the EVE-NG and GNS3 implementations as complete infrastructure lifecycles rather than deployment recipes.

The same implementations expose several useful review lenses:

- **Platform / DevOps / SRE:** dependency order, preflight and readiness, health gates, rebuild, terminal state and run evidence.
- **Recovery / resilience:** archive-before-release, stopped-state consistency, checksum verification, retained-state reconstruction and post-restore health.
- **Network automation:** private UI and console access, topology-node management discovery, session-scoped SSH/inventory material and node-native management protocols.
- **Cloud / FinOps:** high-resource compute lifetime, resource-age and cost context, continuity-gated compute release, and visibility of resources intentionally retained after execution compute ends.
- **Network emulation:** EVE-NG and GNS3 remain authoritative for topology, node behaviour and their native state models while the surrounding execution lifecycle is governed separately.

Changes in this PR:

- adds architecture notes for EVE-NG and GNS3;
- rewrites the implementation READMEs around readiness, private access, health, continuity, reconstruction and compute release;
- documents EVE-NG lab-definition and selected stopped-QEMU overlay preservation with verified restore;
- documents GNS3 project, controller and writable-node-state continuity;
- aligns the shared module READMEs with the shipped lifecycle contracts;
- refreshes the Core README to the current 84 runtime modules and 29 reference blueprints.

A useful review can focus on any one of these boundaries; it does not require expertise in the emulator itself.

Documentation only. No runtime behaviour changes.