### PR TITLE
Fix private lab access session lifecycle

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Added
 
-- Added live EVE-NG QEMU console discovery so native VNC forwards follow nodes started during an access session.
+- Added live EVE-NG and GNS3 console discovery so native VNC, Telnet, SPICE and web-console forwards follow nodes during an access session.
 - Added targeted Galaxy collection refresh with `hyops setup galaxy --collection <name>`.
 - Added `hyops blueprint init` and `hyops blueprint edit` as the environment-local blueprint workflow. Initialized blueprints are now the default execution source, while `--file` remains an explicit override.
 - Added managed workstation-to-device automation access for EVE-NG and GNS3, including target discovery, scoped SSH configuration, inventory output, proxy settings, client commands, and optional local routing.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 - Added targeted Galaxy collection refresh with `hyops setup galaxy --collection <name>`.
 - Added `hyops blueprint init` and `hyops blueprint edit` as the environment-local blueprint workflow. Initialized blueprints are now the default execution source, while `--file` remains an explicit override.
 - Added managed workstation-to-device automation access for EVE-NG and GNS3, including target discovery, scoped SSH configuration, inventory output, proxy settings, client commands, and optional local routing.
+- Added one-session web access for named or declared device sets, with per-target HTTP or HTTPS settings and loopback-only forwards.
 - Added vault-backed EVE-NG IOL and GNS3 IOU licence placement, checksum-verified image registration, and archive exclusion for licence material.
 - Added a private GCP Containerlab blueprint that preserves native topology semantics and combines host provisioning, KVM readiness, health verification, cost context, and verified off-host recovery state.
 - Added a provider-neutral stop-state verifier for destructive lifecycle decisions.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Added
 
+- Added live EVE-NG QEMU console discovery so native VNC forwards follow nodes started during an access session.
 - Added targeted Galaxy collection refresh with `hyops setup galaxy --collection <name>`.
 - Added `hyops blueprint init` and `hyops blueprint edit` as the environment-local blueprint workflow. Initialized blueprints are now the default execution source, while `--file` remains an explicit override.
 - Added managed workstation-to-device automation access for EVE-NG and GNS3, including target discovery, scoped SSH configuration, inventory output, proxy settings, client commands, and optional local routing.
@@ -18,6 +19,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Changed
 
+- Applied the controlled keep, archive or destroy decision when GNS3 access closes.
 - Pinned `hybridops.app` and `hybridops.helper` to `0.1.9` for the Containerlab and device-automation release set.
 - Expanded CI coverage across the public CLI surface and every shipped blueprint.
 - Aligned source package and runtime version metadata with the `v0.1.4` release line and added regression coverage for installed version reporting.

--- a/blueprints/gcp/containerlab@v1/README.md
+++ b/blueprints/gcp/containerlab@v1/README.md
@@ -138,10 +138,12 @@ Use the private node-management path with:
 ```bash
 hyops blueprint access --env <env> --ref gcp/containerlab@v1 --automation
 hyops blueprint device list --env <env> --ref gcp/containerlab@v1
-hyops blueprint device web --env <env> --ref gcp/containerlab@v1 <device> --scheme https --port 443
+hyops blueprint device web --env <env> --ref gcp/containerlab@v1 <device> --scheme http --port 80
 ```
 
 HybridOps reads running node addresses from Containerlab inspection output. The default management network is `172.20.20.0/24`; change the runtime blueprint when the topology declares another subnet.
+
+For several interfaces, use `hyops blueprint device edit` to declare each target's web service. The generated file documents the available fields. Open named targets together or use `--all`. One Ctrl-C closes every tunnel. Add `--open-all` to open every URL in the workstation browser.
 
 ## Validated lifecycle
 

--- a/blueprints/gcp/containerlab@v1/README.md
+++ b/blueprints/gcp/containerlab@v1/README.md
@@ -133,6 +133,16 @@ The estimate provides lifecycle decision context. GCP billing remains authoritat
 127.0.0.1:2222
 ```
 
+Use the private node-management path with:
+
+```bash
+hyops blueprint access --env <env> --ref gcp/containerlab@v1 --automation
+hyops blueprint device list --env <env> --ref gcp/containerlab@v1
+hyops blueprint device web --env <env> --ref gcp/containerlab@v1 <device> --scheme https --port 443
+```
+
+HybridOps reads running node addresses from Containerlab inspection output. The default management network is `172.20.20.0/24`; change the runtime blueprint when the topology declares another subnet.
+
 ## Validated lifecycle
 
 The GCP acceptance path established that:

--- a/blueprints/gcp/containerlab@v1/blueprint.yml
+++ b/blueprints/gcp/containerlab@v1/blueprint.yml
@@ -24,6 +24,13 @@ access:
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
   offer_destroy_on_close: true
+  automation:
+    discovery_mode: "containerlab-inspect"
+    management_network_label: "clab"
+    management_cidr: "172.20.20.0/24"
+    management_gateway: "172.20.20.1"
+    default_user: "admin"
+    local_socks_port: 0
 
 steps:
   - id: gcp_containerlab_network

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -67,6 +67,14 @@ hyops blueprint access --env <env> --ref gcp/eve-ng@v1 --automation
 
 HybridOps discovers management leases and produces session-scoped SSH configuration and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
 
+While that session remains open, expose a device web interface on loopback:
+
+```bash
+hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 <device> --scheme https --port 443
+```
+
+The device may be identified by target name or management IP. Appliance certificates may produce the expected local browser warning.
+
 ## Continuity and compute release
 
 The blueprint declares `platform/linux/eve-ng-lab-archive` as its archive-before-release contract.

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -57,6 +57,8 @@ hyops blueprint access --env <env> --ref gcp/eve-ng@v1
 
 The access session resolves the current host from HybridOps state and forwards the EVE-NG interface through IAP. The VM and EVE-NG HTTP service remain private.
 
+Add `--native-consoles` to follow active QEMU VNC ports during the session. New node consoles are forwarded on loopback as they start. The workstation must have a VNC handler registered for links opened by EVE-NG.
+
 For direct automation of topology nodes, connect a management interface to `Cloud8` and run:
 
 ```bash

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -67,13 +67,20 @@ hyops blueprint access --env <env> --ref gcp/eve-ng@v1 --automation
 
 HybridOps discovers management leases and produces session-scoped SSH configuration and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
 
-While that session remains open, expose a device web interface on loopback:
+While that session remains open, expose one device web interface on loopback:
 
 ```bash
-hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 <device> --scheme https --port 443
+hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 <device> --scheme http --port 80
 ```
 
-The device may be identified by target name or management IP. Appliance certificates may produce the expected local browser warning.
+The device may be identified by target name or management IP. For several interfaces, use `hyops blueprint device edit` to declare each target's web service. The generated file documents the available fields. Open named targets together, or every declared service:
+
+```bash
+hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 <device-1> <device-2>
+hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 --all
+```
+
+One Ctrl-C closes every tunnel. Add `--open-all` to open every URL in the workstation browser. Appliance certificates may produce the expected local browser warning.
 
 ## Continuity and compute release
 

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -66,6 +66,8 @@ hyops blueprint access --env <env> --ref gcp/gns3@v1 --automation
 
 HybridOps discovers management leases and produces session-scoped SSH configuration, target data and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
 
+Closing an interactive access session offers the same keep, archive or destroy decision as an explicit blueprint teardown.
+
 ## Continuity and compute release
 
 The blueprint declares `platform/linux/gns3-lab-archive` as its archive-before-release contract.

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -58,6 +58,8 @@ hyops blueprint access --env <env> --ref gcp/gns3@v1
 
 The access session resolves the current host from HybridOps state and forwards the authenticated GNS3 API/UI endpoint through IAP. The VM and GNS3 service remain private.
 
+Add `--native-consoles` when using the desktop client's Telnet, VNC, SPICE or web console handlers. HybridOps reads node console assignments from the authenticated GNS3 API and maintains matching loopback forwards while access remains open.
+
 For direct automation of topology nodes, map a GNS3 Cloud node to `hyops-mgmt0`, connect device management interfaces to it and run:
 
 ```bash

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -68,13 +68,20 @@ hyops blueprint access --env <env> --ref gcp/gns3@v1 --automation
 
 HybridOps discovers management leases and produces session-scoped SSH configuration, target data and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
 
-While that session remains open, expose a device web interface on loopback:
+While that session remains open, expose one device web interface on loopback:
 
 ```bash
-hyops blueprint device web --env <env> --ref gcp/gns3@v1 <device> --scheme https --port 443
+hyops blueprint device web --env <env> --ref gcp/gns3@v1 <device> --scheme http --port 80
 ```
 
-The device may be identified by target name or management IP. Appliance certificates may produce the expected local browser warning.
+The device may be identified by target name or management IP. For several interfaces, use `hyops blueprint device edit` to declare each target's web service. The generated file documents the available fields. Open named targets together, or every declared service:
+
+```bash
+hyops blueprint device web --env <env> --ref gcp/gns3@v1 <device-1> <device-2>
+hyops blueprint device web --env <env> --ref gcp/gns3@v1 --all
+```
+
+One Ctrl-C closes every tunnel. Add `--open-all` to open every URL in the workstation browser. Appliance certificates may produce the expected local browser warning.
 
 Closing an interactive access session offers the same keep, archive or destroy decision as an explicit blueprint teardown.
 

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -68,6 +68,14 @@ hyops blueprint access --env <env> --ref gcp/gns3@v1 --automation
 
 HybridOps discovers management leases and produces session-scoped SSH configuration, target data and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
 
+While that session remains open, expose a device web interface on loopback:
+
+```bash
+hyops blueprint device web --env <env> --ref gcp/gns3@v1 <device> --scheme https --port 443
+```
+
+The device may be identified by target name or management IP. Appliance certificates may produce the expected local browser warning.
+
 Closing an interactive access session offers the same keep, archive or destroy decision as an explicit blueprint teardown.
 
 ## Continuity and compute release

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -20,6 +20,7 @@ access:
   remote_port: 3080
   local_port: 3080
   open_browser: false
+  offer_destroy_on_close: true
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
   automation:

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -23,6 +23,9 @@ access:
   offer_destroy_on_close: true
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
+  native_console_mode: "gns3-api"
+  native_console_username: "gns3"
+  native_console_password_env: "GNS3_SERVER_PASSWORD"
   automation:
     management_network_label: "hyops-mgmt0"
     management_cidr: "172.29.130.0/24"

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -86,6 +86,8 @@ Open the private UI:
 hyops blueprint access --env <env> --ref onprem/eve-ng@v1
 ```
 
+Add `--native-consoles` to follow active QEMU VNC ports during the session. New node consoles are forwarded on loopback as they start. The workstation must have a VNC handler registered for links opened by EVE-NG.
+
 Connect a device management interface to `Cloud8`, then add `--automation` to
 open a private workstation-to-device path. HybridOps writes the SSH config,
 device target file and automation inventory under the selected environment.

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -71,6 +71,8 @@ password from the environment vault:
 hyops secrets show --env gns3-lab --raw GNS3_SERVER_PASSWORD
 ```
 
+Add `--native-consoles` to forward the Telnet, VNC, SPICE and web console ports declared for GNS3 nodes. Keep the access command running while using the desktop client.
+
 Press Ctrl-C in the access terminal to close the tunnel. HybridOps then offers to keep the environment, archive its projects before teardown, or destroy without an archive.
 
 ## Default VM

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -71,7 +71,7 @@ password from the environment vault:
 hyops secrets show --env gns3-lab --raw GNS3_SERVER_PASSWORD
 ```
 
-Press Ctrl-C in the access terminal to close the tunnel.
+Press Ctrl-C in the access terminal to close the tunnel. HybridOps then offers to keep the environment, archive its projects before teardown, or destroy without an archive.
 
 ## Default VM
 

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -19,6 +19,7 @@ access:
   state_ref: "platform/onprem/platform-vm#gns3_vm"
   remote_port: 3080
   local_port: 3080
