### PR TITLE
fix: destroy GNS3 guest state with parent VM

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Fixed
 
+- Allowed disposable GNS3 guest operations to be cleared with their parent VM when guest SSH is unavailable during teardown.
 - Preserved concise module failure details after a blueprint progress step fails.
 - Surfaced EVE-NG IOL licence mismatches with the target hostname and Linux host ID before any image changes.
 - Reported the complete configured EVE-NG image set, including operator-supplied IOL images, in blueprint progress output.

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -125,6 +125,7 @@ steps:
       - gcp_gns3_vm
     with_deps: false
     skip_if_state_ok: false
+    destroy_subsumed_by: gcp_gns3_vm
     contracts:
       addressing_mode: "static"
     inputs:
@@ -155,6 +156,7 @@ steps:
       - gcp_gns3_server
     with_deps: false
     skip_if_state_ok: false
+    destroy_subsumed_by: gcp_gns3_vm
     contracts:
       addressing_mode: "static"
     inputs:
@@ -200,6 +202,7 @@ steps:
       - gcp_gns3_images
     with_deps: false
     skip_if_state_ok: false
+    destroy_subsumed_by: gcp_gns3_vm
     contracts:
       addressing_mode: "static"
     inputs:
@@ -225,6 +228,7 @@ steps:
       - gcp_gns3_starter_lab
     with_deps: false
     skip_if_state_ok: false
+    destroy_subsumed_by: gcp_gns3_vm
     contracts:
       addressing_mode: "static"
     inputs:

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -97,6 +97,7 @@ steps:
     action: "deploy"
     phase: "operations"
     with_deps: false
+    destroy_subsumed_by: gns3_vm
     requires:
       - gns3_vm
     contracts:
@@ -123,6 +124,7 @@ steps:
     action: "deploy"
     phase: "operations"
     with_deps: false
+    destroy_subsumed_by: gns3_vm
     requires:
       - gns3_server
     contracts:
@@ -164,6 +166,7 @@ steps:
     action: "deploy"
     phase: "operations"
     with_deps: false
+    destroy_subsumed_by: gns3_vm
     requires:
       - gns3_images
     contracts:
@@ -185,6 +188,7 @@ steps:
     action: "deploy"
     phase: "operations"
     with_deps: false
+    destroy_subsumed_by: gns3_vm
     requires:
       - gns3_starter_lab
     contracts:

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -29,7 +29,11 @@ from hyops.runtime.exitcodes import CANCELLED, OPERATOR_ERROR
 from hyops.runtime.gcp import diagnose_project_billing
 from hyops.runtime.gcp_cost import estimate_gcp_vm_cost
 from hyops.runtime.layout import ensure_layout
-from hyops.runtime.module_state import read_module_state, split_module_state_ref
+from hyops.runtime.module_state import (
+    read_module_state,
+    split_module_state_ref,
+    write_module_state,
+)
 from hyops.runtime.operator_output import concise_error
 from hyops.runtime.paths import resolve_runtime_paths
 from hyops.runtime.progress import ProgressDisplay, verbose_enabled
@@ -3632,6 +3636,81 @@ def run_destroy(ns) -> int:
         ),
         show_elapsed=False,
     )
+    deferred_by_parent: dict[str, list[tuple[dict[str, Any], dict[str, Any]]]] = {}
+
+    def finish_subsumed_steps(parent_id: str) -> list[str]:
+        failures: list[str] = []
+        for child_step, child_result in deferred_by_parent.pop(parent_id, []):
+            child_ref, child_instance = split_module_state_ref(
+                child_step["module_ref"],
+                state_instance=child_step.get("state_instance") or None,
+            )
+            try:
+                previous = read_module_state(
+                    paths.state_dir,
+                    child_ref,
+                    state_instance=child_instance,
+                )
+            except FileNotFoundError:
+                previous = {}
+            except Exception as exc:
+                child_result.update(
+                    {
+                        "status": "failed",
+                        "rc": OPERATOR_ERROR,
+                        "reason": f"failed to read deferred state: {exc}",
+                    }
+                )
+                failures.append(child_step["id"])
+                continue
+
+            state_payload = dict(previous)
+            state_payload.update(
+                {
+                    "module_ref": child_ref,
+                    "status": "destroyed",
+                    "updated_at": datetime.now(timezone.utc).strftime(
+                        "%Y-%m-%dT%H:%M:%SZ"
+                    ),
+                    "outputs": {},
+                    "output_count": 0,
+                    "destroyed_by_blueprint_step": parent_id,
+                }
+            )
+            for transient_key in (
+                "active_command",
+                "failed_command",
+                "last_error",
+                "mutation_started",
+            ):
+                state_payload.pop(transient_key, None)
+            if child_instance:
+                state_payload["state_instance"] = child_instance
+            try:
+                write_module_state(
+                    paths.state_dir,
+                    child_ref,
+                    state_payload,
+                    state_instance=child_instance,
+                )
+            except Exception as exc:
+                child_result.update(
+                    {
+                        "status": "failed",
+                        "rc": OPERATOR_ERROR,
+                        "reason": f"parent was destroyed but child state update failed: {exc}",
+                    }
+                )
+                failures.append(child_step["id"])
+                continue
+            child_result.update(
+                {
+                    "status": "subsumed",
+                    "rc": 0,
+                    "reason": f"destroyed with parent step {parent_id}",
+                }
+            )
+        return failures
 
     total_steps = len(destroy_order)
     for step_position, step_id in enumerate(destroy_order, start=1):
