### PR TITLE
feat: make preflight bypass auditable

### DIFF
--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -24,7 +24,7 @@ import yaml
 from hyops.drivers.iac.terragrunt.contracts import get_contract
 from hyops.runtime.browser import is_windows_wsl, open_operator_url
 from hyops.runtime.cost import CostEstimate, format_money
-from hyops.runtime.evidence import new_run_id
+from hyops.runtime.evidence import EvidenceWriter, new_run_id
 from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
 from hyops.runtime.gcp import diagnose_project_billing
 from hyops.runtime.gcp_cost import estimate_gcp_vm_cost
@@ -32,6 +32,11 @@ from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import read_module_state, split_module_state_ref
 from hyops.runtime.paths import resolve_runtime_paths
 from hyops.runtime.progress import ProgressDisplay, verbose_enabled
+from hyops.runtime.preflight_decision import (
+    complete_preflight_decision,
+    new_preflight_decision,
+    validate_preflight_bypass,
+)
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.source_roots import resolve_blueprints_root
 from hyops.runtime.storage import format_runtime_storage_error, require_runtime_writable
@@ -719,7 +724,12 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
     t.add_argument(
         "--skip-preflight",
         action="store_true",
-        help="Skip blueprint-level preflight gate before step execution.",
+        help="Explicitly bypass the blueprint-level preflight gate.",
+    )
+    t.add_argument(
+        "--preflight-bypass-reason",
+        default=None,
+        help="Required reason when --skip-preflight is used.",
     )
     t.add_argument(
         "--yes",
@@ -813,7 +823,12 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
     b.add_argument(
         "--skip-preflight",
         action="store_true",
-        help="Skip deploy preflight after teardown.",
+        help="Explicitly bypass deploy preflight after teardown.",
+    )
+    b.add_argument(
+        "--preflight-bypass-reason",
+        default=None,
+        help="Required reason when --skip-preflight is used.",
     )
     b.add_argument(
         "--yes",
@@ -2538,16 +2553,43 @@ def run_deploy(ns) -> int:
         print(f"ERR: blueprint deploy failed: {format_runtime_storage_error(exc)}")
         return OPERATOR_ERROR
 
+    skip_preflight = bool(getattr(ns, "skip_preflight", False))
+    try:
+        preflight_bypass_reason = validate_preflight_bypass(
+            command="deploy",
+            skip_preflight=skip_preflight,
+            reason=getattr(ns, "preflight_bypass_reason", None),
+        )
+    except ValueError as exc:
+        print(f"ERR: blueprint deploy failed: {exc}")
+        return OPERATOR_ERROR
+
+    preflight_decision = new_preflight_decision(
+        command="deploy",
+        skip_preflight=skip_preflight,
+        reason=preflight_bypass_reason,
+        scope="blueprint",
+    )
     preflight_summary: dict[str, Any] | None = None
-    if not bool(getattr(ns, "skip_preflight", False)):
+    if not skip_preflight:
         preflight_steps, preflight_required, preflight_optional = compute_preflight(payload, ns, paths)
         preflight_status = "ok" if not preflight_required else "failed"
+        preflight_decision = complete_preflight_decision(
+            preflight_decision,
+            passed=not preflight_required,
+            detail=(
+                ""
+                if not preflight_required
+                else f"required_failures={','.join(preflight_required)}"
+            ),
+        )
         preflight_summary = {
             "status": preflight_status,
             "required_failures": list(preflight_required),
             "optional_failures": list(preflight_optional),
             "steps": preflight_steps,
         }
+        ns.preflight_context = preflight_decision
         if not json_mode:
             print(
                 f"blueprint={payload['blueprint_ref']} mode={payload['mode']} "
@@ -2580,6 +2622,10 @@ def run_deploy(ns) -> int:
                     )
                 )
             return OPERATOR_ERROR
+    elif not json_mode:
+        print("WARN: blueprint preflight bypassed; decision will be recorded with executed steps")
+
+    ns.preflight_context = preflight_decision
 
     confirm_rc = _confirm_deploy_if_needed(ns, payload, paths)
     if confirm_rc != 0:
@@ -2901,6 +2947,7 @@ def run_deploy(ns) -> int:
         "required_failures": required_failures,
         "optional_failures": optional_failures,
         "steps": step_results,
+        "preflight_decision": preflight_decision,
     }
     if preflight_summary is not None:
         output["preflight"] = preflight_summary
@@ -3460,6 +3507,24 @@ def run_rebuild(ns) -> int:
         print("ERR: --json is not supported with blueprint rebuild --execute")
         return OPERATOR_ERROR
 
+    skip_preflight = bool(getattr(ns, "skip_preflight", False))
+    try:
+        preflight_bypass_reason = validate_preflight_bypass(
+            command="rebuild",
+            skip_preflight=skip_preflight,
+            reason=getattr(ns, "preflight_bypass_reason", None),
+        )
+    except ValueError as exc:
+        print(f"ERR: blueprint rebuild failed: {exc}")
+        return OPERATOR_ERROR
+
+    rebuild_preflight_decision = new_preflight_decision(
+        command="rebuild",
+        skip_preflight=skip_preflight,
+        reason=preflight_bypass_reason,
+        scope="blueprint",
+    )
+
     try:
         require_runtime_selection(
             getattr(ns, "root", None),
@@ -3497,27 +3562,24 @@ def run_rebuild(ns) -> int:
     record_dir = paths.logs_dir / "blueprint" / token / run_id
     record_dir.mkdir(parents=True, exist_ok=True)
     record_file = record_dir / "rebuild.json"
+    record_writer = EvidenceWriter(record_dir)
 
     def write_record(
         status: str, destroy_rc: int | None, deploy_rc: int | None
     ) -> None:
-        record_file.write_text(
-            json.dumps(
-                {
-                    "blueprint_ref": payload["blueprint_ref"],
-                    "env": env_name,
-                    "run_id": run_id,
-                    "status": status,
-                    "destroy_order": destroy_order,
-                    "deploy_order": payload["order"],
-                    "destroy_rc": destroy_rc,
-                    "deploy_rc": deploy_rc,
-                },
-                indent=2,
-                sort_keys=True,
-            )
-            + "\n",
-            encoding="utf-8",
+        record_writer.write_json(
+            record_file.name,
+            {
+                "blueprint_ref": payload["blueprint_ref"],
+                "env": env_name,
+                "run_id": run_id,
+                "status": status,
+                "destroy_order": destroy_order,
+                "deploy_order": payload["order"],
+                "destroy_rc": destroy_rc,
+                "deploy_rc": deploy_rc,
+                "preflight": rebuild_preflight_decision,
+            },
         )
 
     write_record("running", None, None)
@@ -3529,6 +3591,7 @@ def run_rebuild(ns) -> int:
             "execute": True,
             "archive_before_destroy": False,
             "skip_archive": bool(payload.get("archive_before_destroy")),
+            "preflight_bypass_reason": preflight_bypass_reason,
         }
     )
     print("rebuild_phase=destroy status=running")
@@ -3541,7 +3604,11 @@ def run_rebuild(ns) -> int:
 
     print("rebuild_phase=destroy status=ok")
     print("rebuild_phase=deploy status=running")