+  offer_destroy_on_close: true
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
   automation:

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -22,6 +22,9 @@ access:
   offer_destroy_on_close: true
   ssh_user: "opsadmin"
   ssh_key_file: "~/.ssh/id_ed25519"
+  native_console_mode: "gns3-api"
+  native_console_username: "gns3"
+  native_console_password_env: "GNS3_SERVER_PASSWORD"
   automation:
     management_network_label: "hyops-mgmt0"
     management_cidr: "172.29.130.0/24"

--- a/hyops/blueprint/automation_access.py
+++ b/hyops/blueprint/automation_access.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import ipaddress
+import json
 import os
 import re
 import shlex
@@ -13,7 +14,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-
 
 _TARGET_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$")
 
@@ -69,6 +69,59 @@ def parse_dnsmasq_leases(text: str, management_cidr: str, *, default_user: str) 
                 "port": 22,
                 "mac": mac.lower(),
                 "source": "dhcp-lease",
+            }
+        )
+    return sorted(candidates, key=lambda item: ipaddress.ip_address(item["host"]))
+
+
+def parse_containerlab_inspect(
+    text: str,
+    management_cidr: str,
+    *,
+    default_user: str,
+) -> list[dict[str, Any]]:
+    """Return target candidates from Containerlab JSON inspection output."""
+
+    try:
+        payload = json.loads(str(text or "{}"))
+    except json.JSONDecodeError:
+        return []
+    records: list[Any] = []
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict):
+        for value in payload.values():
+            if isinstance(value, list):
+                records.extend(value)
+    network = ipaddress.ip_network(management_cidr, strict=False)
+    candidates: list[dict[str, Any]] = []
+    used_names: set[str] = set()
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        raw_address = str(record.get("ipv4_address") or "").split("/", 1)[0]
+        try:
+            address = ipaddress.ip_address(raw_address)
+        except ValueError:
+            continue
+        if address not in network:
+            continue
+        base = _safe_name(str(record.get("name") or f"device-{address}"))
+        name = base
+        suffix = 2
+        while name in used_names:
+            name = f"{base[:58]}-{suffix}"
+            suffix += 1
+        used_names.add(name)
+        candidates.append(
+            {
+                "name": name,
+                "host": str(address),
+                "user": default_user,
+                "port": 22,
+                "mac": "",
+                "source": "containerlab-inspect",
+                "platform": str(record.get("kind") or "").strip(),
             }
         )
     return sorted(candidates, key=lambda item: ipaddress.ip_address(item["host"]))
@@ -158,8 +211,13 @@ def _target_template(candidates: list[dict[str, Any]], management_label: str) ->
                     f"    host: {item['host']}",
                     f"    user: {item['user']}",
                     "    port: 22",
-                    f"    mac: {item['mac']}",
-                    "    source: dhcp-lease",
+                    f"    mac: {item.get('mac', '')}",
+                    f"    source: {item.get('source') or 'static'}",
+                    *(
+                        [f"    platform: {item['platform']}"]
+                        if item.get("platform")
+                        else []
+                    ),
                     "    groups: [network_devices]",
                 ]
             )
@@ -171,7 +229,7 @@ def _merge_discovered_targets(
     candidates: list[dict[str, Any]],
     management_label: str,
 ) -> list[str]:
-    """Add DHCP targets without replacing operator-managed target settings."""
+    """Add discovered targets without replacing operator-managed settings."""
 
     try:
         payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
