### PR TITLE
feat(cli): add CLI module validator and environment diagnosticsFeat/my first pr

### DIFF
--- a/hybridops/cli/validator.py
+++ b/hybridops/cli/validator.py
@@ -1,0 +1,51 @@
+"""
+CLI Module Validator for HybridOps Core.
+
+Provides diagnostic utilities to validate CLI configurations, schema contracts,
+and execution environment health before workflow execution.
+"""
+
+from typing import Dict, Any, List, Optional
+import os
+import sys
+
+class CLIValidator:
+    """Validates execution environments and configurations for HybridOps CLI."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        self.config = config or {}
+
+    def validate_environment(self) -> Dict[str, Any]:
+        """
+        Check execution environment readiness.
+        
+        Returns:
+            Dict containing validation status and diagnostic details.
+        """
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        is_supported = sys.version_info >= (3, 8)
+        
+        return {
+            "status": "success" if is_supported else "failed",
+            "python_version": python_version,
+            "supported": is_supported,
+            "env_vars_present": "HYBRID_OPS_ENV" in os.environ
+        }
+
+    def validate_schema(self, schema_data: Dict[str, Any], required_keys: List[str]) -> Dict[str, Any]:
+        """
+        Validate presence of required keys in schema contracts.
+        
+        Args:
+            schema_data: Input dictionary to validate.
+            required_keys: List of expected key names.
+            
+        Returns:
+            Dict containing validation outcome and missing keys if any.
+        """
+        missing_keys = [key for key in required_keys if key not in schema_data]
+        return {
+            "is_valid": len(missing_keys) == 0,
+            "missing_keys": missing_keys,
+            "total_checked": len(required_keys)
+        }

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,29 @@
+"""Unit tests for CLI Module Validator."""
+
+import pytest
+from hybridops.cli.validator import CLIValidator
+
+def test_validate_environment():
+    validator = CLIValidator()
+    res = validator.validate_environment()
+    
+    assert "status" in res
+    assert "python_version" in res
+    assert res["status"] in ["success", "failed"]
+
+def test_validate_schema_valid():
+    validator = CLIValidator()
+    schema = {"name": "hybrid-core", "version": "1.0.0"}
+    res = validator.validate_schema(schema, ["name", "version"])
+    
+    assert res["is_valid"] is True
+    assert len(res["missing_keys"]) == 0
+
+def test_validate_schema_invalid():
+    validator = CLIValidator()
+    schema = {"name": "hybrid-core"}
+    res = validator.validate_schema(schema, ["name", "version", "environment"])
+    
+    assert res["is_valid"] is False
+    assert "version" in res["missing_keys"]
+    assert "environment" in res["missing_keys"]


### PR DESCRIPTION
### Summary
Introduces a CLI validator module (`hybridops/cli/validator.py`) along with comprehensive unit tests (`tests/test_validator.py`) to provide environment health checks and schema contract validation.

### Changes Introduced
- Added `CLIValidator` class with `validate_environment` and `validate_schema` methods.
- Added test coverage in `tests/test_validator.py` using `pytest`.

### Key Modules Affected
- `hybridops/cli/validator.py`
- `tests/test_validator.py`

### How to Test
Execute test suite locally using pytest:
`pytest tests/test_validator.py`

### PR Checklist
- [x] Code follows project naming conventions and typing guidelines
- [x] Unit tests added and passing
- [x] Inline documentation updated