@@ -3685,6 +3764,32 @@ def run_destroy(ns) -> int:
                 "skipped",
                 plain=f"step={step_id} status=skipped reason={reason}",
                 detail=f"{reason}, {completed_detail}",
+            )
+            if state_status in {"destroyed", "absent"}:
+                required_failures.extend(finish_subsumed_steps(step_id))
+            continue
+
+        destroy_parent = str(step.get("destroy_subsumed_by") or "").strip()
+        if destroy_parent:
+            result = dict(base)
+            result.update(
+                {
+                    "status": "deferred",
+                    "reason": f"destroyed with parent step {destroy_parent}",
+                    "rc": 0,
+                }
+            )
+            step_results.append(result)
+            deferred_by_parent.setdefault(destroy_parent, []).append((step, result))
+            progress.finish(
+                step_id,
+                step_id,
+                "deferred",
+                plain=(
+                    f"step={step_id} status=deferred "
+                    f"reason=destroy-subsumed-by-{destroy_parent}"
+                ),
+                detail=f"awaiting {destroy_parent}, {completed_detail}",
             )
             continue
 
@@ -3744,6 +3849,7 @@ def run_destroy(ns) -> int:
                 plain=f"step={step_id} status=ok progress={progress_after}%",
                 detail=completed_detail,
             )
+            required_failures.extend(finish_subsumed_steps(step_id))
             continue
 
         result = dict(base)
@@ -3787,6 +3893,18 @@ def run_destroy(ns) -> int:
             print(f"error: {failure_detail}", file=sys.stderr)
         if fail_fast:
             break
+
+    for parent_id, pending in deferred_by_parent.items():
+        for child_step, child_result in pending:
+            child_result.update(
+                {
+                    "status": "failed",
+                    "rc": OPERATOR_ERROR,
+                    "reason": f"parent step {parent_id} was not confirmed destroyed",
+                }
+            )
+            if child_step["id"] not in required_failures:
+                required_failures.append(child_step["id"])
 
     final_status = "ok" if not required_failures else "failed"
     if cancelled:

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -459,6 +459,13 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             norm_token = normalize_state_instance(token)
             state_instance = norm_token or ""
 
+        destroy_subsumed_by = ""
+        if step.get("destroy_subsumed_by") is not None:
+            destroy_subsumed_by = as_non_empty_string(
+                step.get("destroy_subsumed_by"),
+                f"steps[{idx}].destroy_subsumed_by",
+            )
+
         presentation: dict[str, Any] = {}
         raw_presentation = step.get("presentation")
         if raw_presentation is not None:
@@ -571,6 +578,7 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                     step.get("retain_on_destroy"),
                     f"steps[{idx}].retain_on_destroy",
                 ),
+                "destroy_subsumed_by": destroy_subsumed_by,
                 "destroy_gate": bool_field(
                     step.get("destroy_gate"),
                     f"steps[{idx}].destroy_gate",
@@ -585,6 +593,21 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         )
 
     id_set = {s["id"] for s in steps}
+    by_id = {s["id"]: s for s in steps}
+
+    def depends_on(step_id: str, required_id: str) -> bool:
+        pending = list(by_id[step_id]["requires"])
+        visited: set[str] = set()
+        while pending:
+            candidate = pending.pop()
+            if candidate == required_id:
+                return True
+            if candidate in visited or candidate not in by_id:
+                continue
+            visited.add(candidate)
+            pending.extend(by_id[candidate]["requires"])
+        return False
+
     for step in steps:
         for req in step["requires"]:
             if req not in id_set:
@@ -597,6 +620,22 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             if step["optional"] or step["retain_on_destroy"]:
                 raise ValueError(
                     f"step '{step['id']}' destroy_gate cannot be optional or retained"
+                )
+        destroy_parent = step["destroy_subsumed_by"]
+        if destroy_parent:
+            if destroy_parent not in id_set:
+                raise ValueError(
+                    f"step '{step['id']}' destroy_subsumed_by references unknown step "
+                    f"'{destroy_parent}'"
+                )
+            if not depends_on(step["id"], destroy_parent):
+                raise ValueError(
+                    f"step '{step['id']}' destroy_subsumed_by must reference an "
+                    "upstream dependency"
+                )
+            if step["retain_on_destroy"] or step["destroy_gate"]:
+                raise ValueError(
+                    f"step '{step['id']}' destroy_subsumed_by cannot be retained or a destroy gate"
                 )
 
     order = topological_order(steps)

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -209,6 +209,73 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertEqual(command.call_count, 1)
         self.assertEqual(command.call_args.args[0]["id"], "vm")
 