@@ -181,7 +239,7 @@ def _merge_discovered_targets(
         raise ValueError(f"automation target file must contain a targets list: {path}")
 
     targets = payload.get("targets") or []
-    by_mac: dict[str, dict[str, Any]] = {}
+    by_identity: dict[tuple[str, str], dict[str, Any]] = {}
     occupied_hosts: set[str] = set()
     occupied_names: set[str] = set()
     for raw in targets:
@@ -195,14 +253,19 @@ def _merge_discovered_targets(
             occupied_hosts.add(host)
         if name:
             occupied_names.add(name)
-        if mac and source == "dhcp-lease":
-            by_mac[mac] = raw
+        if source == "dhcp-lease" and mac:
+            by_identity[(source, mac)] = raw
+        elif source == "containerlab-inspect" and name:
+            by_identity[(source, name)] = raw
 
     changed = False
     added: list[str] = []
     for candidate in candidates:
         mac = str(candidate.get("mac") or "").lower()
-        existing = by_mac.get(mac)
+        source = str(candidate.get("source") or "").strip()
+        identity_value = mac if source == "dhcp-lease" else str(candidate["name"])
+        identity = (source, identity_value)
+        existing = by_identity.get(identity)
         if existing is not None:
             previous_host = str(existing.get("host") or "").strip()
             current_host = str(candidate["host"])
@@ -227,11 +290,12 @@ def _merge_discovered_targets(
             "user": str(candidate["user"]),
             "port": int(candidate.get("port") or 22),
             "mac": mac,
-            "source": "dhcp-lease",
+            "source": source,
+            "platform": str(candidate.get("platform") or ""),
             "groups": ["network_devices"],
         }
         targets.append(target)
-        by_mac[mac] = target
+        by_identity[identity] = target
         occupied_names.add(name)
         occupied_hosts.add(str(candidate["host"]))
         added.append(name)
@@ -240,7 +304,7 @@ def _merge_discovered_targets(
     if changed:
         content = [
             "# Devices reachable through the HybridOps-managed lab network.",
-            f"# DHCP devices on {management_label} are maintained automatically.",
+            f"# Discovered devices on {management_label} are maintained automatically.",
             "# Add static targets or adjust names and credentials when required.",
             yaml.safe_dump({"version": 1, "targets": targets}, sort_keys=False).rstrip(),
             "",
@@ -395,6 +459,7 @@ def prepare_automation_session(
     gateway: dict[str, Any],
     socks_port: int,
     lease_text: str = "",
+    discovery_text: str = "",
     target_file_override: str = "",
 ) -> dict[str, Any]:
     """Create target configuration and client files for one access session."""
@@ -415,11 +480,18 @@ def prepare_automation_session(
     )
     if target_file_override and not target_file.is_file():
         raise ValueError(f"automation target file does not exist: {target_file}")
-    candidates = parse_dnsmasq_leases(
-        lease_text,
-        automation["management_cidr"],
-        default_user=automation["default_user"],
-    )
+    if automation.get("discovery_mode") == "containerlab-inspect":
+        candidates = parse_containerlab_inspect(
+            discovery_text,
+            automation["management_cidr"],
+            default_user=automation["default_user"],
+        )
+    else:
+        candidates = parse_dnsmasq_leases(
+            lease_text,
+            automation["management_cidr"],
+            default_user=automation["default_user"],
+        )
     if not target_file.exists():
         _write_private(
             target_file,

--- a/hyops/blueprint/automation_access.py
+++ b/hyops/blueprint/automation_access.py
@@ -16,6 +16,7 @@ from typing import Any
 import yaml
 
 _TARGET_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$")
+_WEB_SCHEMES = {"http", "https"}
 
 
 def _safe_name(value: str, *, fallback: str = "device") -> str:
@@ -177,19 +178,41 @@ def _load_targets(path: Path, management_cidr: str) -> list[dict[str, Any]]:
         mac = str(raw.get("mac") or "").strip().lower()
         source = str(raw.get("source") or "").strip()
         platform = str(raw.get("platform") or "").strip()
-        targets.append(
-            {
-                "name": name,
-                "host": str(address),
-                "user": user,
-                "port": port,
-                "identity_file": identity,
-                "groups": list(dict.fromkeys(groups)),
-                "mac": mac,
-                "source": source,
-                "platform": platform,
-            }
-        )
+        web_raw = raw.get("web")
+        web: dict[str, Any] | None = None
+        if web_raw is not None:
+            if not isinstance(web_raw, dict):
+                raise ValueError(f"automation target {name} web must be a mapping")
+            scheme = str(web_raw.get("scheme") or "https").strip().lower()
+            if scheme not in _WEB_SCHEMES:
+                raise ValueError(
+                    f"automation target {name} web scheme must be http or https"
+                )
+            web_port = int(web_raw.get("port") or (443 if scheme == "https" else 80))
+            if not 1 <= web_port <= 65535:
+                raise ValueError(
+                    f"automation target {name} web port must be between 1 and 65535"
+                )
+            web_path = str(web_raw.get("path") or "/").strip()
+            if not web_path.startswith("/") or web_path.startswith("//"):
+                raise ValueError(
+                    f"automation target {name} web path must begin with one /"
+                )
+            web = {"scheme": scheme, "port": web_port, "path": web_path}
+        target = {
+            "name": name,
+            "host": str(address),
+            "user": user,
+            "port": port,
+            "identity_file": identity,
+            "groups": list(dict.fromkeys(groups)),
+            "mac": mac,
+            "source": source,
+            "platform": platform,
+        }
+        if web is not None:
+            target["web"] = web
+        targets.append(target)
     return targets
 
 
@@ -198,6 +221,8 @@ def _target_template(candidates: list[dict[str, Any]], management_label: str) ->
         "# Devices reachable through the HybridOps-managed lab network.",
         f"# Connect a management interface to {management_label}, then set the SSH user.",
         "# identity_file is optional; omit it to use agent, keyboard-interactive, or password auth.",
+        "# Optional web service: web: {scheme: https, port: 443, path: /}",
+        "# device web --all selects only targets that declare web.",
         "version: 1",
         "targets:",
     ]

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -838,6 +838,42 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
     device_ssh.add_argument("target", help="Discovered or operator-defined device name.")
     device_ssh.set_defaults(_handler=run_device)
 
+    device_web = device_commands.add_parser(
+        "web",
+        help="Open a device web interface through the managed lab gateway.",
+    )
+    add_device_args(device_web)
+    device_web.add_argument("target", help="Device name or management IPv4 address.")
+    device_web.add_argument(
+        "--scheme",
+        choices=("http", "https"),
+        default="https",
+        help="Remote web scheme (default: https).",
+    )
+    device_web.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="Remote web port (default: 443 for https or 80 for http).",
+    )
+    device_web.add_argument(
+        "--path",
+        default="/",
+        help="URL path to open (default: /).",
+    )
+    device_web.add_argument(
+        "--local-port",
+        type=int,
+        default=0,
+        help="Local loopback port (default: choose an available port).",
+    )
+    device_web.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open the default browser.",
+    )
+    device_web.set_defaults(_handler=run_device)
+
     device_shell = device_commands.add_parser(
         "shell",
         help="Open a shell configured for the active device session.",
@@ -1275,6 +1311,56 @@ def run_device(ns) -> int:
                 print(f"device targets: {material['target_file']}")
                 print(f"edit: {_device_edit_command(ns)}")
             return int(result.returncode)
+        if action == "web":
+            address, target = _resolve_device_target(ns.target, automation, targets)
+            scheme = str(getattr(ns, "scheme", "https") or "https")
+            remote_port = int(getattr(ns, "port", 0) or (443 if scheme == "https" else 80))
+            if not 1 <= remote_port <= 65535:
+                raise ValueError("--port must be between 1 and 65535")
+            path = str(getattr(ns, "path", "/") or "/")
+            if not path.startswith("/") or path.startswith("//"):
+                raise ValueError("--path must begin with one /")
+            local_port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
+            _require_local_ports_available([local_port])
+            label = str(target["name"] if target else address)
+            argv = [
+                ssh,
+                "-F",
+                str(ssh_config),
+                "-N",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "-L",
+                f"127.0.0.1:{local_port}:{address}:{remote_port}",
+                str(material["gateway_alias"]),
+            ]
+            proc: subprocess.Popen | None = None
+            try:
+                proc = subprocess.Popen(
+                    argv,
+                    cwd=str(Path.home()),
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                _wait_for_local_port(local_port, proc)
+                local_url = f"{scheme}://127.0.0.1:{local_port}{path}"
+                print(f"device web access: {label}")
+                print(f"local URL: {local_url}")
+                print(f"target: {scheme}://{address}:{remote_port}{path}")
+                print("press Ctrl-C to close access")
+                if not bool(getattr(ns, "no_browser", False)):
+                    open_operator_url(local_url)
+                return_code = proc.wait()
+                if return_code:
+                    detail = (proc.stderr.read() if proc.stderr else "").strip()
+                    raise ValueError(detail or f"device web tunnel exited with rc={return_code}")
+                return 0
+            except KeyboardInterrupt:
+                print("device web access closed")
+                return 0
+            finally:
+                _stop_process(proc)
         if action in {"shell", "run"}:
             environment = _device_process_environment(material)
             if action == "shell":
@@ -2082,6 +2168,21 @@ def _read_automation_leases(
     ssh_target: str,
     automation: dict[str, Any],
 ) -> str:
+    if automation.get("discovery_mode") == "containerlab-inspect":
+        result = subprocess.run(
+            [
+                *ssh_base,
+                ssh_target,
+                "sudo -n containerlab inspect --all -f json",
+            ],
+            cwd=str(Path.home()),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=20,
+            check=False,
+        )
+        return result.stdout if result.returncode == 0 else ""
     lease_file = str(automation.get("lease_file") or "").strip()
     if not lease_file:
         return ""
@@ -2133,6 +2234,7 @@ def _prepare_automation_access(
         gateway=gateway,
         socks_port=socks_port,
         lease_text=lease_text,
+        discovery_text=lease_text,
         target_file_override=str(getattr(ns, "targets", "") or ""),
     )
     return socks_port, session
@@ -2165,6 +2267,7 @@ def _automation_refresher(
             gateway=gateway,
             socks_port=socks_port,
             lease_text=lease_text,
+            discovery_text=lease_text,
         )
         added = list(updated.get("new_targets") or [])
         session.clear()
@@ -2191,7 +2294,10 @@ def _print_automation_access(
         f"{automation['management_network_label']} "
         f"({automation['management_cidr']})"
     )
-    print("device discovery: watching management-network DHCP leases")
+    if automation.get("discovery_mode") == "containerlab-inspect":
+        print("device discovery: reading Containerlab runtime state")
+    else:
+        print("device discovery: watching management-network DHCP leases")
     print("device commands: hyops blueprint device --help")
     if verbose_enabled():
         print(f"device proxy: {session['socks_proxy']}")

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1500,7 +1500,79 @@ def _require_local_ports_available(ports: list[int]) -> None:
 def _native_console_status(ports: list[int]) -> str:
     if ports:
         return "native console ports: " + ", ".join(str(item) for item in ports)
-    return "native consoles: no active QEMU nodes; web access remains available"
+    return "native consoles: waiting for active QEMU nodes"
+
+
+def _discover_eve_qemu_console_ports(
+    ssh_base: list[str],
+    ssh_target: str,
+    known_hosts_file: Path,
+) -> list[int]:
+    probe = subprocess.run(
+        [*ssh_base, ssh_target, "sudo -n ss -H -lntp"],
+        cwd=str(Path.home()),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=20,
+        check=False,
+    )
+    if probe.returncode != 0:
+        raise ValueError(
+            "failed to discover native EVE-NG consoles: "
+            + _ssh_access_error(probe.stderr, known_hosts_file)
+        )
+    return _parse_eve_qemu_console_ports(probe.stdout)
+
+
+def _native_console_refresher(
+    *,
+    ssh_base: list[str],
+    ssh_target: str,
+    known_hosts_file: Path,
+    forwarded_ports: list[int],
+) -> tuple[Callable[[], None], Callable[[], None]]:
+    forwarded = set(forwarded_ports)
+    processes: dict[int, subprocess.Popen] = {}
+    failed: set[int] = set()
+
+    def refresh() -> None:
+        active = _discover_eve_qemu_console_ports(
+            ssh_base,
+            ssh_target,
+            known_hosts_file,
+        )
+        for port in active:
+            if port in forwarded:
+                continue
+            proc: subprocess.Popen | None = None
+            try:
+                _require_local_ports_available([port])
+                argv = [*ssh_base, "-N", "-o", "ExitOnForwardFailure=yes"]
+                argv.extend(["-L", f"127.0.0.1:{port}:127.0.0.1:{port}"])
+                argv.append(ssh_target)
+                proc = subprocess.Popen(argv, cwd=str(Path.home()))
+                _wait_for_local_port(port, proc, timeout_s=10)
+            except Exception as exc:
+                _stop_process(proc)
+                if port not in failed:
+                    print(
+                        f"WARN: native console port {port} could not be forwarded: {exc}",
+                        flush=True,
+                    )
+                    failed.add(port)
+                continue
+            processes[port] = proc
+            forwarded.add(port)
+            failed.discard(port)
+            print(f"native console available: vnc://127.0.0.1:{port}", flush=True)
+
+    def stop() -> None:
+        for proc in processes.values():
+            _stop_process(proc)
+        processes.clear()
+
+    return refresh, stop
 
 
 def _print_native_console_client_guidance() -> None:
@@ -2166,7 +2238,29 @@ def _wait_for_access_processes(
         time.sleep(0.5)
 
 
+def _combine_maintenance(
+    *callbacks: Callable[[], None] | None,
+) -> Callable[[], None] | None:
+    active = tuple(callback for callback in callbacks if callback is not None)
+    if not active:
+        return None
+
+    def run() -> None:
+        first_error: Exception | None = None
+        for callback in active:
+            try:
+                callback()
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
+    return run
+
+
 def run_access(ns) -> int:
+    native_console_stop: Callable[[], None] | None = None
     try:
         payload = _resolve_and_validate(ns)
         access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
@@ -2239,21 +2333,11 @@ def run_access(ns) -> int:
             if bool(getattr(ns, "native_consoles", False)):
                 if str(access.get("native_console_mode") or "") != "eve-ng-qemu":
                     raise ValueError("blueprint does not declare native EVE-NG console access")
-                probe = subprocess.run(
-                    [*ssh_base, ssh_target, "sudo -n ss -H -lntp"],
-                    cwd=str(Path.home()),
-                    text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    timeout=20,
-                    check=False,
+                console_ports = _discover_eve_qemu_console_ports(
+                    ssh_base,
+                    ssh_target,
+                    known_hosts_file,
                 )
-                if probe.returncode != 0:
-                    raise ValueError(
-                        "failed to discover native EVE-NG consoles: "
-                        + _ssh_access_error(probe.stderr, known_hosts_file)
-                    )
-                console_ports = _parse_eve_qemu_console_ports(probe.stdout)
                 if console_ports:
                     _require_local_ports_available(console_ports)
 
@@ -2312,8 +2396,6 @@ def run_access(ns) -> int:
             if bool(getattr(ns, "native_consoles", False)):
                 _print_native_console_client_guidance()
                 print(_native_console_status(console_ports))
-                if not console_ports:
-                    print("native console setup: start a QEMU node, then rerun access with --native-consoles")
             proc = subprocess.Popen(argv, cwd=str(Path.home()))
             time.sleep(2)
             if proc.poll() is not None:
@@ -2333,6 +2415,18 @@ def run_access(ns) -> int:
                     socks_port=socks_port,
                     session=automation_session,
                 )
+            native_console_refresh = None
+            if bool(getattr(ns, "native_consoles", False)):
+                native_console_refresh, native_console_stop = _native_console_refresher(
+                    ssh_base=ssh_base,
+                    ssh_target=ssh_target,
+                    known_hosts_file=known_hosts_file,
+                    forwarded_ports=console_ports,
+                )
+            maintenance = _combine_maintenance(
+                automation_refresh,
+                native_console_refresh,
+            )
             route_proc: subprocess.Popen | None = None
             route_plan: dict[str, Any] | None = None
             if automation and bool(getattr(ns, "route_lab", False)):
@@ -2345,6 +2439,8 @@ def run_access(ns) -> int:
                     )
                     _print_lab_route_ready(automation)
                 except BaseException:
+                    if native_console_stop is not None:
+                        native_console_stop()
                     _stop_process(proc)
                     raise
             if access_type != "ssh-tcp-forward" and not bool(
@@ -2356,13 +2452,17 @@ def run_access(ns) -> int:
                 rc = _wait_for_access_processes(
                     proc,
                     route_proc,
-                    maintenance=automation_refresh,
+                    maintenance=maintenance,
                 )
                 _stop_lab_route(route_proc, route_plan)
+                if native_console_stop is not None:
+                    native_console_stop()
                 _stop_process(proc)
                 return rc
             except KeyboardInterrupt:
                 _stop_lab_route(route_proc, route_plan)
+                if native_console_stop is not None:
+                    native_console_stop()
                 _stop_process(proc)
                 print("access closed")
                 return _offer_access_close_destroy(ns, payload, state)
@@ -2423,21 +2523,11 @@ def run_access(ns) -> int:
             if bool(getattr(ns, "native_consoles", False)):
                 if str(access.get("native_console_mode") or "") != "eve-ng-qemu":
                     raise ValueError("blueprint does not declare native EVE-NG console access")
-                probe = subprocess.run(
-                    [*ssh_base, ssh_target, "sudo -n ss -H -lntp"],
-                    cwd=str(Path.home()),
-                    text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    timeout=20,
-                    check=False,
+                console_ports = _discover_eve_qemu_console_ports(
+                    ssh_base,
+                    ssh_target,
+                    known_hosts_file,
                 )
-                if probe.returncode != 0:
-                    raise ValueError(
-                        "failed to discover native EVE-NG consoles: "
-                        + _ssh_access_error(probe.stderr, known_hosts_file)
-                    )
-                console_ports = _parse_eve_qemu_console_ports(probe.stdout)
                 if console_ports:
                     _require_local_ports_available(console_ports)
             automation_session: dict[str, Any] | None = None
@@ -2503,8 +2593,6 @@ def run_access(ns) -> int:
         if bool(getattr(ns, "native_consoles", False)):
             _print_native_console_client_guidance()
             print(_native_console_status(console_ports))
-            if not console_ports:
-                print("native console setup: start a QEMU node, then rerun access with --native-consoles")
         access_started_at = time.monotonic()
         proc = subprocess.Popen(argv, cwd=str(Path.home()))
         time.sleep(2)
@@ -2526,6 +2614,18 @@ def run_access(ns) -> int:
                 socks_port=socks_port,
                 session=automation_session,
             )
+        native_console_refresh = None
+        if bool(getattr(ns, "native_consoles", False)):
+            native_console_refresh, native_console_stop = _native_console_refresher(
+                ssh_base=ssh_base,
+                ssh_target=ssh_target,
+                known_hosts_file=known_hosts_file,
+                forwarded_ports=console_ports,
+            )
+        maintenance = _combine_maintenance(
+            automation_refresh,
+            native_console_refresh,
+        )
         route_proc: subprocess.Popen | None = None
         route_plan: dict[str, Any] | None = None
         if automation and bool(getattr(ns, "route_lab", False)):
@@ -2538,6 +2638,8 @@ def run_access(ns) -> int:
                 )
                 _print_lab_route_ready(automation)
             except BaseException:
+                if native_console_stop is not None:
+                    native_console_stop()
                 _stop_process(proc)
                 _stop_process(iap_proc)
                 raise
@@ -2548,14 +2650,18 @@ def run_access(ns) -> int:
             rc = _wait_for_access_processes(
                 proc,
                 route_proc,
-                maintenance=automation_refresh,
+                maintenance=maintenance,
             )
             _stop_lab_route(route_proc, route_plan)
+            if native_console_stop is not None:
+                native_console_stop()
             _stop_process(proc)
             _stop_process(iap_proc)
             return rc
         except KeyboardInterrupt:
             _stop_lab_route(route_proc, route_plan)
+            if native_console_stop is not None:
+                native_console_stop()
             _stop_process(proc)
             _stop_process(iap_proc)
             print("access closed")
@@ -2568,6 +2674,8 @@ def run_access(ns) -> int:
                 access_started_at=access_started_at,
             )
     except Exception as exc:
+        if native_console_stop is not None:
+            native_console_stop()
         if "iap_proc" in locals():
             _stop_process(iap_proc)
         print(f"ERR: blueprint access failed: {exc}")

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -840,26 +840,36 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
 
     device_web = device_commands.add_parser(
         "web",
-        help="Open a device web interface through the managed lab gateway.",
+        help="Open device web interfaces through the managed lab gateway.",
     )
     add_device_args(device_web)
-    device_web.add_argument("target", help="Device name or management IPv4 address.")
+    device_web.add_argument(
+        "target",
+        nargs="*",
+        help="One or more device names or management IPv4 addresses.",
+    )
+    device_web.add_argument(
+        "--all",
+        dest="all_targets",
+        action="store_true",
+        help="Open every target that declares a web service.",
+    )
     device_web.add_argument(
         "--scheme",
         choices=("http", "https"),
-        default="https",
-        help="Remote web scheme (default: https).",
+        default=None,
+        help="Override the declared remote web scheme.",
     )
     device_web.add_argument(
         "--port",
         type=int,
-        default=0,
-        help="Remote web port (default: 443 for https or 80 for http).",
+        default=None,
+        help="Override the declared remote web port.",
     )
     device_web.add_argument(
         "--path",
-        default="/",
-        help="URL path to open (default: /).",
+        default=None,
+        help="Override the declared URL path.",
     )
     device_web.add_argument(
         "--local-port",
@@ -867,10 +877,16 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         default=0,
         help="Local loopback port (default: choose an available port).",
     )
-    device_web.add_argument(
+    browser_mode = device_web.add_mutually_exclusive_group()
+    browser_mode.add_argument(
         "--no-browser",
         action="store_true",
         help="Do not open the default browser.",
+    )
+    browser_mode.add_argument(
+        "--open-all",
+        action="store_true",
+        help="Open every local URL when several targets are selected.",
     )
     device_web.set_defaults(_handler=run_device)
 
@@ -1162,6 +1178,181 @@ def _resolve_device_target(
     return str(address), None
 
 
+def _device_web_requests(
+    ns,
+    automation: dict[str, Any],
+    targets: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    raw_targets = getattr(ns, "target", []) or []
+    if isinstance(raw_targets, str):
+        target_tokens = [raw_targets]
+    else:
+        target_tokens = [str(item) for item in raw_targets]
+    target_tokens = [item.strip() for item in target_tokens if item.strip()]
+    use_all = bool(getattr(ns, "all_targets", False))
+    if use_all and target_tokens:
+        raise ValueError("device web accepts target names or --all, not both")
+    if use_all:
+        selected = [
+            (str(target["host"]), target)
+            for target in targets
+            if isinstance(target.get("web"), dict)
+        ]
+        if not selected:
+            raise ValueError(
+                "no targets declare web access; run device edit and add a web mapping"
+            )
+    else:
+        if not target_tokens:
+            raise ValueError("device web requires at least one target or --all")
+        selected = [
+            _resolve_device_target(token, automation, targets)
+            for token in target_tokens
+        ]
+
+    scheme_override = str(getattr(ns, "scheme", None) or "").strip().lower()
+    if scheme_override and scheme_override not in {"http", "https"}:
+        raise ValueError("--scheme must be http or https")
+    port_override = int(getattr(ns, "port", None) or 0)
+    if port_override and not 1 <= port_override <= 65535:
+        raise ValueError("--port must be between 1 and 65535")
+    path_override = getattr(ns, "path", None)
+    if path_override is not None:
+        path_override = str(path_override or "/")
+        if not path_override.startswith("/") or path_override.startswith("//"):
+            raise ValueError("--path must begin with one /")
+
+    requests: list[dict[str, Any]] = []
+    seen_addresses: set[str] = set()
+    for address, target in selected:
+        if address in seen_addresses:
+            raise ValueError(f"device web target is duplicated: {address}")
+        seen_addresses.add(address)
+        declared = target.get("web") if target else None
+        web = declared if isinstance(declared, dict) else {}
+        scheme = scheme_override or str(web.get("scheme") or "https")
+        remote_port = port_override or int(
+            web.get("port") or (443 if scheme == "https" else 80)
+        )
+        path = str(
+            path_override if path_override is not None else web.get("path") or "/"
+        )
+        requests.append(
+            {
+                "address": address,
+                "label": str(target["name"] if target else address),
+                "scheme": scheme,
+                "remote_port": remote_port,
+                "path": path,
+            }
+        )
+    return requests
+
+
+def _run_device_web(
+    ns,
+    *,
+    ssh: str,
+    ssh_config: Path,
+    gateway_alias: str,
+    automation: dict[str, Any],
+    targets: list[dict[str, Any]],
+) -> int:
+    requests = _device_web_requests(ns, automation, targets)
+    requested_local_port = int(getattr(ns, "local_port", 0) or 0)
+    if requested_local_port and len(requests) > 1:
+        raise ValueError("--local-port is available only with one device web target")
+
+    sessions: list[dict[str, Any]] = []
+    try:
+        for request in requests:
+            local_port = _available_local_port(requested_local_port)
+            _require_local_ports_available([local_port])
+            argv = [
+                ssh,
+                "-F",
+                str(ssh_config),
+                "-N",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "-L",
+                (
+                    f"127.0.0.1:{local_port}:{request['address']}:"
+                    f"{request['remote_port']}"
+                ),
+                gateway_alias,
+            ]
+            proc = subprocess.Popen(
+                argv,
+                cwd=str(Path.home()),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                _wait_for_local_port(local_port, proc)
+            except Exception:
+                _stop_process(proc)
+                raise
+            local_url = (
+                f"{request['scheme']}://127.0.0.1:{local_port}{request['path']}"
+            )
+            target_url = (
+                f"{request['scheme']}://{request['address']}:"
+                f"{request['remote_port']}{request['path']}"
+            )
+            sessions.append(
+                {
+                    "label": request["label"],
+                    "local_url": local_url,
+                    "target_url": target_url,
+                    "proc": proc,
+                }
+            )
+
+        if len(sessions) == 1:
+            session = sessions[0]
+            print(f"device web access: {session['label']}")
+            print(f"local URL: {session['local_url']}")
+            print(f"target: {session['target_url']}")
+        else:
+            print(f"device web access: {len(sessions)} targets")
+            for session in sessions:
+                print(
+                    f"- {session['label']}  local={session['local_url']}  "
+                    f"target={session['target_url']}"
+                )
+        print("press Ctrl-C to close access")
+
+        open_all = bool(getattr(ns, "open_all", False))
+        no_browser = bool(getattr(ns, "no_browser", False))
+        if len(sessions) > 1 and not no_browser and not open_all:
+            print("browser: not opened; use --open-all to open every URL")
+        if not no_browser and (len(sessions) == 1 or open_all):
+            for session in sessions:
+                open_operator_url(str(session["local_url"]))
+
+        while True:
+            for session in sessions:
+                proc = session["proc"]
+                return_code = proc.poll()
+                if return_code is None:
+                    continue
+                detail = (proc.stderr.read() if proc.stderr else "").strip()
+                raise ValueError(
+                    detail
+                    or f"device web tunnel for {session['label']} exited with "
+                    f"rc={return_code}"
+                )
+            time.sleep(0.25)
+    except KeyboardInterrupt:
+        print("device web access closed")
+        return 0
+    finally:
+        for session in reversed(sessions):
+            _stop_process(session["proc"])
+
+
 def _device_process_environment(material: dict[str, Any]) -> dict[str, str]:
     required = {
         "SSH configuration": Path(material["ssh_config"]),
@@ -1243,9 +1434,13 @@ def run_device(ns) -> int:
                     user = str(target["user"])
                     if source == "DHCP" and user == automation["default_user"]:
                         user += " (default)"
+                    web = target.get("web")
+                    web_summary = ""
+                    if isinstance(web, dict):
+                        web_summary = f"  web={web['scheme']}:{web['port']}"
                     print(
                         f"{target['name']}  {target['host']}  user={user}  "
-                        f"port={target['port']}  {platform}  {source}"
+                        f"port={target['port']}  {platform}  {source}{web_summary}"
                     )
             return 0
 
@@ -1312,55 +1507,14 @@ def run_device(ns) -> int:
                 print(f"edit: {_device_edit_command(ns)}")
             return int(result.returncode)
         if action == "web":
-            address, target = _resolve_device_target(ns.target, automation, targets)
-            scheme = str(getattr(ns, "scheme", "https") or "https")
-            remote_port = int(getattr(ns, "port", 0) or (443 if scheme == "https" else 80))
-            if not 1 <= remote_port <= 65535:
-                raise ValueError("--port must be between 1 and 65535")
-            path = str(getattr(ns, "path", "/") or "/")
-            if not path.startswith("/") or path.startswith("//"):
-                raise ValueError("--path must begin with one /")
-            local_port = _available_local_port(int(getattr(ns, "local_port", 0) or 0))
-            _require_local_ports_available([local_port])
-            label = str(target["name"] if target else address)
-            argv = [
-                ssh,
-                "-F",
-                str(ssh_config),
-                "-N",
-                "-o",
-                "ExitOnForwardFailure=yes",
-                "-L",
-                f"127.0.0.1:{local_port}:{address}:{remote_port}",
-                str(material["gateway_alias"]),
-            ]
-            proc: subprocess.Popen | None = None
-            try:
-                proc = subprocess.Popen(
-                    argv,
-                    cwd=str(Path.home()),
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                )
-                _wait_for_local_port(local_port, proc)
-                local_url = f"{scheme}://127.0.0.1:{local_port}{path}"
-                print(f"device web access: {label}")
-                print(f"local URL: {local_url}")
-                print(f"target: {scheme}://{address}:{remote_port}{path}")
-                print("press Ctrl-C to close access")
-                if not bool(getattr(ns, "no_browser", False)):
-                    open_operator_url(local_url)
-                return_code = proc.wait()
-                if return_code:
-                    detail = (proc.stderr.read() if proc.stderr else "").strip()
-                    raise ValueError(detail or f"device web tunnel exited with rc={return_code}")
-                return 0
-            except KeyboardInterrupt:
-                print("device web access closed")
-                return 0
-            finally:
-                _stop_process(proc)
+            return _run_device_web(
+                ns,
+                ssh=ssh,
+                ssh_config=ssh_config,
+                gateway_alias=str(material["gateway_alias"]),
+                automation=automation,
+                targets=targets,
+            )
         if action in {"shell", "run"}:
             environment = _device_process_environment(material)
             if action == "shell":
@@ -1545,7 +1699,7 @@ def _wait_for_local_port(
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         if proc.poll() is not None:
-            raise RuntimeError(f"IAP SSH tunnel exited with rc={proc.returncode}")
+            raise RuntimeError(f"SSH tunnel exited with rc={proc.returncode}")
         probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             probe.bind(("127.0.0.1", port))
@@ -1555,7 +1709,7 @@ def _wait_for_local_port(
         finally:
             probe.close()
         time.sleep(0.25)
-    raise TimeoutError("timed out waiting for the local IAP SSH tunnel")
+    raise TimeoutError("timed out waiting for the local SSH tunnel")
 
 
 def _parse_eve_qemu_console_ports(output: str) -> list[int]:

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import errno
 import hashlib
 import ipaddress
@@ -15,6 +16,9 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -36,24 +40,17 @@ from hyops.runtime.module_state import (
 )
 from hyops.runtime.operator_output import concise_error
 from hyops.runtime.paths import resolve_runtime_paths
-from hyops.runtime.progress import ProgressDisplay, verbose_enabled
 from hyops.runtime.preflight_decision import (
     complete_preflight_decision,
     new_preflight_decision,
     validate_preflight_bypass,
 )
+from hyops.runtime.progress import ProgressDisplay, verbose_enabled
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.source_roots import resolve_blueprints_root
 from hyops.runtime.storage import format_runtime_storage_error, require_runtime_writable
+from hyops.runtime.vault import VaultAuth, read_env
 
-from .contracts import (
-    enforce_step_contracts,
-    explicit_step_inputs_changed,
-    module_state_ok,
-    module_state_status,
-    resolved_step_inputs_file,
-    step_state_ref,
-)
 from .automation_access import (
     automation_session_paths,
     build_tunnel_ssh_argv,
@@ -62,14 +59,24 @@ from .automation_access import (
     local_route_conflicts,
     prepare_automation_session,
 )
-from .planner import compute_preflight, run_step_module_command
-from .schema import load_blueprint, resolve_blueprint_file, validate_blueprint
+from .contracts import (
+    enforce_step_contracts,
+    explicit_step_inputs_changed,
+    module_state_ok,
+    module_state_status,
+    resolved_step_inputs_file,
+    step_state_ref,
+)
+from .iol_repair import (
+    MODULE_REF as IOL_IMAGES_MODULE_REF,
+)
 from .iol_repair import (
     IolRepairError,
-    MODULE_REF as IOL_IMAGES_MODULE_REF,
     parse_iol_mismatch,
     repair_iol_license,
 )
+from .planner import compute_preflight, run_step_module_command
+from .schema import load_blueprint, resolve_blueprint_file, validate_blueprint
 
 
 def _runtime_overlay_for_ref(ns, blueprint_ref: str) -> str:
@@ -1497,9 +1504,11 @@ def _require_local_ports_available(ports: list[int]) -> None:
             sock.close()
 
 
-def _native_console_status(ports: list[int]) -> str:
+def _native_console_status(ports: list[int], *, mode: str = "eve-ng-qemu") -> str:
     if ports:
         return "native console ports: " + ", ".join(str(item) for item in ports)
+    if mode == "gns3-api":
+        return "native consoles: waiting for GNS3 nodes"
     return "native consoles: waiting for active QEMU nodes"
 
 
@@ -1575,11 +1584,153 @@ def _native_console_refresher(
     return refresh, stop
 
 
-def _print_native_console_client_guidance() -> None:
-    if not is_windows_wsl():
+def _runtime_access_secret(paths, env_name: str, env_key: str) -> str:
+    value = str(os.environ.get(env_key) or "").strip()
+    if value:
+        return value
+    vault_file = paths.vault_dir / "bootstrap.vault.env"
+    try:
+        values = read_env(vault_file, VaultAuth())
+    except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as exc:
+        raise ValueError(
+            f"native console credential {env_key} could not be read from the environment vault"
+        ) from exc
+    value = str(values.get(env_key) or "").strip()
+    if not value:
+        raise ValueError(
+            f"native console credential {env_key} is missing; run: "
+            f"hyops secrets ensure --env {env_name} {env_key}"
+        )
+    return value
+
+
+def _gns3_api_json(url: str, username: str, password: str) -> Any:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Basic {token}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return json.load(response)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise ValueError("GNS3 console discovery API request failed") from exc
+
+
+def _discover_gns3_consoles(
+    local_api_port: int,
+    username: str,
+    password: str,
+) -> list[tuple[int, str, str]]:
+    root = f"http://127.0.0.1:{local_api_port}/v2"
+    projects = _gns3_api_json(f"{root}/projects", username, password)
+    if not isinstance(projects, list):
+        raise ValueError("GNS3 projects response is invalid")
+    consoles: dict[int, tuple[int, str, str]] = {}
+    local_hosts = {"127.0.0.1", "localhost", "0.0.0.0", "::", "::1"}
+    for project in projects:
+        if not isinstance(project, dict):
+            continue
+        project_id = str(project.get("project_id") or "").strip()
+        if not project_id:
+            continue
+        encoded_id = urllib.parse.quote(project_id, safe="")
+        nodes = _gns3_api_json(
+            f"{root}/projects/{encoded_id}/nodes",
+            username,
+            password,
+        )
+        if not isinstance(nodes, list):
+            continue
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            host = str(node.get("console_host") or "").strip().lower()
+            console_type = str(node.get("console_type") or "").strip().lower()
+            raw_port = node.get("console")
+            if host not in local_hosts or console_type in {"", "none"}:
+                continue
+            if not isinstance(raw_port, int) or not 1 <= raw_port <= 65535:
+                continue
+            name = str(node.get("name") or node.get("node_id") or "node").strip()
+            consoles[raw_port] = (raw_port, console_type, name)
+    return [consoles[port] for port in sorted(consoles)]
+
+
+def _gns3_console_refresher(
+    *,
+    ssh_base: list[str],
+    ssh_target: str,
+    local_api_port: int,
+    username: str,
+    password: str,
+) -> tuple[Callable[[], None], Callable[[], None]]:
+    forwarded: set[int] = set()
+    processes: dict[int, subprocess.Popen] = {}
+    failed: set[int] = set()
+
+    def refresh() -> None:
+        for port, console_type, name in _discover_gns3_consoles(
+            local_api_port,
+            username,
+            password,
+        ):
+            if port in forwarded:
+                continue
+            proc: subprocess.Popen | None = None
+            try:
+                _require_local_ports_available([port])
+                argv = [*ssh_base, "-N", "-o", "ExitOnForwardFailure=yes"]
+                argv.extend(["-L", f"127.0.0.1:{port}:127.0.0.1:{port}"])
+                argv.append(ssh_target)
+                proc = subprocess.Popen(argv, cwd=str(Path.home()))
+                _wait_for_local_port(port, proc, timeout_s=10)
+            except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
+                _stop_process(proc)
+                if port not in failed:
+                    print(
+                        f"WARN: {name} console port {port} could not be forwarded: {exc}",
+                        flush=True,
+                    )
+                    failed.add(port)
+                continue
+            processes[port] = proc
+            forwarded.add(port)
+            failed.discard(port)
+            scheme = "spice" if console_type.startswith("spice") else console_type
+            print(
+                f"native console available: {name} "
+                f"({console_type}) {scheme}://127.0.0.1:{port}",
+                flush=True,
+            )
+
+    def stop() -> None:
+        for proc in processes.values():
+            _stop_process(proc)
+        processes.clear()
+
+    return refresh, stop
+
+
+def _print_native_console_client_guidance(mode: str) -> None:
+    if mode == "gns3-api":
+        print("GNS3 node consoles are forwarded to their matching local ports.")
         return
-    print("Windows native consoles require the EVE-NG Windows Client Pack.")
-    print("HTML5 consoles remain available without it.")
+    if is_windows_wsl():
+        print("Windows native consoles require the EVE-NG Windows Client Pack.")
+        print("HTML5 consoles remain available without it.")
+
+
+def _native_console_mode(access: dict[str, Any], enabled: bool) -> str:
+    if not enabled:
+        return ""
+    mode = str(access.get("native_console_mode") or "").strip()
+    if mode not in {"eve-ng-qemu", "gns3-api"}:
+        raise ValueError("blueprint does not declare supported native console access")
+    return mode
 
 
 def _extract_access_host(outputs: dict[str, Any]) -> str:
@@ -2329,10 +2480,12 @@ def run_access(ns) -> int:
                 raise ValueError(
                     _ssh_access_error(identity_check.stderr, known_hosts_file)
                 )
+            native_console_mode = _native_console_mode(
+                access,
+                bool(getattr(ns, "native_consoles", False)),
+            )
             console_ports: list[int] = []
-            if bool(getattr(ns, "native_consoles", False)):
-                if str(access.get("native_console_mode") or "") != "eve-ng-qemu":
-                    raise ValueError("blueprint does not declare native EVE-NG console access")
+            if native_console_mode == "eve-ng-qemu":
                 console_ports = _discover_eve_qemu_console_ports(
                     ssh_base,
                     ssh_target,
@@ -2393,13 +2546,20 @@ def run_access(ns) -> int:
                     automation_session,
                     route_requested=bool(getattr(ns, "route_lab", False)),
                 )
-            if bool(getattr(ns, "native_consoles", False)):
-                _print_native_console_client_guidance()
-                print(_native_console_status(console_ports))
+            if native_console_mode:
+                _print_native_console_client_guidance(native_console_mode)
+                print(
+                    _native_console_status(
+                        console_ports,
+                        mode=native_console_mode,
+                    )
+                )
             proc = subprocess.Popen(argv, cwd=str(Path.home()))
             time.sleep(2)
             if proc.poll() is not None:
                 return OPERATOR_ERROR
+            if native_console_mode == "gns3-api":
+                _wait_for_local_port(port, proc)
             if automation:
                 _wait_for_local_port(socks_port, proc)
             automation_refresh = None
@@ -2416,13 +2576,27 @@ def run_access(ns) -> int:
                     session=automation_session,
                 )
             native_console_refresh = None
-            if bool(getattr(ns, "native_consoles", False)):
+            if native_console_mode == "eve-ng-qemu":
                 native_console_refresh, native_console_stop = _native_console_refresher(
                     ssh_base=ssh_base,
                     ssh_target=ssh_target,
                     known_hosts_file=known_hosts_file,
                     forwarded_ports=console_ports,
                 )
+            elif native_console_mode == "gns3-api":
+                password_env = str(access["native_console_password_env"])
+                native_console_refresh, native_console_stop = _gns3_console_refresher(
+                    ssh_base=ssh_base,
+                    ssh_target=ssh_target,
+                    local_api_port=port,
+                    username=str(access["native_console_username"]),
+                    password=_runtime_access_secret(
+                        paths,
+                        str(getattr(ns, "env", "") or "default"),
+                        password_env,
+                    ),
+                )
+                native_console_refresh()
             maintenance = _combine_maintenance(
                 automation_refresh,
                 native_console_refresh,
@@ -2486,6 +2660,11 @@ def run_access(ns) -> int:
         if not gcloud:
             raise ValueError("gcloud is required; run: hyops setup gcp")
         iap_proc: subprocess.Popen | None = None
+        native_console_mode = _native_console_mode(
+            access,
+            bool(getattr(ns, "native_consoles", False)),
+        )
+        console_ports: list[int] = []
         if str(access.get("type") or "") == "gcp-iap-ssh-forward":
             ssh_user = str(access.get("ssh_user") or "").strip()
             ssh_key = str(Path(str(access.get("ssh_key_file") or "")).expanduser().resolve())
@@ -2519,10 +2698,7 @@ def run_access(ns) -> int:
                 "-p", str(iap_port),
             ]
             ssh_target = f"{ssh_user}@127.0.0.1"
-            console_ports: list[int] = []
-            if bool(getattr(ns, "native_consoles", False)):
-                if str(access.get("native_console_mode") or "") != "eve-ng-qemu":
-                    raise ValueError("blueprint does not declare native EVE-NG console access")
+            if native_console_mode == "eve-ng-qemu":
                 console_ports = _discover_eve_qemu_console_ports(
                     ssh_base,
                     ssh_target,
@@ -2591,14 +2767,21 @@ def run_access(ns) -> int:
         print(f"billing: {'enabled' if enabled else 'disabled'}" if validated else "billing: unable to verify")
         _print_cost_estimate(cost_estimate, state=state)
         if bool(getattr(ns, "native_consoles", False)):
-            _print_native_console_client_guidance()
-            print(_native_console_status(console_ports))
+            _print_native_console_client_guidance(native_console_mode)
+            print(
+                _native_console_status(
+                    console_ports,
+                    mode=native_console_mode,
+                )
+            )
         access_started_at = time.monotonic()
         proc = subprocess.Popen(argv, cwd=str(Path.home()))
         time.sleep(2)
         if proc.poll() is not None:
             _stop_process(iap_proc)
             return OPERATOR_ERROR
+        if native_console_mode == "gns3-api":
+            _wait_for_local_port(port, proc)
         if automation:
             _wait_for_local_port(socks_port, proc)
         automation_refresh = None
@@ -2615,13 +2798,27 @@ def run_access(ns) -> int:
                 session=automation_session,
             )
         native_console_refresh = None
-        if bool(getattr(ns, "native_consoles", False)):
+        if native_console_mode == "eve-ng-qemu":
             native_console_refresh, native_console_stop = _native_console_refresher(
                 ssh_base=ssh_base,
                 ssh_target=ssh_target,
                 known_hosts_file=known_hosts_file,
                 forwarded_ports=console_ports,
             )
+        elif native_console_mode == "gns3-api":
+            password_env = str(access["native_console_password_env"])
+            native_console_refresh, native_console_stop = _gns3_console_refresher(
+                ssh_base=ssh_base,
+                ssh_target=ssh_target,
+                local_api_port=port,
+                username=str(access["native_console_username"]),
+                password=_runtime_access_secret(
+                    paths,
+                    str(getattr(ns, "env", "") or "default"),
+                    password_env,
+                ),
+            )
+            native_console_refresh()
         maintenance = _combine_maintenance(
             automation_refresh,
             native_console_refresh,

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -266,6 +266,14 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
         raw_automation = raw_access.get("automation")
         if raw_automation is not None:
             automation = as_mapping(raw_automation, "access.automation")
+            discovery_mode = str(
+                automation.get("discovery_mode") or "dnsmasq-leases"
+            ).strip()
+            if discovery_mode not in {"dnsmasq-leases", "containerlab-inspect"}:
+                raise ValueError(
+                    "access.automation.discovery_mode must be dnsmasq-leases or "
+                    "containerlab-inspect"
+                )
             management_cidr = as_non_empty_string(
                 automation.get("management_cidr"),
                 "access.automation.management_cidr",
@@ -290,42 +298,47 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 raise ValueError(
                     "access.automation.management_gateway must be inside management_cidr"
                 )
-            management_dhcp_range = as_non_empty_string(
-                automation.get("management_dhcp_range"),
-                "access.automation.management_dhcp_range",
-            )
-            try:
-                dhcp_start_raw, dhcp_end_raw = management_dhcp_range.split("-", 1)
-                dhcp_start = ipaddress.ip_address(dhcp_start_raw.strip())
-                dhcp_end = ipaddress.ip_address(dhcp_end_raw.strip())
-            except ValueError as exc:
-                raise ValueError(
-                    "access.automation.management_dhcp_range must be START-END"
-                ) from exc
-            reserved_addresses = {
-                management_network.network_address,
-                management_network.broadcast_address,
-            }
-            if (
-                dhcp_start.version != 4
-                or dhcp_end.version != 4
-                or dhcp_start not in management_network
-                or dhcp_end not in management_network
-                or int(dhcp_start) > int(dhcp_end)
-                or dhcp_start in reserved_addresses
-                or dhcp_end in reserved_addresses
-                or int(dhcp_start) <= int(gateway_address) <= int(dhcp_end)
-            ):
-                raise ValueError(
-                    "access.automation.management_dhcp_range must contain an "
-                    "ordered, usable range inside management_cidr"
+            management_dhcp_range = ""
+            lease_file = ""
+            if discovery_mode == "dnsmasq-leases":
+                management_dhcp_range = as_non_empty_string(
+                    automation.get("management_dhcp_range"),
+                    "access.automation.management_dhcp_range",
                 )
-            lease_file = as_non_empty_string(
-                automation.get("lease_file"),
-                "access.automation.lease_file",
-            )
-            if not lease_file.startswith("/"):
-                raise ValueError("access.automation.lease_file must be an absolute path")
+                try:
+                    dhcp_start_raw, dhcp_end_raw = management_dhcp_range.split("-", 1)
+                    dhcp_start = ipaddress.ip_address(dhcp_start_raw.strip())
+                    dhcp_end = ipaddress.ip_address(dhcp_end_raw.strip())
+                except ValueError as exc:
+                    raise ValueError(
+                        "access.automation.management_dhcp_range must be START-END"
+                    ) from exc
+                reserved_addresses = {
+                    management_network.network_address,
+                    management_network.broadcast_address,
+                }
+                if (
+                    dhcp_start.version != 4
+                    or dhcp_end.version != 4
+                    or dhcp_start not in management_network
+                    or dhcp_end not in management_network
+                    or int(dhcp_start) > int(dhcp_end)
+                    or dhcp_start in reserved_addresses
+                    or dhcp_end in reserved_addresses
+                    or int(dhcp_start) <= int(gateway_address) <= int(dhcp_end)
+                ):
+                    raise ValueError(
+                        "access.automation.management_dhcp_range must contain an "
+                        "ordered, usable range inside management_cidr"
+                    )
+                lease_file = as_non_empty_string(
+                    automation.get("lease_file"),
+                    "access.automation.lease_file",
+                )
+                if not lease_file.startswith("/"):
+                    raise ValueError(
+                        "access.automation.lease_file must be an absolute path"
+                    )
             local_socks_port = int(automation.get("local_socks_port") or 0)
             if local_socks_port and not 1 <= local_socks_port <= 65535:
                 raise ValueError(
@@ -338,8 +351,9 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 ),
                 "management_cidr": str(management_network),
                 "management_gateway": str(gateway_address),
-                "management_dhcp_range": f"{dhcp_start}-{dhcp_end}",
+                "management_dhcp_range": management_dhcp_range,
                 "lease_file": lease_file,
+                "discovery_mode": discovery_mode,
                 "default_user": str(
                     automation.get("default_user") or "admin"
                 ).strip()

--- a/hyops/blueprint/schema.py
+++ b/hyops/blueprint/schema.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import ipaddress
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Any
+
 import yaml
 
 from hyops.runtime.refs import normalize_module_ref
@@ -204,6 +205,12 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
             "native_console_mode": str(
                 raw_access.get("native_console_mode") or ""
             ).strip(),
+            "native_console_username": str(
+                raw_access.get("native_console_username") or ""
+            ).strip(),
+            "native_console_password_env": str(
+                raw_access.get("native_console_password_env") or ""
+            ).strip(),
             "guest_network_label": str(
                 raw_access.get("guest_network_label") or ""
             ).strip(),
@@ -233,10 +240,19 @@ def validate_blueprint(spec: dict[str, Any], path: Path) -> dict[str, Any]:
                 raise ValueError(
                     "access.ssh_key_file is required for SSH-forward access"
                 )
-        if access["native_console_mode"] not in {"", "eve-ng-qemu"}:
+        if access["native_console_mode"] not in {"", "eve-ng-qemu", "gns3-api"}:
             raise ValueError(
-                "access.native_console_mode must be eve-ng-qemu when set"
+                "access.native_console_mode must be eve-ng-qemu or gns3-api when set"
             )
+        if access["native_console_mode"] == "gns3-api":
+            if not access["native_console_username"]:
+                raise ValueError(
+                    "access.native_console_username is required for gns3-api consoles"
+                )
+            if not access["native_console_password_env"]:
+                raise ValueError(
+                    "access.native_console_password_env is required for gns3-api consoles"
+                )
         guest_fields = [
             access["guest_network_label"],
             access["guest_gateway"],

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -14,13 +14,16 @@ from unittest.mock import Mock, patch
 from hyops.blueprint.command import (
     _access_known_hosts_file,
     _combine_maintenance,
+    _discover_gns3_consoles,
     _extract_access_host,
+    _gns3_console_refresher,
     _native_console_refresher,
     _native_console_status,
     _offer_access_close_destroy,
     _parse_eve_qemu_console_ports,
     _print_native_console_client_guidance,
     _require_local_ports_available,
+    _runtime_access_secret,
     _ssh_access_error,
     _ssh_access_trust_options,
     _wait_for_local_port,
@@ -163,7 +166,7 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
             patch("hyops.blueprint.command.is_windows_wsl", return_value=True),
             patch("hyops.blueprint.command.sys.stdout", stdout),
         ):
-            _print_native_console_client_guidance()
+            _print_native_console_client_guidance("eve-ng-qemu")
 
         message = stdout.getvalue()
         self.assertIn("EVE-NG Windows Client Pack", message)
@@ -175,9 +178,85 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
             patch("hyops.blueprint.command.is_windows_wsl", return_value=False),
             patch("hyops.blueprint.command.sys.stdout", stdout),
         ):
-            _print_native_console_client_guidance()
+            _print_native_console_client_guidance("eve-ng-qemu")
 
         self.assertEqual(stdout.getvalue(), "")
+
+    def test_gns3_console_discovery_uses_controller_local_nodes(self) -> None:
+        projects = [{"project_id": "project one"}]
+        nodes = [
+            {
+                "name": "router-1",
+                "console": 5000,
+                "console_host": "127.0.0.1",
+                "console_type": "telnet",
+            },
+            {
+                "name": "desktop-1",
+                "console": 5901,
+                "console_host": "0.0.0.0",
+                "console_type": "vnc",
+            },
+            {
+                "name": "remote-node",
+                "console": 5002,
+                "console_host": "192.0.2.10",
+                "console_type": "telnet",
+            },
+        ]
+        with patch(
+            "hyops.blueprint.command._gns3_api_json",
+            side_effect=[projects, nodes],
+        ) as request:
+            consoles = _discover_gns3_consoles(3080, "gns3", "secret")
+
+        self.assertEqual(
+            consoles,
+            [(5000, "telnet", "router-1"), (5901, "vnc", "desktop-1")],
+        )
+        self.assertIn("project%20one", request.call_args_list[1].args[0])
+
+    def test_gns3_console_refresh_forwards_each_dynamic_port_once(self) -> None:
+        proc = Mock()
+        proc.poll.return_value = None
+        proc.wait.return_value = 0
+        with (
+            patch(
+                "hyops.blueprint.command._discover_gns3_consoles",
+                return_value=[(5000, "telnet", "router-1")],
+            ),
+            patch("hyops.blueprint.command._require_local_ports_available"),
+            patch("hyops.blueprint.command._wait_for_local_port"),
+            patch("hyops.blueprint.command.subprocess.Popen", return_value=proc) as popen,
+        ):
+            refresh, stop = _gns3_console_refresher(
+                ssh_base=["ssh", "-o", "BatchMode=yes"],
+                ssh_target="opsadmin@127.0.0.1",
+                local_api_port=3080,
+                username="gns3",
+                password="secret",
+            )
+            refresh()
+            refresh()
+            stop()
+
+        popen.assert_called_once()
+        self.assertIn(
+            "127.0.0.1:5000:127.0.0.1:5000",
+            popen.call_args.args[0],
+        )
+        proc.terminate.assert_called_once()
+
+    def test_runtime_console_secret_uses_environment_first(self) -> None:
+        paths = SimpleNamespace(vault_dir=Path("/unused"))
+        with (
+            patch.dict("hyops.blueprint.command.os.environ", {"GNS3_PASSWORD": "value"}),
+            patch("hyops.blueprint.command.read_env") as read_env,
+        ):
+            value = _runtime_access_secret(paths, "lab", "GNS3_PASSWORD")
+
+        self.assertEqual(value, "value")
+        read_env.assert_not_called()
 
     def test_rejects_local_console_port_conflict(self) -> None:
         listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -9,11 +9,13 @@ import unittest
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from hyops.blueprint.command import (
     _access_known_hosts_file,
+    _combine_maintenance,
     _extract_access_host,
+    _native_console_refresher,
     _native_console_status,
     _offer_access_close_destroy,
     _parse_eve_qemu_console_ports,
@@ -104,11 +106,56 @@ LISTEN 0 1 [::]:32769 [::]:* users:(("qemu-system-x86",pid=1,fd=21))
 """
         self.assertEqual(_parse_eve_qemu_console_ports(output), [32769, 32770])
 
-    def test_empty_console_set_keeps_web_access_available(self) -> None:
+    def test_empty_console_set_waits_for_active_nodes(self) -> None:
         self.assertEqual(
             _native_console_status([]),
-            "native consoles: no active QEMU nodes; web access remains available",
+            "native consoles: waiting for active QEMU nodes",
         )
+
+    def test_native_console_refresh_adds_new_qemu_ports(self) -> None:
+        proc = Mock()
+        proc.poll.return_value = None
+        proc.wait.return_value = 0
+        with (
+            patch(
+                "hyops.blueprint.command._discover_eve_qemu_console_ports",
+                return_value=[32769, 32770],
+            ),
+            patch("hyops.blueprint.command._require_local_ports_available"),
+            patch("hyops.blueprint.command._wait_for_local_port"),
+            patch("hyops.blueprint.command.subprocess.Popen", return_value=proc) as popen,
+        ):
+            refresh, stop = _native_console_refresher(
+                ssh_base=["ssh", "-o", "BatchMode=yes"],
+                ssh_target="opsadmin@127.0.0.1",
+                known_hosts_file=Path("/tmp/access.known_hosts"),
+                forwarded_ports=[32769],
+            )
+            refresh()
+            refresh()
+            stop()
+
+        popen.assert_called_once()
+        argv = popen.call_args.args[0]
+        self.assertIn("127.0.0.1:32770:127.0.0.1:32770", argv)
+        self.assertEqual(argv[-1], "opsadmin@127.0.0.1")
+        proc.terminate.assert_called_once()
+
+    def test_combined_maintenance_runs_every_callback(self) -> None:
+        calls: list[str] = []
+
+        def first() -> None:
+            calls.append("first")
+            raise RuntimeError("refresh failed")
+
+        def second() -> None:
+            calls.append("second")
+
+        combined = _combine_maintenance(first, None, second)
+        self.assertIsNotNone(combined)
+        with self.assertRaisesRegex(RuntimeError, "refresh failed"):
+            combined()
+        self.assertEqual(calls, ["first", "second"])
 
     def test_windows_native_console_guidance_names_host_requirement(self) -> None:
         stdout = io.StringIO()

--- a/hyops/blueprint/tests/test_automation_access.py
+++ b/hyops/blueprint/tests/test_automation_access.py
@@ -3,23 +3,29 @@
 from __future__ import annotations
 
 import io
+import json
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import yaml
 
 from hyops.blueprint.automation_access import (
     build_tunnel_ssh_argv,
     linux_tunnel_plan,
+    parse_containerlab_inspect,
     parse_dnsmasq_leases,
     prepare_automation_session,
 )
+from hyops.blueprint.command import (
+    _device_process_environment,
+    _read_automation_leases,
+    run_device,
+)
 from hyops.blueprint.schema import load_blueprint, validate_blueprint
-from hyops.blueprint.command import _device_process_environment, run_device
 
 
 class AutomationAccessTests(unittest.TestCase):
@@ -50,6 +56,57 @@ class AutomationAccessTests(unittest.TestCase):
         self.assertEqual([item["name"] for item in leases], ["r1", "device-52"])
         self.assertEqual(leases[0]["host"], "172.29.128.51")
         self.assertEqual(leases[0]["source"], "dhcp-lease")
+
+    def test_containerlab_inspect_targets_are_scoped(self) -> None:
+        discovered = parse_containerlab_inspect(
+            json.dumps(
+                {
+                    "demo": [
+                        {
+                            "name": "clab-demo-r1",
+                            "kind": "nokia_srlinux",
+                            "ipv4_address": "172.20.20.2/24",
+                        },
+                        {
+                            "name": "outside",
+                            "kind": "linux",
+                            "ipv4_address": "192.0.2.2/24",
+                        },
+                    ]
+                }
+            ),
+            "172.20.20.0/24",
+            default_user="admin",
+        )
+
+        self.assertEqual(len(discovered), 1)
+        self.assertEqual(discovered[0]["name"], "clab-demo-r1")
+        self.assertEqual(discovered[0]["host"], "172.20.20.2")
+        self.assertEqual(discovered[0]["source"], "containerlab-inspect")
+        self.assertEqual(discovered[0]["platform"], "nokia_srlinux")
+
+    def test_containerlab_discovery_uses_native_inspect(self) -> None:
+        result = SimpleNamespace(returncode=0, stdout='{"demo": []}')
+        automation = {
+            "discovery_mode": "containerlab-inspect",
+            "management_cidr": "172.20.20.0/24",
+        }
+
+        with patch(
+            "hyops.blueprint.command.subprocess.run",
+            return_value=result,
+        ) as run:
+            output = _read_automation_leases(
+                ["ssh", "-F", "/tmp/ssh_config"],
+                "gateway",
+                automation,
+            )
+
+        self.assertEqual(output, result.stdout)
+        self.assertEqual(
+            run.call_args.args[0][-1],
+            "sudo -n containerlab inspect --all -f json",
+        )
 
     def test_session_writes_ssh_vscode_and_inventory_material(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -277,6 +334,148 @@ class AutomationAccessTests(unittest.TestCase):
         command = run.call_args.args[0]
         self.assertIn("-l", command)
         self.assertIn("admin", command)
+
+    def test_device_web_forwards_target_through_gateway(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ssh_config = root / "ssh_config"
+            ssh_config.write_text("Host gateway\n", encoding="utf-8")
+            target = {
+                "name": "f5-ltm",
+                "host": "172.29.128.51",
+                "user": "admin",
+                "port": 22,
+                "identity_file": "",
+                "source": "static",
+                "platform": "f5",
+            }
+            material = {
+                "ssh_config": ssh_config,
+                "gateway_alias": "hyops-demo-lab-gateway",
+            }
+            ns = SimpleNamespace(
+                device_cmd="web",
+                target="f5-ltm",
+                scheme="https",
+                port=8443,
+                path="/tmui/",
+                local_port=10443,
+                no_browser=False,
+            )
+            proc = MagicMock()
+            proc.wait.side_effect = KeyboardInterrupt
+            proc.poll.return_value = None
+            output = io.StringIO()
+
+            with patch(
+                "hyops.blueprint.command._device_context",
+                return_value=(self.automation, material, [target]),
+            ), patch(
+                "hyops.blueprint.command.shutil.which",
+                return_value="/usr/bin/ssh",
+            ), patch(
+                "hyops.blueprint.command._available_local_port",
+                return_value=10443,
+            ), patch(
+                "hyops.blueprint.command._require_local_ports_available"
+            ), patch(
+                "hyops.blueprint.command._wait_for_local_port"
+            ), patch(
+                "hyops.blueprint.command.subprocess.Popen",
+                return_value=proc,
+            ) as popen, patch(
+                "hyops.blueprint.command.open_operator_url"
+            ) as open_url, patch(
+                "hyops.blueprint.command._stop_process"
+            ) as stop, redirect_stdout(output):
+                rc = run_device(ns)
+
+        self.assertEqual(rc, 0)
+        command = popen.call_args.args[0]
+        self.assertIn("127.0.0.1:10443:172.29.128.51:8443", command)
+        self.assertEqual(command[-1], "hyops-demo-lab-gateway")
+        open_url.assert_called_once_with("https://127.0.0.1:10443/tmui/")
+        stop.assert_called_once_with(proc)
+        self.assertIn("device web access: f5-ltm", output.getvalue())
+        self.assertIn("device web access closed", output.getvalue())
+
+    def test_device_web_accepts_management_ip_and_does_not_open_browser(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ssh_config = Path(tmp) / "ssh_config"
+            ssh_config.write_text("Host gateway\n", encoding="utf-8")
+            material = {
+                "ssh_config": ssh_config,
+                "gateway_alias": "hyops-demo-lab-gateway",
+            }
+            ns = SimpleNamespace(
+                device_cmd="web",
+                target="172.29.128.80",
+                scheme="http",
+                port=0,
+                path="/",
+                local_port=0,
+                no_browser=True,
+            )
+            proc = MagicMock()
+            proc.wait.side_effect = KeyboardInterrupt
+            proc.poll.return_value = None
+
+            with patch(
+                "hyops.blueprint.command._device_context",
+                return_value=(self.automation, material, []),
+            ), patch(
+                "hyops.blueprint.command.shutil.which",
+                return_value="/usr/bin/ssh",
+            ), patch(
+                "hyops.blueprint.command._available_local_port",
+                return_value=18080,
+            ), patch(
+                "hyops.blueprint.command._require_local_ports_available"
+            ), patch(
+                "hyops.blueprint.command._wait_for_local_port"
+            ), patch(
+                "hyops.blueprint.command.subprocess.Popen",
+                return_value=proc,
+            ) as popen, patch(
+                "hyops.blueprint.command.open_operator_url"
+            ) as open_url, patch(
+                "hyops.blueprint.command._stop_process"
+            ):
+                rc = run_device(ns)
+
+        self.assertEqual(rc, 0)
+        self.assertIn("127.0.0.1:18080:172.29.128.80:80", popen.call_args.args[0])
+        open_url.assert_not_called()
+
+    def test_device_web_rejects_invalid_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ssh_config = Path(tmp) / "ssh_config"
+            ssh_config.write_text("Host gateway\n", encoding="utf-8")
+            ns = SimpleNamespace(
+                device_cmd="web",
+                target="172.29.128.80",
+                scheme="https",
+                port=443,
+                path="admin",
+                local_port=0,
+                no_browser=True,
+            )
+            output = io.StringIO()
+            with patch(
+                "hyops.blueprint.command._device_context",
+                return_value=(
+                    self.automation,
+                    {"ssh_config": ssh_config, "gateway_alias": "gateway"},
+                    [],
+                ),
+            ), patch(
+                "hyops.blueprint.command.shutil.which",
+                return_value="/usr/bin/ssh",
+            ), redirect_stdout(output):
+                rc = run_device(ns)
+
+        self.assertNotEqual(rc, 0)
+        self.assertIn("--path must begin with one /", output.getvalue())
 
     def test_route_command_uses_existing_ssh_boundary(self) -> None:
         plan = linux_tunnel_plan("demo-lab:gcp/eve-ng@v1")

--- a/hyops/blueprint/tests/test_automation_access.py
+++ b/hyops/blueprint/tests/test_automation_access.py
@@ -16,12 +16,14 @@ import yaml
 from hyops.blueprint.automation_access import (
     build_tunnel_ssh_argv,
     linux_tunnel_plan,
+    load_automation_targets,
     parse_containerlab_inspect,
     parse_dnsmasq_leases,
     prepare_automation_session,
 )
 from hyops.blueprint.command import (
     _device_process_environment,
+    _device_web_requests,
     _read_automation_leases,
     run_device,
 )
@@ -175,6 +177,44 @@ class AutomationAccessTests(unittest.TestCase):
                     target_file_override=str(targets),
                 )
 
+    def test_target_web_settings_are_validated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            targets = Path(tmp) / "targets.yml"
+            targets.write_text(
+                "version: 1\n"
+                "targets:\n"
+                "  - name: f5-ltm\n"
+                "    host: 172.29.128.51\n"
+                "    user: admin\n"
+                "    web:\n"
+                "      scheme: http\n"
+                "      path: /ui/\n",
+                encoding="utf-8",
+            )
+
+            loaded = load_automation_targets(targets, "172.29.128.0/24")
+
+        self.assertEqual(
+            loaded[0]["web"],
+            {"scheme": "http", "port": 80, "path": "/ui/"},
+        )
+
+    def test_target_web_settings_reject_invalid_scheme(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            targets = Path(tmp) / "targets.yml"
+            targets.write_text(
+                "version: 1\n"
+                "targets:\n"
+                "  - name: f5-ltm\n"
+                "    host: 172.29.128.51\n"
+                "    user: admin\n"
+                "    web: {scheme: ftp}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "scheme must be http or https"):
+                load_automation_targets(targets, "172.29.128.0/24")
+
     def test_dhcp_refresh_updates_address_and_preserves_operator_settings(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -257,6 +297,33 @@ class AutomationAccessTests(unittest.TestCase):
         self.assertEqual(
             output.getvalue().strip(),
             "r1  172.29.128.51  user=admin (default)  port=22  ios  DHCP",
+        )
+
+    def test_device_list_shows_declared_web_service(self) -> None:
+        targets = [
+            {
+                "name": "f5-ltm",
+                "host": "172.29.128.52",
+                "user": "admin",
+                "port": 22,
+                "source": "static",
+                "platform": "f5",
+                "web": {"scheme": "https", "port": 443, "path": "/"},
+            }
+        ]
+        ns = SimpleNamespace(device_cmd="list", json=False)
+        output = io.StringIO()
+
+        with patch(
+            "hyops.blueprint.command._device_context",
+            return_value=(self.automation, {}, targets),
+        ), redirect_stdout(output):
+            rc = run_device(ns)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            output.getvalue().strip(),
+            "f5-ltm  172.29.128.52  user=admin  port=22  f5  static  web=https:443",
         )
 
     def test_device_edit_opens_and_validates_target_file(self) -> None:
@@ -363,8 +430,7 @@ class AutomationAccessTests(unittest.TestCase):
                 no_browser=False,
             )
             proc = MagicMock()
-            proc.wait.side_effect = KeyboardInterrupt
-            proc.poll.return_value = None
+            proc.poll.side_effect = KeyboardInterrupt
             output = io.StringIO()
 
             with patch(
@@ -417,8 +483,7 @@ class AutomationAccessTests(unittest.TestCase):
                 no_browser=True,
             )
             proc = MagicMock()
-            proc.wait.side_effect = KeyboardInterrupt
-            proc.poll.return_value = None
+            proc.poll.side_effect = KeyboardInterrupt
 
             with patch(
                 "hyops.blueprint.command._device_context",
@@ -446,6 +511,223 @@ class AutomationAccessTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("127.0.0.1:18080:172.29.128.80:80", popen.call_args.args[0])
         open_url.assert_not_called()
+
+    def test_device_web_all_uses_declared_services_in_one_session(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ssh_config = Path(tmp) / "ssh_config"
+            ssh_config.write_text("Host gateway\n", encoding="utf-8")
+            targets = [
+                {
+                    "name": "f5-ltm",
+                    "host": "172.29.128.51",
+                    "user": "admin",
+                    "port": 22,
+                    "identity_file": "",
+                    "source": "static",
+                    "platform": "f5",
+                    "web": {"scheme": "https", "port": 443, "path": "/tmui/"},
+                },
+                {
+                    "name": "grafana",
+                    "host": "172.29.128.52",
+                    "user": "admin",
+                    "port": 22,
+                    "identity_file": "",
+                    "source": "static",
+                    "platform": "linux",
+                    "web": {"scheme": "http", "port": 3000, "path": "/"},
+                },
+                {
+                    "name": "router",
+                    "host": "172.29.128.53",
+                    "user": "admin",
+                    "port": 22,
+                    "identity_file": "",
+                    "source": "static",
+                    "platform": "ios",
+                },
+            ]
+            material = {
+                "ssh_config": ssh_config,
+                "gateway_alias": "hyops-demo-lab-gateway",
+            }
+            ns = SimpleNamespace(
+                device_cmd="web",
+                target=[],
+                all_targets=True,
+                scheme=None,
+                port=None,
+                path=None,
+                local_port=0,
+                no_browser=False,
+                open_all=False,
+            )
+            first = MagicMock()
+            second = MagicMock()
+            first.poll.side_effect = KeyboardInterrupt
+            output = io.StringIO()
+
+            with patch(
+                "hyops.blueprint.command._device_context",
+                return_value=(self.automation, material, targets),
+            ), patch(
+                "hyops.blueprint.command.shutil.which",
+                return_value="/usr/bin/ssh",
+            ), patch(
+                "hyops.blueprint.command._available_local_port",
+                side_effect=[10443, 13000],
+            ), patch(
+                "hyops.blueprint.command._require_local_ports_available"
+            ), patch(
+                "hyops.blueprint.command._wait_for_local_port"
+            ), patch(
+                "hyops.blueprint.command.subprocess.Popen",
+                side_effect=[first, second],
+            ) as popen, patch(
+                "hyops.blueprint.command.open_operator_url"
+            ) as open_url, patch(
+                "hyops.blueprint.command._stop_process"
+            ) as stop, redirect_stdout(output):
+                rc = run_device(ns)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(popen.call_count, 2)
+        self.assertIn(
+            "127.0.0.1:10443:172.29.128.51:443",
+            popen.call_args_list[0].args[0],
+        )
+        self.assertIn(
+            "127.0.0.1:13000:172.29.128.52:3000",
+            popen.call_args_list[1].args[0],
+        )
+        self.assertIn("device web access: 2 targets", output.getvalue())
+        self.assertIn("use --open-all", output.getvalue())
+        self.assertNotIn("router", output.getvalue())
+        open_url.assert_not_called()
+        self.assertEqual(stop.call_count, 2)
+
+    def test_device_web_open_all_opens_each_declared_service(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ssh_config = Path(tmp) / "ssh_config"
+            ssh_config.write_text("Host gateway\n", encoding="utf-8")
+            targets = [
+                {
+                    "name": "f5-ltm",
+                    "host": "172.29.128.51",
+                    "user": "admin",
+                    "port": 22,
+                    "web": {"scheme": "https", "port": 443, "path": "/"},
+                },
+                {
+                    "name": "grafana",
+                    "host": "172.29.128.52",
+                    "user": "admin",
+                    "port": 22,
+                    "web": {"scheme": "http", "port": 3000, "path": "/"},
+                },
+            ]
+            material = {
+                "ssh_config": ssh_config,
+                "gateway_alias": "hyops-demo-lab-gateway",
+            }
+            ns = SimpleNamespace(
+                device_cmd="web",
+                target=[],
+                all_targets=True,
+                scheme=None,
+                port=None,
+                path=None,
+                local_port=0,
+                no_browser=False,
+                open_all=True,
+            )
+            first = MagicMock()
+            second = MagicMock()
+            first.poll.side_effect = KeyboardInterrupt
+
+            with patch(
+                "hyops.blueprint.command._device_context",
+                return_value=(self.automation, material, targets),
+            ), patch(
+                "hyops.blueprint.command.shutil.which",
+                return_value="/usr/bin/ssh",
+            ), patch(
+                "hyops.blueprint.command._available_local_port",
+                side_effect=[10443, 13000],
+            ), patch(
+                "hyops.blueprint.command._require_local_ports_available"
+            ), patch(
+                "hyops.blueprint.command._wait_for_local_port"
+            ), patch(
+                "hyops.blueprint.command.subprocess.Popen",
+                side_effect=[first, second],
+            ), patch(
+                "hyops.blueprint.command.open_operator_url"
+            ) as open_url, patch(
+                "hyops.blueprint.command._stop_process"
+            ), redirect_stdout(io.StringIO()):
+                rc = run_device(ns)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            [call.args[0] for call in open_url.call_args_list],
+            ["https://127.0.0.1:10443/", "http://127.0.0.1:13000/"],
+        )
+
+    def test_device_web_all_requires_declared_services(self) -> None:
+        ns = SimpleNamespace(
+            target=[],
+            all_targets=True,
+            scheme=None,
+            port=None,
+            path=None,
+        )
+        targets = [
+            {
+                "name": "r1",
+                "host": "172.29.128.51",
+                "user": "admin",
+                "port": 22,
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "no targets declare web access"):
+            _device_web_requests(ns, self.automation, targets)
+
+    def test_device_web_rejects_fixed_local_port_for_multiple_targets(self) -> None:
+        ns = SimpleNamespace(
+            device_cmd="web",
+            target=["172.29.128.51", "172.29.128.52"],
+            all_targets=False,
+            scheme="http",
+            port=None,
+            path=None,
+            local_port=8080,
+            no_browser=True,
+            open_all=False,
+        )
+        output = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmp:
+            ssh_config = Path(tmp) / "ssh_config"
+            ssh_config.write_text("Host gateway\n", encoding="utf-8")
+            material = {
+                "ssh_config": ssh_config,
+                "gateway_alias": "gateway",
+            }
+            with patch(
+                "hyops.blueprint.command._device_context",
+                return_value=(self.automation, material, []),
+            ), patch(
+                "hyops.blueprint.command.shutil.which",
+                return_value="/usr/bin/ssh",
+            ), redirect_stdout(output):
+                rc = run_device(ns)
+
+        self.assertNotEqual(rc, 0)
+        self.assertIn(
+            "--local-port is available only with one device web target",
+            output.getvalue(),
+        )
 
     def test_device_web_rejects_invalid_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/hyops/blueprint/tests/test_gcp_containerlab.py
+++ b/hyops/blueprint/tests/test_gcp_containerlab.py
@@ -102,3 +102,7 @@ class GCPContainerlabBlueprintTest(TestCase):
         self.assertEqual(access["remote_port"], 22)
         self.assertFalse(access["open_browser"])
         self.assertTrue(access["offer_destroy_on_close"])
+        automation = access["automation"]
+        self.assertEqual(automation["discovery_mode"], "containerlab-inspect")
+        self.assertEqual(automation["management_cidr"], "172.20.20.0/24")
+        self.assertEqual(automation["management_gateway"], "172.20.20.1")

--- a/hyops/blueprint/tests/test_gcp_gns3.py
+++ b/hyops/blueprint/tests/test_gcp_gns3.py
@@ -39,6 +39,12 @@ class GCPGNS3BlueprintTest(TestCase):
         self.assertEqual(access["type"], "gcp-iap-ssh-forward")
         self.assertEqual(access["remote_port"], 3080)
         self.assertEqual(access["local_port"], 3080)
+        self.assertEqual(access["native_console_mode"], "gns3-api")
+        self.assertEqual(access["native_console_username"], "gns3")
+        self.assertEqual(
+            access["native_console_password_env"],
+            "GNS3_SERVER_PASSWORD",
+        )
         self.assertTrue(access["offer_destroy_on_close"])
         self.assertFalse(access["open_browser"])
         self.assertEqual(

--- a/hyops/blueprint/tests/test_gcp_gns3.py
+++ b/hyops/blueprint/tests/test_gcp_gns3.py
@@ -39,6 +39,7 @@ class GCPGNS3BlueprintTest(TestCase):
         self.assertEqual(access["type"], "gcp-iap-ssh-forward")
         self.assertEqual(access["remote_port"], 3080)
         self.assertEqual(access["local_port"], 3080)
+        self.assertTrue(access["offer_destroy_on_close"])
         self.assertFalse(access["open_browser"])
         self.assertEqual(
             access["automation"]["management_cidr"],

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -54,6 +54,7 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(access["state_ref"], "platform/onprem/platform-vm#gns3_vm")
         self.assertEqual(access["remote_port"], 3080)
         self.assertEqual(access["local_port"], 3080)
+        self.assertTrue(access["offer_destroy_on_close"])
         self.assertEqual(
             access["automation"]["management_cidr"],
             "172.29.130.0/24",

--- a/hyops/blueprint/tests/test_onprem_gns3.py
+++ b/hyops/blueprint/tests/test_onprem_gns3.py
@@ -55,6 +55,12 @@ class OnPremGNS3BlueprintTest(TestCase):
         self.assertEqual(access["remote_port"], 3080)
         self.assertEqual(access["local_port"], 3080)
         self.assertTrue(access["offer_destroy_on_close"])
+        self.assertEqual(access["native_console_mode"], "gns3-api")
+        self.assertEqual(access["native_console_username"], "gns3")
+        self.assertEqual(
+            access["native_console_password_env"],
+            "GNS3_SERVER_PASSWORD",
+        )
         self.assertEqual(
             access["automation"]["management_cidr"],
             "172.29.130.0/24",

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -103,6 +103,13 @@ class CliRoutingTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("edit", result.stdout)
 
+    def test_device_web_help_includes_multi_target_controls(self) -> None:
+        result = run_cli("blueprint", "device", "web", "--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--all", result.stdout)
+        self.assertIn("--open-all", result.stdout)
+        self.assertIn("[target ...]", result.stdout)
+
     def test_mutating_preflight_bypass_help_requires_reason(self) -> None:
         for args in (
             ("apply", "--help"),


### PR DESCRIPTION
## Summary

- discover and forward EVE-NG QEMU console ports that appear after access starts
- preserve loopback-only native console access across macOS, Windows/WSL and Linux
- offer the controlled keep, archive or destroy flow when GNS3 access closes

## Validation

- `bash tools/ci/check-python.sh`
- `bash tools/ci/check-ruff.sh`
- `python3 -m unittest discover -s hyops/blueprint/tests -p "test_*.py"`
- `python3 -m unittest hyops.tests.test_cli`
- `python3 -m unittest hyops.setup.tests.test_command`
- `git diff --check`