### PR TITLE
feat(eveng): preserve native device configurations

### DIFF
--- a/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
@@ -85,10 +85,10 @@ Live management addresses are session state. Durable role, platform, grouping an
 
 The blueprint configures `platform/linux/eve-ng-lab-archive` before destructive lifecycle actions.
 
-The primary archive retains EVE-NG lab definitions from `/opt/unetlab/labs`. The node-state companion path captures stopped QEMU overlays when node-state preservation is selected. The lifecycle stops running QEMU nodes before capture, validates the overlays and records a separate SHA-256 for the companion archive.
+The primary archive retains EVE-NG lab definitions from `/opt/unetlab/labs` after EVE-NG refreshes saved device configurations in those definitions. The node-state companion path captures stopped QEMU overlays when node-state preservation is selected. The lifecycle stops running QEMU nodes before overlay capture, validates the overlays and records a separate SHA-256 for the companion archive.
 
 ```text
-EVE-NG lab definitions --------------------+
+lab definitions and saved configurations --+
                                             |
 stopped QEMU overlays, when selected -------+--> controller-side retained set
                                             |        |

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -88,10 +88,11 @@ The blueprint declares `platform/linux/eve-ng-lab-archive` as its archive-before
 
 The retained set can contain:
 
-- learner-created lab definitions under `/opt/unetlab/labs`; and
+- learner-created lab definitions under `/opt/unetlab/labs`;
+- device configurations saved through EVE-NG's native export; and
 - stopped QEMU overlay state when node-state preservation is selected by the blueprint.
 
-Before overlay capture, running QEMU nodes are stopped. Each retained archive is checksummed on the controller. Base images remain separately managed, so restored QEMU overlays reconnect to matching installed base images rather than copying those bases into the checkpoint.
+Save intended device changes to startup configuration before teardown. Before overlay capture, running QEMU nodes are stopped. Each retained archive is checksummed on the controller. Base images remain separately managed, so restored QEMU overlays reconnect to matching installed base images rather than copying those bases into the checkpoint.
 
 For an explicit protected destroy:
 

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -51,7 +51,11 @@ archive_before_destroy:
     target_port: 22
     ssh_private_key_file: "~/.ssh/id_ed25519"
     ssh_access_mode: "gcp-iap"
+    load_vault_env: true
+    required_env:
+      - "EVENG_ADMIN_PASSWORD"
     eveng_lab_archive_action: "export"
+    eveng_lab_archive_capture_device_configs: true
     eveng_lab_archive_include_node_state: true
     eveng_lab_archive_stop_running_nodes: true
 

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -55,6 +55,8 @@ archive_before_destroy:
     required_env:
       - "EVENG_ADMIN_PASSWORD"
     eveng_lab_archive_action: "export"
+    # Refresh supported saved device configurations before archiving the lab.
+    # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
     eveng_lab_archive_include_node_state: true
     eveng_lab_archive_stop_running_nodes: true

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -97,9 +97,11 @@ static devices must use `172.29.128.1`. On Linux or WSL, optional
 conflict locally. Windows and macOS applications use the generated SSH
 configuration or local proxy.
 
-When access closes, HybridOps offers to keep the environment, export its lab
-definitions before teardown, or destroy without an export. Direct interactive
-destroy uses the same choices. Automation must pass either
+When access closes, HybridOps offers to keep the environment, preserve saved
+lab state before teardown, or destroy without preservation. Preservation
+refreshes saved device configurations in the lab definitions and includes
+stopped QEMU overlay state when present. Direct interactive destroy uses the
+same choices. Automation must pass either
 `--archive-before-destroy` or `--skip-archive` with `--yes`.
 
 After redeployment, an interactive deploy offers to restore a verified archive.

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -53,7 +53,11 @@ archive_before_destroy:
     ssh_proxy_jump_user: "root"
     become: true
     become_user: "root"
+    load_vault_env: true
+    required_env:
+      - "EVENG_ADMIN_PASSWORD"
     eveng_lab_archive_action: "export"
+    eveng_lab_archive_capture_device_configs: true
     eveng_lab_archive_include_node_state: true
     eveng_lab_archive_stop_running_nodes: true
 

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -57,6 +57,8 @@ archive_before_destroy:
     required_env:
       - "EVENG_ADMIN_PASSWORD"
     eveng_lab_archive_action: "export"
+    # Refresh supported saved device configurations before archiving the lab.
+    # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
     eveng_lab_archive_include_node_state: true
     eveng_lab_archive_stop_running_nodes: true

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -3155,6 +3155,7 @@ def _lab_archive_contract(lifecycle: dict[str, Any]) -> dict[str, Any]:
         "node_included_output": f"{prefix}_node_state_included",
         "node_path_output": f"{prefix}_node_state_archive_path",
         "node_sha256_output": f"{prefix}_node_state_sha256",
+        "device_configs_captured_output": f"{prefix}_device_configs_captured",
     }
 
 
@@ -3294,6 +3295,9 @@ def _run_lab_restore(
             or contract["restore_overwrite_default"],
         }
     )
+    capture_key = f"{prefix}_capture_device_configs"
+    if capture_key in restore_inputs:
+        restore_inputs[capture_key] = False
     if contract["node_state"]:
         restore_inputs.update(
             {
@@ -3922,8 +3926,8 @@ def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> 
 
     print("lab data:")
     print("  1. Keep the environment running")
-    print("  2. Export labs, verify the archive, then destroy")
-    print("  3. Destroy without exporting labs")
+    print("  2. Preserve saved lab state, then destroy")
+    print("  3. Destroy without preserving lab state")
     choices = {"1": "keep", "2": "archive", "3": "skip"}
     while True:
         try:
@@ -3958,7 +3962,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         "with_deps": False,
         "inputs": archive.get("inputs") or {},
     }
-    print("preparing lab archive; active nodes will be stopped and saved state verified")
+    print("preparing saved lab state; active nodes will be stopped")
     print("this may take several minutes, depending on lab size")
     progress = ProgressDisplay(
         enabled=bool(
@@ -4020,6 +4024,8 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         print("ERR: lab archive checksum verification failed; no resources were destroyed")
         return OPERATOR_ERROR
     archive_contents = [contract["contents_label"]]
+    if bool(outputs.get(contract["device_configs_captured_output"], False)):
+        archive_contents.append("saved device configurations")
     verbose = bool(os.getenv("HYOPS_VERBOSE"))
     if verbose:
         print(f"lab archive: {archive_path}")

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -3983,17 +3983,26 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         os.environ["HYOPS_PROGRESS_CHILD"] = "1"
     try:
         rc = run_step_module_command(archive_step, payload, ns, paths)
+    except KeyboardInterrupt:
+        rc = CANCELLED
     finally:
         if previous_child is None:
             os.environ.pop("HYOPS_PROGRESS_CHILD", None)
         else:
             os.environ["HYOPS_PROGRESS_CHILD"] = previous_child
+    archive_status = "cancelled" if int(rc) == CANCELLED else (
+        "ok" if rc == 0 else "failed"
+    )
     progress.finish(
         archive_step["id"],
         "Lab archive",
-        "ok" if rc == 0 else "failed",
-        plain=f"lab_archive status={'ok' if rc == 0 else 'failed'}",
+        archive_status,
+        plain=f"lab_archive status={archive_status}",
     )
+    if int(rc) == CANCELLED:
+        print("Archive interrupted. Resources were retained.")
+        print("Some lab nodes may have been stopped. Check the lab before continuing.")
+        return CANCELLED
     if rc != 0:
         print("ERR: lab export failed; no resources were destroyed")
         return int(rc)

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -548,6 +548,67 @@ class ResumableBlueprintDestroyTest(TestCase):
         command.assert_called_once()
         self.assertEqual(command.call_args.args[0]["id"], "archive_before_destroy")
 
+    def test_interrupted_archive_reports_retained_resources_and_stopped_nodes(self):
+        payload = {
+            "archive_before_destroy": {
+                "module_ref": "platform/test/archive",
+                "state_instance": "lab_archive",
+                "inputs": {},
+            }
+        }
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+        stdout = io.StringIO()
+
+        with (
+            patch(
+                "hyops.blueprint.command.run_step_module_command",
+                side_effect=KeyboardInterrupt,
+            ),
+            patch("hyops.blueprint.command.sys.stdout", stdout),
+        ):
+            rc = _run_archive_before_destroy(_namespace(), payload, paths)
+
+        self.assertEqual(rc, CANCELLED)
+        output = stdout.getvalue()
+        self.assertIn("Archive interrupted. Resources were retained.", output)
+        self.assertIn(
+            "Some lab nodes may have been stopped. Check the lab before continuing.",
+            output,
+        )
+
+    def test_cancelled_archive_stops_before_resource_destroy(self):
+        paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
+        payload = _payload()
+        payload["archive_before_destroy"] = {
+            "module_ref": "platform/test/archive",
+            "state_instance": "lab_archive",
+            "inputs": {"archive_action": "export"},
+        }
+        ns = _namespace()
+        ns.archive_before_destroy = True
+        stdout = io.StringIO()
+
+        with (
+            patch("hyops.blueprint.command._resolve_and_validate", return_value=payload),
+            patch("hyops.blueprint.command.require_runtime_selection"),
+            patch("hyops.blueprint.command.resolve_runtime_paths", return_value=paths),
+            patch("hyops.blueprint.command.ensure_layout"),
+            patch("hyops.blueprint.command.require_runtime_writable"),
+            patch("hyops.blueprint.command._enforce_runtime_blueprint_file_scope"),
+            patch("hyops.blueprint.command.resolved_step_inputs_file", return_value=None),
+            patch(
+                "hyops.blueprint.command.run_step_module_command",
+                return_value=CANCELLED,
+            ) as command,
+            patch("hyops.blueprint.command.sys.stdout", stdout),
+        ):
+            rc = run_destroy(ns)
+
+        self.assertEqual(rc, CANCELLED)
+        command.assert_called_once()
+        self.assertEqual(command.call_args.args[0]["id"], "archive_before_destroy")
+        self.assertIn("Archive interrupted. Resources were retained.", stdout.getvalue())
+
     def test_non_interactive_destroy_requires_explicit_yes(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
         ns = _namespace()

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -362,6 +362,23 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertEqual(selected, "archive")
         self.assertEqual(prompt.call_count, 3)
 
+    def test_archive_choice_describes_preservation_without_extra_mode(self):
+        ns = _namespace()
+        ns.yes = False
+        payload = {"archive_before_destroy": {"module_ref": "platform/test/archive"}}
+
+        with (
+            patch("hyops.blueprint.command.sys.stdin.isatty", return_value=True),
+            patch("hyops.blueprint.command.sys.stdout.isatty", return_value=True),
+            patch("hyops.blueprint.command.input", return_value="1"),
+            patch("builtins.print") as output,
+        ):
+            selected = _select_archive_destroy_mode(ns, payload, "test")
+
+        self.assertEqual(selected, "keep")
+        output.assert_any_call("  2. Preserve saved lab state, then destroy")
+        output.assert_any_call("  3. Destroy without preserving lab state")
+
     def test_archive_choice_interrupt_is_a_distinct_cancellation(self):
         ns = _namespace()
         ns.yes = False
@@ -468,6 +485,41 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertIn("archive saved: lab definitions", output)
         self.assertNotIn(str(archive_path), output)
         self.assertNotIn(checksum, output)
+
+    def test_archive_reports_saved_device_configurations(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive_path = Path(tmp) / "labs.tar.gz"
+            archive_path.write_bytes(b"portable labs")
+            checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+            payload = {
+                "archive_before_destroy": {
+                    "module_ref": "platform/test/archive",
+                    "state_instance": "lab_archive",
+                    "inputs": {},
+                }
+            }
+            paths = SimpleNamespace(state_dir=Path(tmp) / "state")
+            state = {
+                "outputs": {
+                    "eveng_lab_archive_path": str(archive_path),
+                    "eveng_lab_archive_sha256": checksum,
+                    "eveng_lab_archive_device_configs_captured": True,
+                }
+            }
+            stdout = io.StringIO()
+
+            with (
+                patch("hyops.blueprint.command.run_step_module_command", return_value=0),
+                patch("hyops.blueprint.command.read_module_state", return_value=state),
+                patch("hyops.blueprint.command.sys.stdout", stdout),
+            ):
+                rc = _run_archive_before_destroy(_namespace(), payload, paths)
+
+        self.assertEqual(rc, 0)
+        self.assertIn(
+            "archive saved: lab definitions, saved device configurations",
+            stdout.getvalue(),
+        )
 
     def test_failed_archive_stops_before_resource_destroy(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))

--- a/hyops/blueprint/tests/test_gcp_eve_ng.py
+++ b/hyops/blueprint/tests/test_gcp_eve_ng.py
@@ -25,6 +25,14 @@ class GcpEveNgBlueprintTest(TestCase):
             validated["metadata"]["ready_message"],
             "EVE-NG network emulation lab ready",
         )
+        archive = validated["archive_before_destroy"]
+        self.assertTrue(archive["inputs"]["load_vault_env"])
+        self.assertEqual(
+            archive["inputs"]["required_env"], ["EVENG_ADMIN_PASSWORD"]
+        )
+        self.assertTrue(
+            archive["inputs"]["eveng_lab_archive_capture_device_configs"]
+        )
 
         self.assertEqual(
             validated["order"],

--- a/hyops/blueprint/tests/test_onprem_eve_ng.py
+++ b/hyops/blueprint/tests/test_onprem_eve_ng.py
@@ -23,6 +23,14 @@ class OnPremEveNgBlueprintTest(TestCase):
             validated["archive_before_destroy"]["module_ref"],
             "platform/linux/eve-ng-lab-archive",
         )
+        archive_inputs = validated["archive_before_destroy"]["inputs"]
+        self.assertTrue(archive_inputs["load_vault_env"])
+        self.assertEqual(
+            archive_inputs["required_env"], ["EVENG_ADMIN_PASSWORD"]
+        )
+        self.assertTrue(
+            archive_inputs["eveng_lab_archive_capture_device_configs"]
+        )
         self.assertEqual(len(validated["steps"]), 5)
         vm_step = next(
             step for step in validated["steps"] if step["id"] == "eve_ng_vm"

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -34,6 +34,7 @@ def _payload():
             "inputs": {
                 "inventory_state_ref": "platform/test/vm#lab_vm",
                 "eveng_lab_archive_action": "export",
+                "eveng_lab_archive_capture_device_configs": True,
                 "eveng_lab_archive_include_node_state": True,
                 "eveng_lab_archive_stop_running_nodes": True,
             },
@@ -175,6 +176,9 @@ class BlueprintLabRestoreTest(TestCase):
             "b" * 64,
         )
         self.assertFalse(step["inputs"]["eveng_lab_archive_overwrite"])
+        self.assertFalse(
+            step["inputs"]["eveng_lab_archive_capture_device_configs"]
+        )
         self.assertFalse(step["inputs"]["eveng_lab_archive_include_node_state"])
         self.assertFalse(step["inputs"]["eveng_lab_archive_stop_running_nodes"])
 

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from pathlib import PurePath
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 from hyops.validators.common import (
     normalize_required_env,
@@ -101,6 +102,36 @@ def validate(inputs: dict[str, Any]) -> None:
         raise ValueError(
             "inputs.eveng_lab_archive_stop_running_nodes requires an export "
             "that includes node state"
+        )
+    capture_device_configs = data.get("eveng_lab_archive_capture_device_configs")
+    if not isinstance(capture_device_configs, bool):
+        raise ValueError(
+            "inputs.eveng_lab_archive_capture_device_configs must be a boolean"
+        )
+    if capture_device_configs and action != "export":
+        raise ValueError(
+            "inputs.eveng_lab_archive_capture_device_configs requires an export"
+        )
+    api_base_url = require_non_empty_str(
+        data.get("eveng_lab_archive_api_base_url"),
+        "inputs.eveng_lab_archive_api_base_url",
+    )
+    parsed_api_url = urlparse(api_base_url)
+    if parsed_api_url.scheme not in {"http", "https"} or not parsed_api_url.netloc:
+        raise ValueError(
+            "inputs.eveng_lab_archive_api_base_url must be an HTTP or HTTPS URL"
+        )
+    require_non_empty_str(
+        data.get("eveng_lab_archive_api_username"),
+        "inputs.eveng_lab_archive_api_username",
+    )
+    require_non_empty_str(
+        data.get("eveng_lab_archive_api_password_env"),
+        "inputs.eveng_lab_archive_api_password_env",
+    )
+    if not isinstance(data.get("eveng_lab_archive_api_validate_certs"), bool):
+        raise ValueError(
+            "inputs.eveng_lab_archive_api_validate_certs must be a boolean"
         )
     node_state_root = require_non_empty_str(
         data.get("eveng_lab_archive_node_state_root"),

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -112,6 +112,10 @@ def validate(inputs: dict[str, Any]) -> None:
         raise ValueError(
             "inputs.eveng_lab_archive_capture_device_configs requires an export"
         )
+    if not isinstance(data.get("eveng_lab_archive_activate_saved_configs"), bool):
+        raise ValueError(
+            "inputs.eveng_lab_archive_activate_saved_configs must be a boolean"
+        )
     api_base_url = require_non_empty_str(
         data.get("eveng_lab_archive_api_base_url"),
         "inputs.eveng_lab_archive_api_base_url",

--- a/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
@@ -90,6 +90,12 @@ class EveNgLabArchiveValidatorTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "requires an export"):
             validate(inputs)
 
+    def test_saved_configuration_activation_must_be_boolean(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_activate_saved_configs"] = "yes"
+        with self.assertRaisesRegex(ValueError, "must be a boolean"):
+            validate(inputs)
+
     def test_saved_configuration_api_url_must_be_http(self) -> None:
         inputs = valid_inputs()
         inputs["eveng_lab_archive_api_base_url"] = "file:///tmp/eve"

--- a/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
@@ -72,6 +72,30 @@ class EveNgLabArchiveValidatorTests(unittest.TestCase):
         inputs["eveng_lab_archive_stop_running_nodes"] = True
         validate(inputs)
 
+    def test_saved_configuration_capture_is_valid_for_export(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_capture_device_configs"] = True
+        validate(inputs)
+
+    def test_saved_configuration_capture_is_rejected_for_restore(self) -> None:
+        inputs = valid_inputs()
+        inputs.update(
+            {
+                "eveng_lab_archive_action": "restore",
+                "eveng_lab_archive_path": "/tmp/labs.tar.gz",
+                "eveng_lab_archive_expected_sha256": "a" * 64,
+                "eveng_lab_archive_capture_device_configs": True,
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "requires an export"):
+            validate(inputs)
+
+    def test_saved_configuration_api_url_must_be_http(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_api_base_url"] = "file:///tmp/eve"
+        with self.assertRaisesRegex(ValueError, "HTTP or HTTPS"):
+            validate(inputs)
+
     def test_node_state_restore_requires_companion_checksum(self) -> None:
         inputs = valid_inputs()
         inputs.update(

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -2,7 +2,7 @@
 
 Preserves EVE-NG lab continuity independently of the execution host and restores verified state after reconstruction.
 
-The primary archive contains learner-created lab definitions from `/opt/unetlab/labs`. A companion archive can also preserve stopped QEMU overlay state when the selected continuity policy requires writable node state to survive.
+The primary archive contains learner-created lab definitions from `/opt/unetlab/labs`. Before export, the module can ask EVE-NG to write saved device configurations into those definitions. A companion archive can preserve stopped QEMU overlay state.
 
 ## Export
 
@@ -22,6 +22,16 @@ eveng_lab_archive_stop_running_nodes: true
 ```
 
 The archive role stops running QEMU nodes, validates their overlay disks and creates a separately checksummed node-state companion archive. Base images remain independently managed and are paired with the restored overlays on the reconstructed host.
