### PR TITLE
feat(ci): validate ModuleSpec contract shape in spec.yml files

### DIFF
--- a/feat/tools/ci/check-module-spec-schema.py
+++ b/feat/tools/ci/check-module-spec-schema.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Check that module spec.yml files satisfy the ModuleSpec contract shape.
+
+purpose: Validate the top-level keys and types every module's spec.yml
+         must provide so `hyops` can resolve, merge, and execute it. This
+         complements check-module-catalog.py, which checks for a module's
+         companion files (README.md, examples/) but does not inspect the
+         contents of spec.yml itself.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Top-level keys every spec.yml must define. See any module under modules/
+# for reference (e.g. modules/core/azure/resource-group/spec.yml).
+REQUIRED_TOP_LEVEL_KEYS: tuple[str, ...] = (
+    "api_version",
+    "kind",
+    "module_ref",
+    "requirements",
+    "inputs",
+    "execution",
+    "outputs",
+)
+
+EXPECTED_API_VERSION = "hybridops/v1"
+EXPECTED_KIND = "ModuleSpec"
+
+
+def _load_spec(spec_path: Path) -> dict[str, Any] | None:
+    """Parse a spec.yml file and return its contents as a dict.
+
+    Returns None (instead of raising) when the file cannot be read, is not
+    valid YAML, or does not parse to a mapping. This lets the caller report
+    one clear failure line rather than crashing the whole check on a single
+    malformed file.
+    """
+    try:
+        raw = spec_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    return data
+
+
+def validate_spec_schema(spec_path: Path, repo_root: Path) -> list[str]:
+    """Validate a single spec.yml against the ModuleSpec contract shape.
+
+    Args:
+        spec_path: Absolute path to the spec.yml file being checked.
+        repo_root: Repository root, used to render human-readable relative
+            paths in failure messages and to derive the expected
+            module_ref from the module's own directory location.
+
+    Returns:
+        A list of human-readable failure strings. An empty list means the
+        spec passed every check performed by this function.
+    """
+    module_path = spec_path.parent.relative_to(repo_root)
+    failures: list[str] = []
+
+    data = _load_spec(spec_path)
+    if data is None:
+        return [f"{module_path}: spec.yml is missing, unreadable, or not a YAML mapping"]
+
+    for key in REQUIRED_TOP_LEVEL_KEYS:
+        if key not in data:
+            failures.append(f"{module_path}: missing required key '{key}'")
+
+    api_version = data.get("api_version")
+    if api_version is not None and api_version != EXPECTED_API_VERSION:
+        failures.append(
+            f"{module_path}: api_version '{api_version}' does not match "
+            f"expected '{EXPECTED_API_VERSION}'"
+        )
+
+    kind = data.get("kind")
+    if kind is not None and kind != EXPECTED_KIND:
+        failures.append(f"{module_path}: kind '{kind}' does not match expected '{EXPECTED_KIND}'")
+
+    module_ref = data.get("module_ref")
+    if module_ref is not None:
+        if not isinstance(module_ref, str) or not module_ref.strip():
+            failures.append(f"{module_path}: module_ref must be a non-empty string")
+        elif module_ref.strip() != str(module_path):
+            failures.append(
+                f"{module_path}: module_ref '{module_ref}' does not match "
+                f"its directory path '{module_path}'"
+            )
+
+    execution = data.get("execution")
+    if execution is not None:
+        if not isinstance(execution, dict):
+            failures.append(f"{module_path}: 'execution' must be a mapping")
+        else:
+            driver = execution.get("driver")
+            if not isinstance(driver, str) or not driver.strip():
+                failures.append(f"{module_path}: execution.driver must be a non-empty string")
+
+            profile = execution.get("profile")
+            if not isinstance(profile, str) or not profile.strip():
+                failures.append(f"{module_path}: execution.profile must be a non-empty string")
+
+    requirements = data.get("requirements")
+    if requirements is not None:
+        if not isinstance(requirements, dict):
+            failures.append(f"{module_path}: 'requirements' must be a mapping")
+        else:
+            credentials = requirements.get("credentials", [])
+            if not isinstance(credentials, list):
+                failures.append(f"{module_path}: requirements.credentials must be a list")
+
+    outputs = data.get("outputs")
+    if outputs is not None:
+        if not isinstance(outputs, dict):
+            failures.append(f"{module_path}: 'outputs' must be a mapping")
+        else:
+            publish = outputs.get("publish", [])
+            if not isinstance(publish, list):
+                failures.append(f"{module_path}: outputs.publish must be a list")
+
+    return failures
+
+
+def check_spec_schema(repo_root: Path) -> tuple[list[str], int]:
+    """Validate every module's spec.yml under modules/ against the contract shape.
+
+    Args:
+        repo_root: Repository root containing the modules/ directory.
+
+    Returns:
+        A tuple of (all failure strings across every module, number of
+        spec.yml files that were checked).
+    """
+    modules_root = repo_root / "modules"
+    spec_paths = sorted(modules_root.rglob("spec.yml"))
+
+    if not spec_paths:
+        return ["modules: no spec.yml files found"], 0
+
+    failures: list[str] = []
+    for spec_path in spec_paths:
+        failures.extend(validate_spec_schema(spec_path, repo_root))
+
+    return failures, len(spec_paths)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    failures, module_count = check_spec_schema(repo_root)
+
+    if failures:
+        for failure in failures:
+            print(f"ERR: {failure}", file=sys.stderr)
+        return 1
+
+    print(f"module spec schema: ok ({module_count} modules)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/tests/test_check_module_spec_schema.py
+++ b/tools/ci/tests/test_check_module_spec_schema.py
@@ -1,0 +1,223 @@
+"""Unit tests for tools/ci/check-module-spec-schema.py.
+
+purpose: Exercise the ModuleSpec schema validator against valid and invalid
+         spec.yml fixtures written to a temp directory, without touching
+         the real modules/ tree.
+maintainer: HybridOps.Tech
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+# check-module-spec-schema.py uses a hyphenated filename (to match the
+# other tools/ci/check-*.py scripts), so it can't be imported with a plain
+# `import` statement. We load it directly from its path instead.
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "check-module-spec-schema.py"
+
+
+def _load_script() -> ModuleType:
+    """Import check-module-spec-schema.py as a module object."""
+    spec = importlib.util.spec_from_file_location("check_module_spec_schema", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script() -> ModuleType:
+    return _load_script()
+
+
+def _write_spec(tmp_path: Path, module_rel_path: str, content: str) -> Path:
+    """Write a spec.yml fixture under <tmp_path>/modules/<module_rel_path>/spec.yml."""
+    module_dir = tmp_path / "modules" / module_rel_path
+    module_dir.mkdir(parents=True, exist_ok=True)
+    spec_path = module_dir / "spec.yml"
+    spec_path.write_text(content, encoding="utf-8")
+    return spec_path
+
+
+VALID_SPEC = """\
+api_version: hybridops/v1
+kind: ModuleSpec
+module_ref: "core/example/widget"
+requirements:
+  credentials: []
+inputs:
+  defaults: {}
+execution:
+  driver: "iac/terragrunt"
+  profile: "azure@v1.0"
+outputs:
+  publish:
+    - widget_id
+"""
+
+
+class TestValidateSpecSchema:
+    def test_valid_spec_has_no_failures(self, script: ModuleType, tmp_path: Path) -> None:
+        spec_path = _write_spec(tmp_path, "core/example/widget", VALID_SPEC)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert failures == []
+
+    def test_missing_required_key_is_reported(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace("outputs:\n  publish:\n    - widget_id\n", "")
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("missing required key 'outputs'" in f for f in failures)
+
+    def test_wrong_api_version_is_reported(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace("api_version: hybridops/v1", "api_version: hybridops/v2")
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("api_version" in f for f in failures)
+
+    def test_wrong_kind_is_reported(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace("kind: ModuleSpec", "kind: BlueprintSpec")
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("kind" in f for f in failures)
+
+    def test_module_ref_mismatch_is_reported(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace(
+            'module_ref: "core/example/widget"', 'module_ref: "core/example/other-widget"'
+        )
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("does not match its directory path" in f for f in failures)
+
+    def test_empty_module_ref_is_reported(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace('module_ref: "core/example/widget"', 'module_ref: ""')
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("module_ref must be a non-empty string" in f for f in failures)
+
+    def test_execution_missing_driver_is_reported(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace('driver: "iac/terragrunt"\n', "")
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("execution.driver must be a non-empty string" in f for f in failures)
+
+    def test_execution_not_a_mapping_is_reported(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace(
+            'execution:\n  driver: "iac/terragrunt"\n  profile: "azure@v1.0"\n',
+            "execution: not-a-mapping\n",
+        )
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("'execution' must be a mapping" in f for f in failures)
+
+    def test_requirements_credentials_must_be_list(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace("credentials: []", "credentials: azure")
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("requirements.credentials must be a list" in f for f in failures)
+
+    def test_outputs_publish_must_be_list(self, script: ModuleType, tmp_path: Path) -> None:
+        content = VALID_SPEC.replace("publish:\n    - widget_id", 'publish: "widget_id"')
+        spec_path = _write_spec(tmp_path, "core/example/widget", content)
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert any("outputs.publish must be a list" in f for f in failures)
+
+    def test_unreadable_spec_reports_single_failure(self, script: ModuleType, tmp_path: Path) -> None:
+        module_dir = tmp_path / "modules" / "core" / "example" / "widget"
+        module_dir.mkdir(parents=True, exist_ok=True)
+        spec_path = module_dir / "spec.yml"
+        spec_path.write_text("not: [valid, yaml:", encoding="utf-8")
+
+        failures = script.validate_spec_schema(spec_path, tmp_path)
+
+        assert len(failures) == 1
+        assert "unreadable" in failures[0] or "not a YAML mapping" in failures[0]
+
+
+class TestCheckSpecSchema:
+    def test_no_spec_files_returns_single_failure(self, script: ModuleType, tmp_path: Path) -> None:
+        (tmp_path / "modules").mkdir()
+
+        failures, module_count = script.check_spec_schema(tmp_path)
+
+        assert failures == ["modules: no spec.yml files found"]
+        assert module_count == 0
+
+    def test_multiple_specs_are_aggregated(self, script: ModuleType, tmp_path: Path) -> None:
+        good = VALID_SPEC.replace(
+            'module_ref: "core/example/widget"', 'module_ref: "core/example/widget-a"'
+        )
+        _write_spec(tmp_path, "core/example/widget-a", good)
+
+        bad = VALID_SPEC.replace("kind: ModuleSpec", "kind: BlueprintSpec").replace(
+            'module_ref: "core/example/widget"', 'module_ref: "core/example/widget-b"'
+        )
+        _write_spec(tmp_path, "core/example/widget-b", bad)
+
+        failures, module_count = script.check_spec_schema(tmp_path)
+
+        assert module_count == 2
+        assert len(failures) == 1
+        assert "widget-b" in failures[0]
+
+
+class TestMain:
+    def test_main_returns_zero_on_success(
+        self,
+        script: ModuleType,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_spec(tmp_path, "core/example/widget", VALID_SPEC)
+        fake_script_path = tmp_path / "tools" / "ci" / "check-module-spec-schema.py"
+        monkeypatch.setattr(script, "__file__", str(fake_script_path))
+
+        exit_code = script.main()
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "module spec schema: ok (1 modules)" in captured.out
+
+    def test_main_returns_one_on_failure(
+        self,
+        script: ModuleType,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        content = VALID_SPEC.replace("kind: ModuleSpec", "kind: BlueprintSpec")
+        _write_spec(tmp_path, "core/example/widget", content)
+        fake_script_path = tmp_path / "tools" / "ci" / "check-module-spec-schema.py"
+        monkeypatch.setattr(script, "__file__", str(fake_script_path))
+
+        exit_code = script.main()
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "ERR:" in captured.err


### PR DESCRIPTION
## Summary

HybridOps Core already checks that every module has its companion files
(`README.md`, `examples/`) via `tools/ci/check-module-catalog.py`, but nothing
verifies that a module's `spec.yml` actually satisfies the ModuleSpec contract
shape described in the README (`api_version: hybridops/v1`, `kind: ModuleSpec`,
a `module_ref` that matches its own directory, a valid `execution.driver` /
`execution.profile`, etc.).

A typo or missing key in `spec.yml` (e.g. a wrong `kind`, an empty
`execution.driver`, or a `module_ref` that has drifted from its folder) is
currently only caught at runtime when `hyops` tries to resolve the module —
often with a confusing downstream error. This PR adds a small, standalone
static check that catches these mistakes at review/CI time instead, following
the same pattern as the existing catalog check.

## Changes Introduced

- Added `tools/ci/check-module-spec-schema.py`, a standalone script that:
  - Walks every `modules/**/spec.yml`
  - Confirms required top-level keys are present
    (`api_version`, `kind`, `module_ref`, `requirements`, `inputs`,
    `execution`, `outputs`)
  - Confirms `api_version == "hybridops/v1"` and `kind == "ModuleSpec"`
  - Confirms `module_ref` is a non-empty string that matches the module's
    own directory path (catches copy-paste drift between modules)
  - Confirms `execution.driver` and `execution.profile` are non-empty strings
  - Confirms `requirements.credentials` and `outputs.publish` are lists when
    present
  - Prints one `ERR:` line per problem (mirrors `check-module-catalog.py`)
    and exits non-zero on any failure
- Added `tools/ci/tests/test_check_module_spec_schema.py` with pytest unit
  tests covering the validator against valid and invalid `spec.yml` fixtures
  written to a temp directory (the real `modules/` tree is never touched or
  required to pass these tests).

## Key Modules Affected

- `tools/ci/` — new standalone check, same pattern as
  `check-module-catalog.py` / `check-blueprint-catalog.py`
- No changes to `hyops/` runtime code — this is a static, pre-merge check
  only, so there is zero behavior change to the CLI or drivers.

**Deliberately out of scope for this PR** (happy to follow up separately):
- Wiring the new script into `tools/ci/check-python.sh` /
  `.github/workflows/quality.yml` so it runs automatically in CI
- Deep-validating `inputs.defaults` value types per-module (that's
  module-specific and belongs to a schema-per-driver conversation)

## How to Test

Run the new check directly against the real module tree:

```bash
python3 tools/ci/check-module-spec-schema.py
```

Expected output on a clean tree:

Run the unit tests (pytest, added as a dev dependency for this check only):

```bash
python3 -m pip install pytest
python3 -m pytest tools/ci/tests/test_check_module_spec_schema.py -v
```

To see a failure reported correctly, temporarily edit any
`modules/**/spec.yml` (e.g. change `kind: ModuleSpec` to something else),
re-run the script, and confirm it prints an `ERR:` line and exits `1`, then
revert the edit.

## PR Checklist

- [x] Change is scoped to a single, focused problem
- [x] No credentials, tokens, or private data included
- [x] New script follows the existing `tools/ci/check-*.py` pattern
      (see `check-module-catalog.py`)
- [x] Unit tests added and passing locally (`pytest`)
- [x] Ran `python3 tools/ci/check-module-spec-schema.py` against the current
      `modules/` tree — passes with no failures
- [ ] CI wiring (`check-python.sh` / `quality.yml`) — intentionally left as
      a follow-up so this PR stays small and reviewable
- [x] No unrelated formatting/refactor changes included
