### PR TITLE
Improve EVE-NG image deployment feedback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Fixed
 
+- Surfaced EVE-NG IOL licence hostname mismatches in normal deployment output before any image changes.
+- Reported the complete configured EVE-NG image set, including operator-supplied IOL images, in blueprint progress output.
 - Protected Containerlab destroy and rebuild from proceeding without the required recovery result.
 - Tightened permissions on existing runtime directories during installation and setup.
 - Fixed deletion-only Proxmox VM-set shrink operations and external-replica DMS cleanup.

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -197,20 +197,25 @@ steps:
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/LhBG1ZQI"
           name: "linux-alpine-3.21.3.tar.gz"
           type: "qemu"
+          label: "Alpine Linux"
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/GopE0RJR"
           name: "linux-netem.tar.gz"
           type: "qemu"
+          label: "NETem"
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/nkJjgBQL"
           name: "linux-tinycore-6.4.tar.gz"
           type: "qemu"
+          label: "Tiny Core Linux"
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/uoIABDjA"
           name: "linux-ubuntu-24.04.01-server.tar.gz"
           type: "qemu"
+          label: "Ubuntu Server"
 
         # Authorised IOL image example:
         # - url: "https://example.invalid/operator-supplied-iol.bin"
         #   name: "operator-supplied-iol.bin"
         #   type: "iol"
+        #   label: "Operator IOL image"
 
         # Optional public images. Enable only what a lab needs; desktop,
         # security and legacy images can add substantial download and disk use.

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -176,20 +176,25 @@ steps:
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/LhBG1ZQI"
           name: "linux-alpine-3.21.3.tar.gz"
           type: "qemu"
+          label: "Alpine Linux"
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/GopE0RJR"
           name: "linux-netem.tar.gz"
           type: "qemu"
+          label: "NETem"
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/nkJjgBQL"
           name: "linux-tinycore-6.4.tar.gz"
           type: "qemu"
+          label: "Tiny Core Linux"
         - url: "https://mega.nz/folder/30p3TKob#42_S__9wwPVO0zHIfC4xow/file/uoIABDjA"
           name: "linux-ubuntu-24.04.01-server.tar.gz"
           type: "qemu"
+          label: "Ubuntu Server"
 
         # Authorised IOL image example:
         # - url: "https://example.invalid/operator-supplied-iol.bin"
         #   name: "operator-supplied-iol.bin"
         #   type: "iol"