+
+To refresh saved device configurations before export, enable:
+
+```yaml
+load_vault_env: true
+required_env: ["EVENG_ADMIN_PASSWORD"]
+eveng_lab_archive_capture_device_configs: true
+```
+
+Capture uses the EVE-NG API on the target host. Failure stops the archive step and leaves the execution host in place.
 
 ## Restore
 

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -5,7 +5,7 @@ module_ref: "platform/linux/eve-ng-lab-archive"
 
 metadata:
   title: "Linux EVE-NG Lab Archive"
-  description: "Export or restore portable EVE-NG lab definitions without retaining the workload VM."
+  description: "Export or restore portable EVE-NG lab definitions, saved configurations and stopped QEMU state without retaining the workload VM."
 
 requirements:
   credentials: []
@@ -57,6 +57,11 @@ inputs:
     eveng_lab_archive_node_state_path: ""
     eveng_lab_archive_node_state_expected_sha256: ""
     eveng_lab_archive_qemu_img: "/opt/qemu/bin/qemu-img"
+    eveng_lab_archive_capture_device_configs: false
+    eveng_lab_archive_api_base_url: "http://127.0.0.1"
+    eveng_lab_archive_api_username: "admin"
+    eveng_lab_archive_api_password_env: "EVENG_ADMIN_PASSWORD"
+    eveng_lab_archive_api_validate_certs: false
 
 execution:
   driver: "config/ansible"
