### PR TITLE
fix: render deferred lifecycle steps as pending

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Fixed
 
+- Rendered parent-managed destroy steps as pending rather than failed while the parent step is still running.
 - Allowed disposable GNS3 guest operations to be cleared with their parent VM when guest SSH is unavailable during teardown.
 - Preserved concise module failure details after a blueprint progress step fails.
 - Surfaced EVE-NG IOL licence mismatches with the target hostname and Linux host ID before any image changes.

--- a/hyops/runtime/progress.py
+++ b/hyops/runtime/progress.py
@@ -154,6 +154,7 @@ class ProgressDisplay:
         symbol = {
             "ok": "✓",
             "skipped": "○",
+            "deferred": "○",
             "retained": "○",
             "cancelled": "!",
             "failed-optional": "!",
@@ -161,6 +162,7 @@ class ProgressDisplay:
         tone = {
             "ok": "success",
             "skipped": "warning",
+            "deferred": "warning",
             "retained": "warning",
             "cancelled": "warning",
             "failed-optional": "warning",

--- a/hyops/runtime/tests/test_progress.py
+++ b/hyops/runtime/tests/test_progress.py
@@ -75,6 +75,25 @@ class ProgressDisplayTests(unittest.TestCase):
             "| Network  overall 0%\r\x1b[2K✓ Network  overall 20%\n",
         )
 
+    def test_tty_renders_deferred_status_as_pending(self) -> None:
+        output = _Stream(True)
+        display = ProgressDisplay(enabled=True, show_elapsed=False)
+        with redirect_stdout(output), patch.dict(
+            os.environ, {"NO_COLOR": "1"}
+        ), patch.object(display, "_animate"):
+            display.finish(
+                "healthcheck",
+                "healthcheck",
+                "deferred",
+                plain="ignored",
+                detail="awaiting vm, overall 20%",
+            )
+
+        self.assertEqual(
+            output.getvalue(),
+            "\r\x1b[2K○ healthcheck  awaiting vm, overall 20%\n",
+        )
+
     def test_tty_label_can_be_updated(self) -> None:
         output = _Stream(True)
         display = ProgressDisplay(enabled=True)


### PR DESCRIPTION
## Summary

Render parent-managed destroy steps as pending while their parent step runs. Deferred GNS3 guest operations no longer display a failure marker before the VM is destroyed.

## Validation

- `python3 -m unittest hyops.runtime.tests.test_progress hyops.blueprint.tests.test_destroy hyops.blueprint.tests.test_gcp_gns3 hyops.blueprint.tests.test_onprem_gns3`
- `python3 -m unittest discover -s hyops -p "test_*.py"`
- `git diff --check`

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.