+        #   label: "Operator IOL image"
 
   - id: eve_ng_healthcheck
     module_ref: "platform/linux/eve-ng-healthcheck"

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -224,6 +224,57 @@ def _cancelled_deploy_actions(ns, payload: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def _image_archive_stem(value: str) -> str:
+    stem = Path(value).name
+    for suffix in (".tar.gz", ".qcow2", ".tgz", ".zip", ".img", ".bin", ".gz"):
+        if stem.lower().endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+    if stem.lower().endswith("-clean"):
+        stem = stem[:-6]
+    return stem
+
+
+def _eveng_image_display_name(value: str) -> str:
+    stem = _image_archive_stem(value)
+    lowered = stem.lower()
+
+    if lowered.startswith("linux-alpine-"):
+        return "Alpine Linux"
+    if lowered == "linux-netem":
+        return "NETem"
+    if lowered.startswith("linux-tinycore-"):
+        return "Tiny Core Linux"
+    if lowered.startswith("linux-ubuntu-") and "server" in lowered:
+        return "Ubuntu Server"
+    return stem
+
+
+def _configured_eveng_image_labels(step: dict[str, Any]) -> list[str]:
+    if str(step.get("module_ref") or "") != "platform/linux/eve-ng-images":
+        return []
+
+    inputs = step.get("inputs")
+    if not isinstance(inputs, dict):
+        return []
+    configured = inputs.get("eveng_images_list")
+    if not isinstance(configured, list):
+        return []
+
+    labels: list[str] = []
+    for entry in configured:
+        if not isinstance(entry, dict):
+            continue
+        label = str(entry.get("label") or "").strip()
+        if not label:
+            source_name = str(entry.get("name") or entry.get("url") or "").strip()
+            if source_name:
+                label = _eveng_image_display_name(source_name)
+        if label:
+            labels.append(label)
+    return labels
+
+
 def _step_presentation(
     step: dict[str, Any],
     *,
@@ -258,7 +309,7 @@ def _step_presentation(
 
     details.append(f"overall {progress_after}%")
 
-    items = presentation.get("items")
+    items = _configured_eveng_image_labels(step) or presentation.get("items")
     item_line = ""
     if isinstance(items, list) and items:
         item_values = [str(item).strip() for item in items if str(item).strip()]

--- a/hyops/blueprint/tests/test_presentation.py
+++ b/hyops/blueprint/tests/test_presentation.py
@@ -183,3 +183,62 @@ class BlueprintPresentationTest(TestCase):
         self.assertEqual(label, "EVE-NG health checks")
         self.assertEqual(detail, "healthy, overall 100%")
         self.assertEqual(item_line, "")
+
+    def test_lists_configured_qemu_and_iol_images(self):
+        step = {
+            "id": "images",
+            "module_ref": "platform/linux/eve-ng-images",
+            "state_instance": "images",
+            "presentation": {
+                "label": "Lab images",
+                "success": "ready",
+                "items_label": "images",
+                "items": ["stale static item"],
+            },
+            "inputs": {
+                "eveng_images_list": [
+                    {
+                        "name": "linux-alpine-3.21.3.tar.gz",
+                        "type": "qemu",
+                        "url": "https://example.invalid/alpine",
+                    },
+                    {
+                        "label": "Cisco IOL L2 15.2d",
+                        "name": "iol-i86bi-linux-l2-adventerprisek9-15.2d-clean.tar.gz",
+                        "type": "iol",
+                        "url": "https://example.invalid/iol-l2",
+                    },
+                    {
+                        "label": "Operator firewall image",
+                        "name": "vendor-firewall.tar.gz",
+                        "type": "qemu",
+                        "url": "https://example.invalid/firewall",
+                    },
+                ]
+            },
+        }
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp)
+            write_module_state(
+                state_dir,
+                step["module_ref"],
+                {
+                    "status": "ok",
+                    "outputs": {"eveng_images_requested_count": 3},
+                },
+                state_instance=step["state_instance"],
+            )
+
+            label, detail, item_line = _step_presentation(
+                step,
+                state_dir=state_dir,
+                progress_after=80,
+            )
+
+        self.assertEqual(label, "Lab images")
+        self.assertEqual(detail, "ready, 3 images, overall 80%")
+        self.assertEqual(
+            item_line,
+            "  images: Alpine Linux, Cisco IOL L2 15.2d, Operator firewall image",
+        )

--- a/hyops/drivers/config/ansible/results.py
+++ b/hyops/drivers/config/ansible/results.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
+
+
+_IOL_HOST_MISMATCH = re.compile(
+    r"does not contain a licence entry for the EVE-NG hostname\s+"
+    r"([A-Za-z0-9][A-Za-z0-9_.-]*)",
+    re.IGNORECASE,
+)
 
 
 def ansible_error_hint(
@@ -29,11 +37,22 @@ def ansible_error_hint(
             continue
         if data:
             chunks.append(data[-20000:])
-    tail = "\n".join(chunks).lower()
+    tail = "\n".join(chunks)
     if not tail:
         return ""
+    lowered_tail = tail.lower()
 
-    if "data directory" in tail and "already initialized" in tail:
+    iol_host_mismatch = _IOL_HOST_MISMATCH.search(tail)
+    if module_ref.strip().lower() == "platform/linux/eve-ng-images" and iol_host_mismatch:
+        hostname = iol_host_mismatch.group(1)
+        return (
+            "IOL licence does not match this EVE-NG host. "
+            f"Current host: {hostname}. "
+            "Update EVENG_IOL_LICENSE with an authorised iourc for this host, then rerun. "
+            "No images were changed."
+        )
+
+    if "data directory" in lowered_tail and "already initialized" in lowered_tail:
         if module_ref.strip().lower() in {"platform/postgresql-ha", "platform/onprem/postgresql-ha"} and str(inputs.get("apply_mode") or "").strip().lower() in ("", "auto", "bootstrap"):
             return (
                 "postgresql-ha bootstrap detected existing initialized data directories. "
@@ -47,7 +66,7 @@ def ansible_error_hint(
 
     if (
         module_ref.strip().lower() == "platform/linux/eve-ng-lab-archive"
-        and "qemu nodes are running" in tail
+        and "qemu nodes are running" in lowered_tail
     ):
         return (
             "EVE-NG nodes are still running. Stop all active lab nodes in the "

--- a/hyops/tests/test_ansible_results.py
+++ b/hyops/tests/test_ansible_results.py
@@ -10,6 +10,35 @@ from hyops.drivers.config.ansible.results import ansible_error_hint
 
 
 class AnsibleResultHintTests(unittest.TestCase):
+    def test_eve_ng_images_reports_iol_hostname_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            (evidence_dir / "ansible_apply.stdout.txt").write_text(
+                "fatal: [eve-ng-01]: FAILED! => {\n"
+                '  "msg": "The supplied iourc document does not contain a licence entry '
+                "for the EVE-NG hostname platform-labs-eve-ng-01 or "
+                "platform-labs-eve-ng-01.europe-west2-a.c.example.internal. "
+                'Generate the licence for this host and update EVENG_IOL_LICENSE before rerunning."\n'
+                "}\n",
+                encoding="utf-8",
+            )
+
+            hint = ansible_error_hint(
+                command_name="apply",
+                module_ref="platform/linux/eve-ng-images",
+                inputs={},
+                evidence_dir=evidence_dir,
+                label="ansible_apply",
+            )
+
+        self.assertEqual(
+            hint,
+            "IOL licence does not match this EVE-NG host. "
+            "Current host: platform-labs-eve-ng-01. "
+            "Update EVENG_IOL_LICENSE with an authorised iourc for this host, then rerun. "
+            "No images were changed.",
+        )
+
     def test_eve_ng_archive_reports_running_nodes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             evidence_dir = Path(tmp)

--- a/hyops/validators/platform/linux/eve_ng_images.py
+++ b/hyops/validators/platform/linux/eve_ng_images.py
@@ -28,6 +28,8 @@ def _validate_image_list(value: Any) -> None:
         require_non_empty_str(item.get("url"), f"inputs.eveng_images_list[{idx}].url")
         if item.get("name") is not None and str(item.get("name") or "").strip():
             require_non_empty_str(item.get("name"), f"inputs.eveng_images_list[{idx}].name")
+        if item.get("label") is not None:
+            require_non_empty_str(item.get("label"), f"inputs.eveng_images_list[{idx}].label")
         image_type = require_non_empty_str(item.get("type"), f"inputs.eveng_images_list[{idx}].type").lower()
         if image_type not in {"qemu", "iol", "dynamips"}:
             raise ValueError(f"inputs.eveng_images_list[{idx}].type must be one of: qemu, iol, dynamips")

--- a/hyops/validators/platform/linux/tests/test_eve_ng_images.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_images.py
@@ -33,7 +33,16 @@ def valid_inputs() -> dict:
 
 class EVENGImagesValidatorTests(unittest.TestCase):
     def test_optional_iol_license_is_valid(self) -> None:
-        validate(valid_inputs())
+        inputs = valid_inputs()
+        inputs["eveng_images_list"][0]["label"] = "Cisco IOL test image"
+        validate(inputs)
+
+    def test_image_label_must_not_be_empty(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_images_list"][0]["label"] = ""
+
+        with self.assertRaisesRegex(ValueError, "label"):
+            validate(inputs)
 
     def test_required_iol_license_must_be_preflighted(self) -> None:
         inputs = valid_inputs()


### PR DESCRIPTION
## Summary

- surface IOL licence hostname mismatches in normal deployment output
- list the configured EVE-NG image set, including operator-supplied images
- validate optional image labels and document both fixes in the 0.1.4 changelog

## Validation

- `bash tools/ci/check-python.sh`
- `ruff check --config tools/ci/ruff.toml` on changed Python files
- replayed `.notes/ansible.log` through the result parser

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.