@@ -73,6 +78,8 @@ outputs:
     - eveng_lab_archive_sha256
     - eveng_lab_archive_created_at
     - eveng_lab_archive_folders
+    - eveng_lab_archive_device_configs_captured
+    - eveng_lab_archive_device_config_labs
     - eveng_lab_archive_node_state_included
     - eveng_lab_archive_node_state_archive_path
     - eveng_lab_archive_node_state_sha256

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -58,6 +58,7 @@ inputs:
     eveng_lab_archive_node_state_expected_sha256: ""
     eveng_lab_archive_qemu_img: "/opt/qemu/bin/qemu-img"
     eveng_lab_archive_capture_device_configs: false
+    eveng_lab_archive_activate_saved_configs: true
     eveng_lab_archive_api_base_url: "http://127.0.0.1"
     eveng_lab_archive_api_username: "admin"
     eveng_lab_archive_api_password_env: "EVENG_ADMIN_PASSWORD"

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -52,6 +52,10 @@
             'eveng_lab_archive_sha256': eveng_lab_archive_results.sha256,
             'eveng_lab_archive_created_at': eveng_lab_archive_results.created_at | default(''),
             'eveng_lab_archive_folders': eveng_lab_archive_results.folders,
+            'eveng_lab_archive_device_configs_captured':
+              eveng_lab_archive_results.device_configs_captured | default(false),
+            'eveng_lab_archive_device_config_labs':
+              eveng_lab_archive_results.device_config_labs | default([]),
             'eveng_lab_archive_node_state_included':
               eveng_lab_archive_results.node_state_included | default(false),
             'eveng_lab_archive_node_state_archive_path':


### PR DESCRIPTION
## Summary

- invoke EVE-NG native configuration export before archive creation
- require verified configuration capture before resource destruction
- activate saved configurations after lab restoration
- report interrupted preservation without continuing to resource destruction
- cover the workflow in the GCP and on-premises EVE-NG blueprints

Depends on hybridops-tech/ansible-collection-helper#28.

Closes #327.

## Validation

- `python3 -m unittest discover -s hyops -p 'test_*.py'` (366 tests)
- collection role smoke test through hybridops-tech/ansible-collection-helper#28
- GCP EVE-NG Community acceptance using environment `eve-preservation-test`
- preserved, destroyed, rebuilt and restored a Cisco IOL lab
- verified the restored hostname and loopback configuration on the IOL node
- final environment cleanup remains pending the reporter regression test

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.
