### PR TITLE
feat(validators): add reusable module contract validation helper

### DIFF
--- a/hyops/validators/contract.py
+++ b/hyops/validators/contract.py
@@ -1,0 +1,65 @@
+"""Reusable validation helpers for module input contracts.
+
+This module provides small, dependency-free helpers for validating the
+shape of module inputs before they are passed to execution-specific
+validators.
+
+purpose: Shared module contract validation.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hyops.validators.registry import ModuleValidationError
+
+
+def validate_contract(
+    inputs: Any,
+    required: dict[str, type[Any]],
+) -> dict[str, Any]:
+    """Validate required fields and their expected Python types.
+
+    Args:
+        inputs: Module input values to validate.
+        required: Mapping of required field names to their expected types.
+
+    Returns:
+        The original input mapping when validation succeeds.
+
+    Raises:
+        ModuleValidationError: If ``inputs`` is not a mapping, a required
+            field is missing, or a field has an unexpected type.
+
+    Example:
+        >>> validate_contract(
+        ...     {"host": "example.com", "port": 443},
+        ...     {"host": str, "port": int},
+        ... )
+        {'host': 'example.com', 'port': 443}
+    """
+    if not isinstance(inputs, dict):
+        raise ModuleValidationError("inputs must be a mapping")
+
+    for field, expected_type in required.items():
+        if field not in inputs:
+            raise ModuleValidationError(f"inputs.{field} is required")
+
+        value = inputs[field]
+
+        # bool is a subclass of int in Python. Reject it when an integer
+        # contract is explicitly requested because True/False should not
+        # silently satisfy an integer field.
+        if expected_type is int and isinstance(value, bool):
+            raise ModuleValidationError(
+                f"inputs.{field} must be an integer"
+            )
+
+        if not isinstance(value, expected_type):
+            raise ModuleValidationError(
+                f"inputs.{field} must be of type "
+                f"{expected_type.__name__}"
+            )
+
+    return inputs

--- a/hyops/validators/hyops/tests/test_contract_validator.py
+++ b/hyops/validators/hyops/tests/test_contract_validator.py
@@ -1,0 +1,104 @@
+"""Tests for reusable module contract validation."""
+
+from __future__ import annotations
+
+import unittest
+
+from hyops.validators.contract import validate_contract
+from hyops.validators.registry import ModuleValidationError
+
+
+class ContractValidatorTests(unittest.TestCase):
+    """Unit tests for validate_contract."""
+
+    def test_valid_contract_returns_original_inputs(self) -> None:
+        inputs = {
+            "host": "example.com",
+            "port": 443,
+        }
+
+        result = validate_contract(
+            inputs,
+            {
+                "host": str,
+                "port": int,
+            },
+        )
+
+        self.assertIs(result, inputs)
+
+    def test_missing_required_field_raises_error(self) -> None:
+        inputs = {
+            "host": "example.com",
+        }
+
+        with self.assertRaisesRegex(
+            ModuleValidationError,
+            r"inputs\.port is required",
+        ):
+            validate_contract(
+                inputs,
+                {
+                    "host": str,
+                    "port": int,
+                },
+            )
+
+    def test_wrong_field_type_raises_error(self) -> None:
+        inputs = {
+            "host": "example.com",
+            "port": "443",
+        }
+
+        with self.assertRaisesRegex(
+            ModuleValidationError,
+            r"inputs\.port must be of type int",
+        ):
+            validate_contract(
+                inputs,
+                {
+                    "host": str,
+                    "port": int,
+                },
+            )
+
+    def test_boolean_is_not_accepted_as_integer(self) -> None:
+        inputs = {
+            "port": True,
+        }
+
+        with self.assertRaisesRegex(
+            ModuleValidationError,
+            r"inputs\.port must be an integer",
+        ):
+            validate_contract(
+                inputs,
+                {
+                    "port": int,
+                },
+            )
+
+    def test_non_mapping_inputs_raise_error(self) -> None:
+        with self.assertRaisesRegex(
+            ModuleValidationError,
+            r"inputs must be a mapping",
+        ):
+            validate_contract(
+                ["host", "example.com"],
+                {
+                    "host": str,
+                },
+            )
+
+    def test_empty_required_contract_accepts_mapping(self) -> None:
+        inputs = {
+            "optional": "value",
+        }
+
+        result = validate_contract(inputs, {})
+
+        self.assertIs(result, inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
Add a small reusable validator for checking required fields and basic field types in module input contracts.
HybridOps Core already provides shared validation primitives and raises ModuleValidationError for invalid module inputs. This change builds on that existing pattern by providing a simple contract validator that can be reused by module validators without duplicating required-field and type-checking logic.
Changes Introduced
Add validate_contract() for validating a module input mapping.
Support required fields with expected Python types.
Return the validated input mapping unchanged when validation succeeds.
Produce clear ModuleValidationError messages when:
inputs are not a mapping;
a required field is missing;
a field contains the wrong type.
Keep the helper dependency-free and compatible with Python 3.11+.
Key Modules Affected
hyops/validators/contract.py
hyops/tests/test_contract_validator.py
How to Test
From the repository root:
python -m pytest hyops/tests/test_contract_validator.py
You can also run the complete test suite:
python -m pytest
PR Checklist
[x] Uses Python typing.
[x] Reuses the existing ModuleValidationError.
[x] Includes unit tests for successful validation.
[x] Includes tests for missing required fields.
[x] Includes tests for invalid field types.
[x] Does not introduce new dependencies.
[x] Keeps the change isolated to the validator/test layers.
[ ] Confirm all repository tests pass locally.
[ ] Review code style before submitting.