-    deploy_rc = int(run_deploy(argparse.Namespace(**child_args)))
+    deploy_ns = argparse.Namespace(**child_args)
+    deploy_rc = int(run_deploy(deploy_ns))
+    deploy_preflight = getattr(deploy_ns, "preflight_context", None)
+    if isinstance(deploy_preflight, dict):
+        rebuild_preflight_decision = dict(deploy_preflight)
     final_status = "ok" if deploy_rc == 0 else "deploy-failed"
     write_record(final_status, destroy_rc, deploy_rc)
     print(f"rebuild_phase=deploy status={'ok' if deploy_rc == 0 else 'failed'}")

--- a/hyops/blueprint/planner.py
+++ b/hyops/blueprint/planner.py
@@ -44,6 +44,7 @@ def run_step_module_command(step: dict[str, Any], payload: dict[str, Any], ns, p
         state_instance=str(step.get("state_instance") or "").strip() or None,
         allow_state_drift_recreate=bool(step.get("verify_state_on_skip", False)),
         profile_override=str(step.get("execution_profile") or "").strip() or None,
+        preflight_context=getattr(ns, "preflight_context", None),
     )
     return int(module_command.run(step_ns))
 

--- a/hyops/blueprint/tests/test_preflight_bypass.py
+++ b/hyops/blueprint/tests/test_preflight_bypass.py
@@ -1,0 +1,162 @@
+"""Tests for blueprint preflight bypass governance."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.blueprint.command import run_deploy
+from hyops.runtime.exitcodes import OPERATOR_ERROR
+from hyops.runtime.paths import RuntimePaths
+
+
+def _payload() -> dict:
+    return {
+        "blueprint_ref": "test/lab@v1",
+        "mode": "hybrid",
+        "path": "/tmp/blueprint.yml",
+        "order": ["host"],
+        "steps": [
+            {
+                "id": "host",
+                "module_ref": "platform/test/host",
+                "state_instance": "host",
+                "action": "deploy",
+                "phase": "platform",
+                "optional": False,
+                "with_deps": False,
+            }
+        ],
+        "policy": {"fail_fast": True},
+    }
+
+
+def _namespace(
+    root: Path,
+    *,
+    skip_preflight: bool = True,
+    reason: str | None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        execute=True,
+        json=False,
+        yes=True,
+        root=str(root),
+        env=None,
+        ref="test/lab@v1",
+        file="",
+        blueprints_root="blueprints",
+        module_root="modules",
+        out_dir=None,
+        deps_inputs_dir=None,
+        deps_force=False,
+        skip_preflight=skip_preflight,
+        preflight_bypass_reason=reason,
+        restore_labs=False,
+        skip_lab_restore=False,
+        overwrite_labs=False,
+    )
+
+
+class BlueprintPreflightBypassTest(TestCase):
+    def test_mutating_blueprint_bypass_requires_reason(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = RuntimePaths.from_root(root)
+            with (
+                patch("hyops.blueprint.command._resolve_and_validate", return_value=_payload()),
+                patch("hyops.blueprint.command.require_runtime_selection"),
+                patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+                patch("hyops.blueprint.command.ensure_layout"),
+                patch("hyops.blueprint.command.require_runtime_writable"),
+                patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+                patch("hyops.blueprint.command.run_step_module_command") as step_command,
+            ):
+                rc = run_deploy(_namespace(root, reason=None))
+
+        self.assertEqual(rc, OPERATOR_ERROR)
+        step_command.assert_not_called()
+
+    def test_bypass_decision_is_propagated_to_executed_steps(self) -> None:
+        captured: dict = {}
+
+        def run_step(_step, _payload, ns, _paths):
+            captured.update(ns.preflight_context)
+            return 0
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = RuntimePaths.from_root(root)
+            with (
+                patch("hyops.blueprint.command._resolve_and_validate", return_value=_payload()),
+                patch("hyops.blueprint.command.require_runtime_selection"),
+                patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+                patch("hyops.blueprint.command.ensure_layout"),
+                patch("hyops.blueprint.command.require_runtime_writable"),
+                patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+                patch("hyops.blueprint.command._confirm_deploy_if_needed", return_value=0),
+                patch("hyops.blueprint.command.resolved_step_inputs_file", return_value=None),
+                patch("hyops.blueprint.command.module_state_ok", return_value=False),
+                patch("hyops.blueprint.command.enforce_step_contracts"),
+                patch("hyops.blueprint.command.run_step_module_command", side_effect=run_step),
+            ):
+                rc = run_deploy(
+                    _namespace(root, reason="controlled provider recovery")
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(captured["scope"], "blueprint")
+        self.assertEqual(captured["decision"], "bypass")
+        self.assertEqual(captured["status"], "bypassed")
+        self.assertEqual(captured["reason"], "controlled provider recovery")
+
+    def test_checked_decision_is_propagated_to_executed_steps(self) -> None:
+        captured: dict = {}
+
+        def run_step(_step, _payload, ns, _paths):
+            captured.update(ns.preflight_context)
+            return 0
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = RuntimePaths.from_root(root)
+            preflight_steps = [{"id": "host", "status": "ready"}]
+            with (
+                patch("hyops.blueprint.command._resolve_and_validate", return_value=_payload()),
+                patch("hyops.blueprint.command.require_runtime_selection"),
+                patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+                patch("hyops.blueprint.command.ensure_layout"),
+                patch("hyops.blueprint.command.require_runtime_writable"),
+                patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+                patch(
+                    "hyops.blueprint.command.compute_preflight",
+                    return_value=(preflight_steps, [], []),
+                ),
+                patch("hyops.blueprint.command._confirm_deploy_if_needed", return_value=0),
+                patch("hyops.blueprint.command.resolved_step_inputs_file", return_value=None),
+                patch("hyops.blueprint.command.module_state_ok", return_value=False),
+                patch("hyops.blueprint.command.enforce_step_contracts"),
+                patch("hyops.blueprint.command.run_step_module_command", side_effect=run_step),
+            ):
+                rc = run_deploy(
+                    _namespace(
+                        root,
+                        skip_preflight=False,
+                        reason=None,
+                    )
+                )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(captured["scope"], "blueprint")
+        self.assertEqual(captured["decision"], "enforce")
+        self.assertEqual(captured["status"], "passed")
+        self.assertEqual(captured["guarantee"], "established")
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/hyops/blueprint/tests/test_preflight_bypass.py
+++ b/hyops/blueprint/tests/test_preflight_bypass.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 

--- a/hyops/blueprint/tests/test_preflight_bypass.py
+++ b/hyops/blueprint/tests/test_preflight_bypass.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
 from hyops.blueprint.command import run_deploy
 from hyops.runtime.exitcodes import OPERATOR_ERROR
 from hyops.runtime.paths import RuntimePaths
+from hyops.runner.command import _remote_blueprint_command
 
 
 def _payload() -> dict:
@@ -154,6 +156,28 @@ class BlueprintPreflightBypassTest(TestCase):
         self.assertEqual(captured["decision"], "enforce")
         self.assertEqual(captured["status"], "passed")
         self.assertEqual(captured["guarantee"], "established")
+
+    def test_runner_forwards_bypass_reason_to_remote_command(self) -> None:
+        ns = SimpleNamespace(
+            runner_blueprint_cmd="deploy",
+            execute=True,
+            skip_preflight=True,
+            preflight_bypass_reason="controlled provider recovery",
+            yes=True,
+        )
+        ctx = SimpleNamespace(remote_hyops="/opt/hybridops/bin/hyops")
+
+        command = _remote_blueprint_command(
+            ns,
+            runtime_root="/tmp/runtime",
+            remote_blueprint_path="/tmp/runtime/config/blueprints/lab.yml",
+            ctx=ctx,
+        )
+
+        self.assertIn("--skip-preflight", command)
+        reason_index = command.index("--preflight-bypass-reason")
+        self.assertEqual(command[reason_index + 1], "controlled provider recovery")
+
 
 if __name__ == "__main__":
     import unittest

--- a/hyops/blueprint/tests/test_rebuild.py
+++ b/hyops/blueprint/tests/test_rebuild.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -42,6 +43,7 @@ def _namespace(root: str, *, execute: bool) -> argparse.Namespace:
         deps_inputs_dir=None,
         deps_force=False,
         skip_preflight=False,
+        preflight_bypass_reason=None,
     )
 
 
@@ -104,6 +106,37 @@ class BlueprintRebuildTests(unittest.TestCase):
         rendered = output.getvalue()
         self.assertNotIn("destroy_order:", rendered)
         self.assertNotIn("deploy_order:", rendered)
+
+    def test_bypass_is_recorded_before_rebuild_destroy(self) -> None:
+        observed = {}
+
+        def destroy(ns):
+            record = Path(ns.root) / "logs/blueprint/gcp_eve-ng_v1/rebuild-test/rebuild.json"
+            observed.update(json.loads(record.read_text(encoding="utf-8")))
+            observed["_file_mode"] = record.stat().st_mode & 0o777
+            return 2
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.blueprint.command._resolve_and_validate", return_value=_payload()
+        ), patch(
+            "hyops.blueprint.command.new_run_id", return_value="rebuild-test"
+        ), patch("hyops.blueprint.command.run_destroy", side_effect=destroy), patch(
+            "hyops.blueprint.command.run_deploy"
+        ) as deploy:
+            ns = _namespace(tmp, execute=True)
+            ns.skip_preflight = True
+            ns.preflight_bypass_reason = "controlled rebuild recovery"
+            self.assertEqual(run_rebuild(ns), 2)
+
+        deploy.assert_not_called()
+        self.assertEqual(observed["status"], "running")
+        self.assertEqual(observed["preflight"]["decision"], "bypass")
+        self.assertEqual(observed["preflight"]["status"], "bypassed")
+        self.assertEqual(
+            observed["preflight"]["reason"],
+            "controlled rebuild recovery",
+        )
+        self.assertEqual(observed["_file_mode"], 0o600)
 
 
 if __name__ == "__main__":

--- a/hyops/commands/_apply_execute.py
+++ b/hyops/commands/_apply_execute.py
@@ -335,6 +335,8 @@ def run_single(
             preflight_request["lifecycle_command"] = command_name
             try:
                 preflight_result = driver_fn(preflight_request)
+                if not isinstance(preflight_result, dict):
+                    raise TypeError("driver preflight returned a non-object result")
             except Exception as exc:
                 preflight_decision = complete_preflight_decision(
                     preflight_decision,
@@ -343,8 +345,6 @@ def run_single(
                 )
                 write_preflight_decision(preflight_decision)
                 raise
-            if not isinstance(preflight_result, dict):
-                raise TypeError("driver preflight returned a non-object result")
             ev.write_json("preflight_result.json", preflight_result)
 
             preflight_status = str(preflight_result.get("status", "unknown")).strip().lower()

--- a/hyops/commands/_apply_execute.py
+++ b/hyops/commands/_apply_execute.py
@@ -27,6 +27,11 @@ from hyops.runtime.exitcodes import CANCELLED
 from hyops.runtime.module_resolve import resolve_module
 from hyops.runtime.module_state import write_module_state
 from hyops.runtime.operator_output import concise_error
+from hyops.runtime.preflight_decision import (
+    complete_preflight_decision,
+    new_preflight_decision,
+    validate_preflight_bypass,
+)
 from hyops.runtime.progress import ProgressDisplay
 from hyops.runtime.stamp import stamp_runtime
 from hyops.runtime.storage import format_runtime_storage_error, require_runtime_writable
@@ -42,6 +47,8 @@ def run_single(
     inputs_file: Path | None,
     out_dir: str | None,
     skip_preflight: bool,
+    preflight_bypass_reason: str = "",
+    preflight_context: dict[str, Any] | None = None,
     state_instance: str | None,
     allow_state_drift_recreate: bool = False,
     import_resource_address: str | None = None,
@@ -51,6 +58,16 @@ def run_single(
     command_name = str(command_name or "apply").strip().lower()
     if command_name not in ("apply", "deploy", "plan", "validate", "destroy", "import"):
         command_name = "apply"
+
+    try:
+        preflight_bypass_reason = validate_preflight_bypass(
+            command=command_name,
+            skip_preflight=skip_preflight,
+            reason=preflight_bypass_reason,
+        )
+    except ValueError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
 
     try:
         require_runtime_writable(paths.root)
@@ -212,27 +229,38 @@ def run_single(
     except Exception:
         pass
 
-    ev.write_json(
-        "meta.json",
-        {
-            "command": command_name,
-            "run_id": run_id,
-            "module_ref": module_ref,
-            "execution": execution_payload,
-            "requirements": {"credentials": resolved.required_credentials},
-            "dependencies": {
-                "items": resolved.dependencies,
-                "warnings": resolved.dependency_warnings,
-            },
-            "outputs": {"publish": resolved.outputs_publish},
-            "paths": {
-                "runtime_root": str(paths.root),
-                "env": str(env_name or ""),
-                "evidence_dir": str(evidence_dir),
-                "state_dir": str(paths.state_dir),
-            },
-        },
+    preflight_decision = new_preflight_decision(
+        command=command_name,
+        skip_preflight=skip_preflight,
+        reason=preflight_bypass_reason,
+        parent=preflight_context,
     )
+    meta_payload: dict[str, Any] = {
+        "command": command_name,
+        "run_id": run_id,
+        "module_ref": module_ref,
+        "execution": execution_payload,
+        "requirements": {"credentials": resolved.required_credentials},
+        "dependencies": {
+            "items": resolved.dependencies,
+            "warnings": resolved.dependency_warnings,
+        },
+        "outputs": {"publish": resolved.outputs_publish},
+        "paths": {
+            "runtime_root": str(paths.root),
+            "env": str(env_name or ""),
+            "evidence_dir": str(evidence_dir),
+            "state_dir": str(paths.state_dir),
+        },
+        "preflight": preflight_decision,
+    }
+
+    def write_preflight_decision(decision: dict[str, Any]) -> None:
+        meta_payload["preflight"] = decision
+        ev.write_json("preflight_decision.json", decision)
+        ev.write_json("meta.json", meta_payload)
+
+    write_preflight_decision(preflight_decision)
     ev.write_json(
         "inputs_resolved.json",
         {
@@ -305,12 +333,29 @@ def run_single(
             preflight_request = dict(request)
             preflight_request["command"] = "preflight"
             preflight_request["lifecycle_command"] = command_name
-            preflight_result = driver_fn(preflight_request)
+            try:
+                preflight_result = driver_fn(preflight_request)
+            except Exception as exc:
+                preflight_decision = complete_preflight_decision(
+                    preflight_decision,
+                    passed=False,
+                    detail=str(exc),
+                )
+                write_preflight_decision(preflight_decision)
+                raise
+            if not isinstance(preflight_result, dict):
+                raise TypeError("driver preflight returned a non-object result")
             ev.write_json("preflight_result.json", preflight_result)
 
             preflight_status = str(preflight_result.get("status", "unknown")).strip().lower()
+            preflight_error = str(preflight_result.get("error") or "").strip()
+            preflight_decision = complete_preflight_decision(
+                preflight_decision,
+                passed=preflight_status == "ok",
+                detail=preflight_error,
+            )
+            write_preflight_decision(preflight_decision)
             if preflight_status != "ok":
-                preflight_error = str(preflight_result.get("error") or "").strip()
                 persist_status_error_state(preflight_error or "preflight failed")
                 if preflight_error:
                     print(

--- a/hyops/commands/apply.py
+++ b/hyops/commands/apply.py
@@ -18,6 +18,7 @@ from hyops.runtime.exitcodes import CANCELLED
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import normalize_state_instance
 from hyops.runtime.paths import resolve_runtime_paths
+from hyops.runtime.preflight_decision import validate_preflight_bypass
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.source_roots import resolve_input_path, resolve_module_root
 
@@ -56,7 +57,12 @@ def _configure_parser(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--skip-preflight",
         action="store_true",
-        help="Skip driver preflight checks (not recommended).",
+        help="Explicitly bypass driver preflight checks.",
+    )
+    p.add_argument(
+        "--preflight-bypass-reason",
+        default=None,
+        help="Required reason when a mutating command uses --skip-preflight.",
     )
     p.set_defaults(_handler=run)
 
@@ -120,6 +126,16 @@ def run(ns) -> int:
         else None
     )
     skip_preflight = bool(getattr(ns, "skip_preflight", False))
+    try:
+        preflight_bypass_reason = validate_preflight_bypass(
+            command=command_name,
+            skip_preflight=skip_preflight,
+            reason=getattr(ns, "preflight_bypass_reason", None),
+        )
+    except ValueError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    preflight_context = getattr(ns, "preflight_context", None)
     allow_state_drift_recreate = bool(getattr(ns, "allow_state_drift_recreate", False))
 
     if with_deps and command_name not in ("apply", "deploy"):
@@ -155,6 +171,8 @@ def run(ns) -> int:
                 inputs_file=dep_inputs,
                 out_dir=out_dir,
                 skip_preflight=skip_preflight,
+                preflight_bypass_reason=preflight_bypass_reason,
+                preflight_context=preflight_context,
                 state_instance=None,
                 allow_state_drift_recreate=allow_state_drift_recreate,
                 profile_override=getattr(ns, "profile_override", None),
@@ -185,6 +203,8 @@ def run(ns) -> int:
         inputs_file=inputs_file,
         out_dir=out_dir,
         skip_preflight=skip_preflight,
+        preflight_bypass_reason=preflight_bypass_reason,
+        preflight_context=preflight_context,
         state_instance=state_instance,
         allow_state_drift_recreate=allow_state_drift_recreate,
         profile_override=getattr(ns, "profile_override", None),

--- a/hyops/commands/notes.md
+++ b/hyops/commands/notes.md
@@ -8,10 +8,14 @@
 4. Create evidence dir:
    - `<root>/logs/module/<module_id>/<run_id>/`
 5. Best-effort stamp to `<root>/meta/runtime.json`.
-6. Resolve driver ref to a `DriverFunc`.
-7. Build DriverRequest and invoke driver.
-8. Persist:
+6. Record the preflight enforcement decision.
+7. Resolve driver ref to a `DriverFunc`.
+8. Run driver preflight unless an explicit bypass was recorded.
+9. Build DriverRequest and invoke driver.
+10. Persist:
    - `meta.json`
+   - `preflight_decision.json`
+   - `preflight_result.json` when driver preflight runs
    - `result.json`
    - any driver artifacts
 

--- a/hyops/commands/rebuild.py
+++ b/hyops/commands/rebuild.py
@@ -16,6 +16,11 @@ from hyops.runtime.evidence import EvidenceWriter, init_evidence_dir, new_run_id
 from hyops.runtime.exitcodes import CANCELLED
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
+from hyops.runtime.preflight_decision import (
+    complete_preflight_decision,
+    new_preflight_decision,
+    validate_preflight_bypass,
+)
 from hyops.runtime.refs import module_id_from_ref, normalize_module_ref
 from hyops.runtime.root import require_runtime_selection
 
@@ -42,7 +47,12 @@ def add_subparser(sp: argparse._SubParsersAction) -> None:
     p.add_argument(
         "--skip-preflight",
         action="store_true",
-        help="Skip preflight phase (not recommended).",
+        help="Explicitly bypass the rebuild preflight phase.",
+    )
+    p.add_argument(
+        "--preflight-bypass-reason",
+        default=None,
+        help="Required reason when --skip-preflight is used.",
     )
     p.add_argument(
         "--yes",
@@ -96,6 +106,17 @@ def run(ns) -> int:
     module_ref = normalize_module_ref(module_ref_raw)
     if not module_ref:
         print("ERR: module_ref is required")
+        return 2
+
+    skip_preflight = bool(getattr(ns, "skip_preflight", False))
+    try:
+        preflight_bypass_reason = validate_preflight_bypass(
+            command="rebuild",
+            skip_preflight=skip_preflight,
+            reason=getattr(ns, "preflight_bypass_reason", None),
+        )
+    except ValueError as exc:
+        print(f"ERR: {exc}")
         return 2
 
     confirm_module_raw = str(getattr(ns, "confirm_module", "") or "").strip()
@@ -154,14 +175,22 @@ def run(ns) -> int:
         "module_id": module_id,
         "status": "error",
         "phases": {},
+        "preflight": new_preflight_decision(
+            command="rebuild",
+            skip_preflight=skip_preflight,
+            reason=preflight_bypass_reason,
+            scope="rebuild",
+        ),
     }
+
     def _write_rebuild_metadata() -> None:
         ev.write_json("meta.json", summary)
+        ev.write_json("preflight_decision.json", summary["preflight"])
         ev.write_json("rebuild_summary.json", summary)
 
     _write_rebuild_metadata()
 
-    if not bool(getattr(ns, "skip_preflight", False)):
+    if not skip_preflight:
         preflight_ns = SimpleNamespace(
             root=getattr(ns, "root", None),
             env=getattr(ns, "env", None),
@@ -176,6 +205,11 @@ def run(ns) -> int:
             inputs=getattr(ns, "inputs", None),
         )
         rc_preflight = int(cmd_preflight.run(preflight_ns))
+        summary["preflight"] = complete_preflight_decision(
+            summary["preflight"],
+            passed=rc_preflight == 0,
+            detail="" if rc_preflight == 0 else f"exit_code={rc_preflight}",
+        )
         summary["phases"]["preflight"] = {"status": "ok" if rc_preflight == 0 else "error", "exit_code": rc_preflight}
         if rc_preflight == CANCELLED:
             summary["phases"]["preflight"]["status"] = "cancelled"
@@ -197,7 +231,8 @@ def run(ns) -> int:
         deps_inputs_dir=None,
         deps_force=False,
         out_dir=getattr(ns, "out_dir", None),
-        skip_preflight=bool(getattr(ns, "skip_preflight", False)),
+        skip_preflight=skip_preflight,
+        preflight_bypass_reason=preflight_bypass_reason,
     )
     rc_destroy = int(cmd_apply.run(destroy_ns))
     summary["phases"]["destroy"] = {"status": "ok" if rc_destroy == 0 else "error", "exit_code": rc_destroy}
@@ -221,7 +256,8 @@ def run(ns) -> int:
         deps_inputs_dir=getattr(ns, "deps_inputs_dir", None),
         deps_force=bool(getattr(ns, "deps_force", False)),
         out_dir=getattr(ns, "out_dir", None),
-        skip_preflight=bool(getattr(ns, "skip_preflight", False)),
+        skip_preflight=skip_preflight,
+        preflight_bypass_reason=preflight_bypass_reason,
     )
     rc_apply = int(cmd_apply.run(apply_ns))
     summary["phases"]["apply"] = {"status": "ok" if rc_apply == 0 else "error", "exit_code": rc_apply}

--- a/hyops/drivers/iac/terragrunt/README.md
+++ b/hyops/drivers/iac/terragrunt/README.md
@@ -36,7 +36,7 @@ Notes:
 - `hyops preflight --module ...`: runs driver contract checks without terragrunt execution.
 - Export hooks are executed only for `apply`/`deploy`.
 
-By default, `hyops apply|deploy|plan|validate` runs driver preflight first and fails fast on contract errors. Use `--skip-preflight` only for controlled troubleshooting.
+Module lifecycle commands run driver preflight by default and fail fast on contract errors. A mutating bypass is limited to controlled recovery or troubleshooting, requires `--skip-preflight` with `--preflight-bypass-reason`, and is recorded before driver execution. Contract resolution and structural validation remain enforced.
 
 Terraform provider cache:
 

--- a/hyops/runner/command.py
+++ b/hyops/runner/command.py
@@ -20,7 +20,10 @@ from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import normalize_module_state_ref, read_module_state
 from hyops.runtime.module_state_contracts import resolve_inventory_groups_from_state
 from hyops.runtime.paths import resolve_runtime_paths
-from hyops.runtime.preflight_decision import validate_preflight_bypass
+from hyops.runtime.preflight_decision import (
+    new_preflight_decision,
+    validate_preflight_bypass,
+)
 from hyops.runtime.proc import run_capture_stream
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.terraform_cloud import (
@@ -914,6 +917,7 @@ def _sync_secret_source_to_runtime(ns, *, paths) -> None:
 
 
 def _execute_runner_blueprint(ns) -> int:
+    preflight_decision: dict[str, Any] | None = None
     if str(getattr(ns, "runner_blueprint_cmd", "") or "").strip() == "deploy":
         try:
             ns.preflight_bypass_reason = validate_preflight_bypass(
@@ -924,6 +928,13 @@ def _execute_runner_blueprint(ns) -> int:
         except ValueError as exc:
             print(f"ERR: runner blueprint setup failed: {exc}")
             return OPERATOR_ERROR
+        preflight_decision = new_preflight_decision(
+            command="deploy",
+            skip_preflight=bool(getattr(ns, "skip_preflight", False)),
+            reason=ns.preflight_bypass_reason,
+            scope="blueprint",
+            decision_source="runner-cli",
+        )
 
     try:
         require_runtime_selection(
@@ -968,23 +979,19 @@ def _execute_runner_blueprint(ns) -> int:
     evidence_root = paths.logs_dir / "runner"
     evidence_dir = init_evidence_dir(evidence_root, run_id)
     ev = EvidenceWriter(evidence_dir)
-    ev.write_json(
-        "dispatch.request.json",
-        {
-            "runner_state_ref": ctx.state_ref,
-            "runner_vm_key": ctx.vm_key,
-            "runtime_root": str(paths.root),
-            "blueprint_file": str(blueprint_path),
-            "runner_blueprint_cmd": ns.runner_blueprint_cmd,
-            "preflight_bypass": {
-                "requested": bool(getattr(ns, "skip_preflight", False)),
-                "reason": str(getattr(ns, "preflight_bypass_reason", "") or ""),
-            },
-            "sync_env": sync_env_keys,
-            "tfc_dispatch": tfc_meta,
-            "gcp_dispatch": gcp_meta,
-        },
-    )
+    dispatch_request: dict[str, Any] = {
+        "runner_state_ref": ctx.state_ref,
+        "runner_vm_key": ctx.vm_key,
+        "runtime_root": str(paths.root),
+        "blueprint_file": str(blueprint_path),
+        "runner_blueprint_cmd": ns.runner_blueprint_cmd,
+        "sync_env": sync_env_keys,
+        "tfc_dispatch": tfc_meta,
+        "gcp_dispatch": gcp_meta,
+    }
+    if preflight_decision is not None:
+        dispatch_request["preflight"] = preflight_decision
+    ev.write_json("dispatch.request.json", dispatch_request)
     print(f"runner={ctx.state_ref} status=running run_id={run_id}")
     print(f"run record: {evidence_dir}")
 

--- a/hyops/runner/command.py
+++ b/hyops/runner/command.py
@@ -20,6 +20,7 @@ from hyops.runtime.layout import ensure_layout
 from hyops.runtime.module_state import normalize_module_state_ref, read_module_state
 from hyops.runtime.module_state_contracts import resolve_inventory_groups_from_state
 from hyops.runtime.paths import resolve_runtime_paths
+from hyops.runtime.preflight_decision import validate_preflight_bypass
 from hyops.runtime.proc import run_capture_stream
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.terraform_cloud import (
@@ -173,7 +174,12 @@ def add_runner_subparser(sp: argparse._SubParsersAction) -> None:
     dep = bssp.add_parser("deploy", help="Run blueprint deploy from the selected runner.")
     add_common_args(dep)
     dep.add_argument("--execute", action="store_true", help="Execute ordered blueprint steps.")
-    dep.add_argument("--skip-preflight", action="store_true", help="Skip blueprint-level preflight gate.")
+    dep.add_argument("--skip-preflight", action="store_true", help="Explicitly bypass blueprint preflight.")
+    dep.add_argument(
+        "--preflight-bypass-reason",
+        default=None,
+        help="Required reason when --skip-preflight is used.",
+    )
     dep.add_argument("--yes", action="store_true", help="Proceed without interactive confirmation.")
     dep.set_defaults(_handler=run_runner_blueprint_deploy)
 
@@ -658,6 +664,9 @@ def _remote_blueprint_command(ns, *, runtime_root: str, remote_blueprint_path: s
             cmd.append("--execute")
         if bool(getattr(ns, "skip_preflight", False)):
             cmd.append("--skip-preflight")
+            reason = str(getattr(ns, "preflight_bypass_reason", None) or "").strip()
+            if reason:
+                cmd.extend(["--preflight-bypass-reason", reason])
         if bool(getattr(ns, "yes", False)):
             cmd.append("--yes")
     return cmd
@@ -905,6 +914,17 @@ def _sync_secret_source_to_runtime(ns, *, paths) -> None:
 
 
 def _execute_runner_blueprint(ns) -> int:
+    if str(getattr(ns, "runner_blueprint_cmd", "") or "").strip() == "deploy":
+        try:
+            ns.preflight_bypass_reason = validate_preflight_bypass(
+                command="deploy",
+                skip_preflight=bool(getattr(ns, "skip_preflight", False)),
+                reason=getattr(ns, "preflight_bypass_reason", None),
+            )
+        except ValueError as exc:
+            print(f"ERR: runner blueprint setup failed: {exc}")
+            return OPERATOR_ERROR
+
     try:
         require_runtime_selection(
             getattr(ns, "root", None),
@@ -956,6 +976,10 @@ def _execute_runner_blueprint(ns) -> int:
             "runtime_root": str(paths.root),
             "blueprint_file": str(blueprint_path),
             "runner_blueprint_cmd": ns.runner_blueprint_cmd,
+            "preflight_bypass": {
+                "requested": bool(getattr(ns, "skip_preflight", False)),
+                "reason": str(getattr(ns, "preflight_bypass_reason", "") or ""),
+            },
             "sync_env": sync_env_keys,
             "tfc_dispatch": tfc_meta,
             "gcp_dispatch": gcp_meta,

--- a/hyops/runtime/README.md
+++ b/hyops/runtime/README.md
@@ -23,6 +23,12 @@ Runtime root is operator state (not repo state). Commands MUST NOT infer repo ro
 - Module: `<root>/logs/module/<module_id>/<run_id>/`
 - Driver: `<root>/logs/driver/<driver_id>/<run_id>/`
 
+Each module run writes `preflight_decision.json`. A normal run records the
+driver preflight result before execution. A mutating bypass requires
+`--skip-preflight` with `--preflight-bypass-reason`; the decision and reason are
+written before the driver can mutate resources. Contract resolution, schema
+validation, and execution-schema checks are not bypassed.
+
 ## Retention and cleanup
 
 The runtime root belongs to the operator. HybridOps does not delete run records

--- a/hyops/runtime/preflight_decision.py
+++ b/hyops/runtime/preflight_decision.py
@@ -1,0 +1,89 @@
+"""Preflight enforcement and audit records for governed execution."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+
+MUTATING_COMMANDS = frozenset({"apply", "deploy", "destroy", "import", "rebuild"})
+MAX_BYPASS_REASON_LENGTH = 500
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def validate_preflight_bypass(
+    *,
+    command: str,
+    skip_preflight: bool,
+    reason: str | None,
+) -> str:
+    """Validate a preflight bypass request and return its normalized reason."""
+
+    command_name = str(command or "").strip().lower()
+    normalized = str(reason or "").strip()
+
+    if normalized and not skip_preflight:
+        raise ValueError("--preflight-bypass-reason requires --skip-preflight")
+    if any(ord(char) < 32 or ord(char) == 127 for char in normalized):
+        raise ValueError("--preflight-bypass-reason must be a single printable line")
+    if len(normalized) > MAX_BYPASS_REASON_LENGTH:
+        raise ValueError(
+            "--preflight-bypass-reason must not exceed "
+            f"{MAX_BYPASS_REASON_LENGTH} characters"
+        )
+    if skip_preflight and command_name in MUTATING_COMMANDS and not normalized:
+        raise ValueError(
+            "--skip-preflight for a mutating command requires "
+            "--preflight-bypass-reason"
+        )
+    return normalized
+
+
+def new_preflight_decision(
+    *,
+    command: str,
+    skip_preflight: bool,
+    reason: str = "",
+    scope: str = "driver",
+    decision_source: str = "operator-cli",
+    parent: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create the record written before a command can cross its preflight boundary."""
+
+    bypassed = bool(skip_preflight)
+    decision: dict[str, Any] = {
+        "schema_version": 1,
+        "scope": str(scope or "driver").strip(),
+        "requirement": f"{str(scope or 'driver').strip()}-preflight",
+        "command": str(command or "").strip().lower(),
+        "mutating": str(command or "").strip().lower() in MUTATING_COMMANDS,
+        "decision": "bypass" if bypassed else "enforce",
+        "status": "bypassed" if bypassed else "pending",
+        "guarantee": "not-established" if bypassed else "pending",
+        "decision_source": str(decision_source or "operator-cli").strip(),
+        "reason": str(reason or "").strip(),
+        "recorded_at": _utc_now(),
+    }
+    if parent:
+        decision["parent"] = dict(parent)
+    return decision
+
+
+def complete_preflight_decision(
+    decision: Mapping[str, Any],
+    *,
+    passed: bool,
+    detail: str = "",
+) -> dict[str, Any]:
+    """Return a completed copy of an enforced preflight decision."""
+
+    completed = dict(decision)
+    completed["status"] = "passed" if passed else "failed"
+    completed["guarantee"] = "established" if passed else "not-established"
+    completed["completed_at"] = _utc_now()
+    if detail:
+        completed["detail"] = str(detail).strip()
+    return completed

--- a/hyops/runtime/tests/test_preflight_decision.py
+++ b/hyops/runtime/tests/test_preflight_decision.py
@@ -1,0 +1,201 @@
+"""Tests for auditable preflight decisions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.commands._apply_execute import run_single
+from hyops.runtime.paths import RuntimePaths
+from hyops.runtime.preflight_decision import (
+    complete_preflight_decision,
+    new_preflight_decision,
+    validate_preflight_bypass,
+)
+
+
+class PreflightDecisionContractTest(TestCase):
+    def test_mutating_bypass_requires_reason(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires --preflight-bypass-reason"):
+            validate_preflight_bypass(
+                command="apply",
+                skip_preflight=True,
+                reason=None,
+            )
+
+    def test_non_mutating_bypass_remains_available_without_reason(self) -> None:
+        self.assertEqual(
+            validate_preflight_bypass(
+                command="validate",
+                skip_preflight=True,
+                reason=None,
+            ),
+            "",
+        )
+
+    def test_reason_without_bypass_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires --skip-preflight"):
+            validate_preflight_bypass(
+                command="destroy",
+                skip_preflight=False,
+                reason="provider incident",
+            )
+
+    def test_completed_decision_preserves_original_record_time(self) -> None:
+        pending = new_preflight_decision(
+            command="deploy",
+            skip_preflight=False,
+        )
+        completed = complete_preflight_decision(pending, passed=True)
+
+        self.assertEqual(completed["status"], "passed")
+        self.assertEqual(completed["guarantee"], "established")
+        self.assertEqual(completed["recorded_at"], pending["recorded_at"])
+        self.assertIn("completed_at", completed)
+
+
+class ModulePreflightEvidenceTest(TestCase):
+    @staticmethod
+    def _resolved(root: Path) -> SimpleNamespace:
+        return SimpleNamespace(
+            module_ref="platform/test/module",
+            module_dir=root / "module",
+            execution={
+                "driver": "test/driver",
+                "profile": "default@v1",
+                "pack_id": "test-pack@v1",
+            },
+            spec={
+                "execution": {
+                    "driver": "test/driver",
+                    "profile": "default@v1",
+                    "pack_id": "test-pack@v1",
+                }
+            },
+            inputs={},
+            required_credentials=[],
+            dependencies=[],
+            dependency_warnings=[],
+            outputs_publish=[],
+        )
+
+    def _run(
+        self,
+        *,
+        skip_preflight: bool,
+        reason: str = "",
+        preflight_ok: bool = True,
+        malformed_preflight: bool = False,
+    ) -> tuple[int, list[str], dict]:
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        paths = RuntimePaths.from_root(root)
+        calls: list[str] = []
+
+        def driver(request):
+            command = str(request["command"])
+            calls.append(command)
+            decision_file = next(root.glob("logs/module/*/*/preflight_decision.json"))
+            decision = json.loads(decision_file.read_text(encoding="utf-8"))
+            if command == "destroy":
+                expected = "bypassed" if skip_preflight else "passed"
+                self.assertEqual(decision["status"], expected)
+            if command == "preflight" and not preflight_ok:
+                return {"status": "error", "error": "readiness check failed"}
+            if command == "preflight" and malformed_preflight:
+                return None
+            return {"status": "ok"}
+
+        with (
+            patch(
+                "hyops.commands._apply_execute.resolve_module",
+                return_value=self._resolved(root),
+            ),
+            patch("hyops.commands._apply_execute.REGISTRY.validate_execution"),
+            patch("hyops.commands._apply_execute.REGISTRY.resolve", return_value=driver),
+            patch(
+                "hyops.commands._apply_execute.new_run_id",
+                return_value="destroy-preflight-test",
+            ),
+            patch("hyops.commands._apply_execute.stamp_runtime"),
+        ):
+            rc = run_single(
+                paths=paths,
+                env_name="test",
+                command_name="destroy",
+                module_ref_raw="platform/test/module",
+                module_root=root / "modules",
+                inputs_file=None,
+                out_dir=None,
+                skip_preflight=skip_preflight,
+                preflight_bypass_reason=reason,
+                state_instance=None,
+            )
+
+        decision_file = next(root.glob("logs/module/*/*/preflight_decision.json"))
+        decision = json.loads(decision_file.read_text(encoding="utf-8"))
+        meta = json.loads(
+            (decision_file.parent / "meta.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(meta["preflight"], decision)
+        return rc, calls, decision
+
+    def test_checked_mutation_records_passed_preflight_before_driver_execution(self) -> None:
+        rc, calls, decision = self._run(skip_preflight=False)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, ["preflight", "destroy"])
+        self.assertEqual(decision["decision"], "enforce")
+        self.assertEqual(decision["status"], "passed")
+        self.assertEqual(decision["guarantee"], "established")
+
+    def test_bypass_is_recorded_with_reason_before_driver_execution(self) -> None:
+        rc, calls, decision = self._run(
+            skip_preflight=True,
+            reason="provider recovery under incident INC-42",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls, ["destroy"])
+        self.assertEqual(decision["decision"], "bypass")
+        self.assertEqual(decision["status"], "bypassed")
+        self.assertEqual(decision["guarantee"], "not-established")
+        self.assertEqual(decision["decision_source"], "operator-cli")
+        self.assertEqual(
+            decision["reason"],
+            "provider recovery under incident INC-42",
+        )
+
+    def test_failed_preflight_records_failed_guarantee_and_prevents_mutation(self) -> None:
+        rc, calls, decision = self._run(
+            skip_preflight=False,
+            preflight_ok=False,
+        )
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(calls, ["preflight"])
+        self.assertEqual(decision["status"], "failed")
+        self.assertEqual(decision["guarantee"], "not-established")
+        self.assertEqual(decision["detail"], "readiness check failed")
+
+    def test_direct_mutating_bypass_without_reason_is_rejected(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            rc = run_single(
+                paths=RuntimePaths.from_root(root),
+                env_name="test",
+                command_name="destroy",
+                module_ref_raw="platform/test/module",
+                module_root=root / "modules",
+                inputs_file=None,
+                out_dir=None,
+                skip_preflight=True,
+                state_instance=None,
+            )
+
+        self.assertEqual(rc, 2)

--- a/hyops/runtime/tests/test_preflight_decision.py
+++ b/hyops/runtime/tests/test_preflight_decision.py
@@ -183,6 +183,21 @@ class ModulePreflightEvidenceTest(TestCase):
         self.assertEqual(decision["guarantee"], "not-established")
         self.assertEqual(decision["detail"], "readiness check failed")
 
+    def test_malformed_preflight_result_is_recorded_as_failed(self) -> None:
+        rc, calls, decision = self._run(
+            skip_preflight=False,
+            malformed_preflight=True,
+        )
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(calls, ["preflight"])
+        self.assertEqual(decision["status"], "failed")
+        self.assertEqual(decision["guarantee"], "not-established")
+        self.assertEqual(
+            decision["detail"],
+            "driver preflight returned a non-object result",
+        )
+
     def test_direct_mutating_bypass_without_reason_is_rejected(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -103,6 +103,19 @@ class CliRoutingTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("edit", result.stdout)
 
+    def test_mutating_preflight_bypass_help_requires_reason(self) -> None:
+        for args in (
+            ("apply", "--help"),
+            ("rebuild", "--help"),
+            ("blueprint", "deploy", "--help"),
+            ("blueprint", "rebuild", "--help"),
+            ("runner", "blueprint", "deploy", "--help"),
+        ):
+            with self.subTest(args=args):
+                result = run_cli(*args)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("--preflight-bypass-reason", result.stdout)
+
     def test_unknown_command_returns_parser_error(self) -> None:
         result = run_cli("not-a-command")
         self.assertEqual(result.returncode, 2)

--- a/hyops/tests/test_rebuild_preflight.py
+++ b/hyops/tests/test_rebuild_preflight.py
@@ -1,0 +1,109 @@
+"""Tests for rebuild preflight evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.commands.rebuild import run
+from hyops.runtime.paths import RuntimePaths
+
+
+def _namespace(root: Path, *, skip_preflight: bool, reason: str | None) -> argparse.Namespace:
+    return argparse.Namespace(
+        root=str(root),
+        env=None,
+        module="platform/test/module",
+        module_root="modules",
+        inputs=None,
+        out_dir=None,
+        skip_preflight=skip_preflight,
+        preflight_bypass_reason=reason,
+        yes=True,
+        confirm_module=None,
+        with_deps=False,
+        deps_inputs_dir=None,
+        deps_force=False,
+    )
+
+
+class RebuildPreflightEvidenceTest(TestCase):
+    def _run(
+        self,
+        *,
+        skip_preflight: bool,
+        reason: str | None,
+    ) -> tuple[int, list[dict], dict]:
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        paths = RuntimePaths.from_root(root)
+        observed: list[dict] = []
+
+        def run_phase(_ns):
+            decision_path = (
+                root
+                / "logs/rebuild/platform__test__module/rebuild-test"
+                / "preflight_decision.json"
+            )
+            observed.append(json.loads(decision_path.read_text(encoding="utf-8")))
+            return 0
+
+        with (
+            patch("hyops.commands.rebuild.require_runtime_selection"),
+            patch("hyops.commands.rebuild.resolve_runtime_paths", return_value=paths),
+            patch("hyops.commands.rebuild.ensure_layout"),
+            patch("hyops.commands.rebuild.new_run_id", return_value="rebuild-test"),
+            patch("hyops.commands.rebuild.cmd_preflight.run", return_value=0),
+            patch("hyops.commands.rebuild.cmd_apply.run", side_effect=run_phase),
+        ):
+            rc = run(
+                _namespace(
+                    root,
+                    skip_preflight=skip_preflight,
+                    reason=reason,
+                )
+            )
+
+        summary_path = (
+            root
+            / "logs/rebuild/platform__test__module/rebuild-test"
+            / "rebuild_summary.json"
+        )
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        return rc, observed, summary
+
+    def test_checked_rebuild_records_passed_preflight_before_destroy(self) -> None:
+        rc, observed, summary = self._run(
+            skip_preflight=False,
+            reason=None,
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(observed), 2)
+        self.assertEqual(observed[0]["status"], "passed")
+        self.assertEqual(observed[0]["guarantee"], "established")
+        self.assertEqual(summary["preflight"], observed[0])
+
+    def test_bypassed_rebuild_records_reason_before_destroy(self) -> None:
+        rc, observed, summary = self._run(
+            skip_preflight=True,
+            reason="controlled rebuild recovery",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(observed), 2)
+        self.assertEqual(observed[0]["status"], "bypassed")
+        self.assertEqual(observed[0]["guarantee"], "not-established")
+        self.assertEqual(observed[0]["reason"], "controlled rebuild recovery")
+        self.assertEqual(summary["preflight"], observed[0])
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/hyops/tests/test_runner_preflight.py
+++ b/hyops/tests/test_runner_preflight.py
@@ -1,0 +1,136 @@
+"""Tests for runner preflight decision propagation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.runner.command import (
+    _execute_runner_blueprint,
+    _remote_blueprint_command,
+)
+from hyops.runtime.exitcodes import OPERATOR_ERROR
+from hyops.runtime.paths import RuntimePaths
+
+
+def _namespace(root: Path, *, reason: str | None) -> argparse.Namespace:
+    return argparse.Namespace(
+        root=str(root),
+        env=None,
+        file=str(root / "config/blueprints/lab.yml"),
+        runner_blueprint_cmd="deploy",
+        runner_state_ref="platform/linux/ops-runner#test",
+        runner_vm_key="runner",
+        execute=True,
+        skip_preflight=True,
+        preflight_bypass_reason=reason,
+        yes=True,
+        sync_env=[],
+        secret_source="runtime",
+        keep_remote_job=False,
+    )
+
+
+class RunnerPreflightDecisionTest(TestCase):
+    def test_missing_reason_stops_before_dispatch(self) -> None:
+        with patch("hyops.runner.command._sync_runtime_to_runner") as dispatch:
+            rc = _execute_runner_blueprint(_namespace(Path("/tmp/runtime"), reason=None))
+
+        self.assertEqual(rc, OPERATOR_ERROR)
+        dispatch.assert_not_called()
+
+    def test_bypass_decision_is_recorded_before_remote_execution(self) -> None:
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        paths = RuntimePaths.from_root(root)
+        blueprint_path = root / "config/blueprints/lab.yml"
+        context = SimpleNamespace(
+            state_ref="platform/linux/ops-runner#test",
+            vm_key="runner",
+            remote_hyops="/opt/hybridops/bin/hyops",
+            remote_core_root="/opt/hybridops/core",
+        )
+        observed: dict[str, object] = {}
+
+        def sync_runtime(*_args, **_kwargs):
+            record_path = root / "logs/runner/runner-test/dispatch.request.json"
+            observed["request"] = json.loads(record_path.read_text(encoding="utf-8"))
+            return "/tmp/job", "/tmp/job/runtime", "/tmp/job/dispatch.env"
+
+        def build_remote_command(ns, **kwargs):
+            command = _remote_blueprint_command(ns, **kwargs)
+            observed["command"] = command
+            return command
+
+        with (
+            patch("hyops.runner.command.require_runtime_selection"),
+            patch("hyops.runner.command.resolve_runtime_paths", return_value=paths),
+            patch("hyops.runner.command.ensure_layout"),
+            patch(
+                "hyops.runner.command._enforce_runtime_blueprint_file_scope",
+                return_value=blueprint_path,
+            ),
+            patch("hyops.runner.command._sync_secret_source_to_runtime"),
+            patch("hyops.runner.command._resolve_runner_context", return_value=context),
+            patch(
+                "hyops.runner.command._resolve_sync_env_values",
+                return_value=({}, [], ""),
+            ),
+            patch(
+                "hyops.runner.command._resolve_tfc_dispatch_env",
+                return_value=({}, {"enabled": "false"}),
+            ),
+            patch(
+                "hyops.runner.command._resolve_gcp_dispatch_env",
+                return_value=({}, {"enabled": "false"}),
+            ),
+            patch("hyops.runner.command.new_run_id", return_value="runner-test"),
+            patch(
+                "hyops.runner.command._sync_runtime_to_runner",
+                side_effect=sync_runtime,
+            ),
+            patch(
+                "hyops.runner.command._remote_blueprint_command",
+                side_effect=build_remote_command,
+            ),
+            patch("hyops.runner.command._ssh_argv", return_value=["ssh", "runner"]),
+            patch(
+                "hyops.runner.command.run_capture_stream",
+                return_value=SimpleNamespace(rc=0, stdout=""),
+            ),
+            patch("hyops.runner.command._sync_runtime_back"),
+            patch("hyops.runner.command._cleanup_local_stage"),
+            patch("hyops.runner.command._cleanup_remote_job"),
+        ):
+            rc = _execute_runner_blueprint(
+                _namespace(root, reason="controlled provider recovery")
+            )
+
+        self.assertEqual(rc, 0)
+        request = observed["request"]
+        self.assertIsInstance(request, dict)
+        decision = request["preflight"]
+        self.assertEqual(decision["schema_version"], 1)
+        self.assertEqual(decision["scope"], "blueprint")
+        self.assertEqual(decision["decision"], "bypass")
+        self.assertEqual(decision["status"], "bypassed")
+        self.assertEqual(decision["guarantee"], "not-established")
+        self.assertEqual(decision["decision_source"], "runner-cli")
+        self.assertEqual(decision["reason"], "controlled provider recovery")
+
+        command = observed["command"]
+        self.assertIn("--skip-preflight", command)
+        reason_index = command.index("--preflight-bypass-reason")
+        self.assertEqual(command[reason_index + 1], "controlled provider recovery")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tools/smoke/hyops-onprem-template-vm-smoke.sh
+++ b/tools/smoke/hyops-onprem-template-vm-smoke.sh
@@ -179,7 +179,8 @@ cleanup_vm() {
     --module platform/onprem/platform-vm \
     --state-instance "$smoke_state_instance" \
     --inputs "$vm_inputs" \
-    --skip-preflight >/dev/null 2>&1
+    --skip-preflight \
+    --preflight-bypass-reason "smoke cleanup after controlled validation" >/dev/null 2>&1
   set -e
 }
 trap cleanup_vm EXIT INT TERM


### PR DESCRIPTION
## Summary

Closes #292.

This change makes mutating preflight bypass explicit and auditable.

It requires an operator-supplied reason, records whether preflight was checked, failed or bypassed before mutation, and preserves that decision through module, blueprint, rebuild and runner execution paths.

The change includes regression tests, runtime documentation and the required smoke-flow update.

## Validation

- `bash tools/ci/check-python.sh`
  - 293 tests passed
- `git diff --check`

No candidate or environment acceptance was required for this runtime-control change.

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.