### PR TITLE
docs: clarify inspection-first path in Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See the full [reference scenario library](https://docs.hybridops.tech/reference-
 
 For installation, workstation setup, target initialisation, and first-run guidance, see the [Quickstart](https://docs.hybridops.tech/guides/getting-started/quickstart/).
 
-Inspect a shipped blueprint locally:
+You can inspect blueprints locally without cloud credentials or a live environment. These commands validate the manifest and display the execution plan:
 
 ```bash
 hyops blueprint validate --ref onprem/authoritative-foundation@v1


### PR DESCRIPTION
Explicitly states that validate/plan commands do not require credentials, as noted in issue feedback.

## Summary

<!-- What problem does this change solve? -->

## Validation

<!-- List the checks or commands you ran. -->

<!-- If this needed candidate or environment acceptance, record the workflow run, artifact/provenance, environment, result, and cleanup. -->

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.