+    def test_child_destroy_is_deferred_until_parent_is_destroyed(self):
+        paths = SimpleNamespace(
+            state_dir=Path("/tmp/state"),
+            root=SimpleNamespace(name="test"),
+        )
+        payload = _payload()
+        payload["steps"][2]["destroy_subsumed_by"] = "vm"
+        statuses = {"network": "destroyed", "vm": "ok", "health": "error"}
+
+        def state_status(_state_dir, state_ref):
+            return statuses[state_ref.rsplit("#", 1)[-1]]
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=payload),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command.require_runtime_writable"),
+            patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+            patch("hyops.blueprint.command.module_state_status", side_effect=state_status),
+            patch(
+                "hyops.blueprint.command.read_module_state",
+                return_value={"status": "error"},
+            ),
+            patch("hyops.blueprint.command.write_module_state") as write_state,
+            patch("hyops.blueprint.command.resolved_step_inputs_file", return_value=None),
+            patch("hyops.blueprint.command.run_step_module_command", return_value=0) as command,
+        ):
+            rc = run_destroy(_namespace())
+
+        self.assertEqual(rc, 0)
+        self.assertEqual([call.args[0]["id"] for call in command.call_args_list], ["vm"])
+        self.assertEqual(write_state.call_args.args[2]["status"], "destroyed")
+        self.assertEqual(
+            write_state.call_args.args[2]["destroyed_by_blueprint_step"],
+            "vm",
+        )
+
+    def test_subsumed_child_is_not_destroyed_when_parent_fails(self):
+        paths = SimpleNamespace(
+            state_dir=Path("/tmp/state"),
+            root=SimpleNamespace(name="test"),
+        )
+        payload = _payload()
+        payload["steps"][2]["destroy_subsumed_by"] = "vm"
+        statuses = {"network": "ok", "vm": "ok", "health": "error"}
+
+        def state_status(_state_dir, state_ref):
+            return statuses[state_ref.rsplit("#", 1)[-1]]
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=payload),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command.require_runtime_writable"),
+            patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+            patch("hyops.blueprint.command.module_state_status", side_effect=state_status),
+            patch("hyops.blueprint.command.write_module_state") as write_state,
+            patch("hyops.blueprint.command.resolved_step_inputs_file", return_value=None),
+            patch("hyops.blueprint.command.run_step_module_command", return_value=2),
+        ):
+            rc = run_destroy(_namespace())
+
+        self.assertEqual(rc, 2)
+        write_state.assert_not_called()
+
     def test_destroy_gate_runs_when_required_step_is_live(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
         payload = _payload()

--- a/hyops/blueprint/tests/test_gcp_gns3.py
+++ b/hyops/blueprint/tests/test_gcp_gns3.py
@@ -30,6 +30,10 @@ class GCPGNS3BlueprintTest(TestCase):
         for step in self.blueprint["steps"][2:]:
             self.assertEqual(step["inputs"]["ssh_access_mode"], "gcp-iap")
 
+    def test_guest_operations_are_destroyed_with_disposable_vm(self) -> None:
+        for step in self.blueprint["steps"][2:]:
+            self.assertEqual(step["destroy_subsumed_by"], "gcp_gns3_vm")
+
     def test_access_uses_loopback_iap_forward(self) -> None:
         access = self.blueprint["access"]
         self.assertEqual(access["type"], "gcp-iap-ssh-forward")

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -44,6 +44,10 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(server_step["inputs"]["gns3_server_port"], 3080)
         self.assertTrue(server_step["inputs"]["gns3_server_require_kvm"])
 
+    def test_guest_operations_are_destroyed_with_disposable_vm(self) -> None:
+        for step in self.blueprint["steps"][2:]:
+            self.assertEqual(step["destroy_subsumed_by"], "gns3_vm")
+
     def test_desktop_client_access_uses_private_tcp_forward(self) -> None:
         access = self.blueprint["access"]
         self.assertEqual(access["type"], "ssh-tcp-forward")


### PR DESCRIPTION
## Summary

Allow disposable GNS3 guest-operation state to be cleared with its parent VM. Blueprint teardown no longer requires guest SSH when the VM is absent or inaccessible. Child state is marked destroyed only after the parent destroy succeeds.

## Validation

- 137 blueprint tests passed
- 11 CLI tests passed
- Python compilation passed
- Diff checks passed

## Scope

This excludes the pending cost-summary work.