### PR TITLE
fix(gcp): block VM deploy on global CPU quota

### DIFF
--- a/hyops/drivers/iac/terragrunt/_internal/execution.py
+++ b/hyops/drivers/iac/terragrunt/_internal/execution.py
@@ -17,6 +17,11 @@ _GCP_CAPACITY_MARKERS = (
     "zone_resource_pool_exhausted",
     "resource pool exhausted",
 )
+_GCP_QUOTA_ERROR = re.compile(
+    r"Quota\s+['\"]?([A-Za-z0-9_-]+)['\"]?\s+exceeded\.\s*"
+    r"Limit:\s*([0-9]+(?:\.[0-9]+)?)",
+    flags=re.IGNORECASE,
+)
 
 
 def translate_gcp_capacity_error(
@@ -26,12 +31,43 @@ def translate_gcp_capacity_error(
     stderr: str,
     env: dict[str, str],
 ) -> str:
-    """Return operator guidance for a GCP zonal capacity failure."""
+    """Return operator guidance for a GCP quota or zonal capacity failure."""
     if command_name != "apply":
         return ""
 
     combined = f"{stderr}\n{stdout}"
     lowered = combined.lower()
+    quota_match = _GCP_QUOTA_ERROR.search(combined)
+    if quota_match is not None:
+        metric = quota_match.group(1).upper()
+        limit_raw = quota_match.group(2)
+        try:
+            limit_value = float(limit_raw)
+            limit = str(int(limit_value)) if limit_value.is_integer() else f"{limit_value:g}"
+        except ValueError:
+            limit = limit_raw
+        machine_match = re.search(
+            r'\bmachine_type\s*=\s*"([a-z][a-z0-9-]+)"',
+            combined,
+            flags=re.IGNORECASE,
+        )
+        project_match = re.search(
+            r'\bproject\s*=\s*"([a-z][a-z0-9:-]+)"',
+            combined,
+            flags=re.IGNORECASE,
+        )
+        machine = str(machine_match.group(1) if machine_match else "").strip()
+        project = str(project_match.group(1) if project_match else "").strip()
+        shape_detail = f" for {machine}" if machine else ""
+        project_detail = f" in project {project}" if project else ""
+        env_name = str(env.get("HYOPS_ENV") or "").strip() or "<env>"
+        return (
+            f"GCP compute quota {metric} is insufficient{project_detail}{shape_detail} "
+            f"(limit={limit}). The requested VM was not created.\n"
+            "hint: release an existing VM through its owning HybridOps environment, "
+            f"choose a smaller machine type, or request more {metric} quota; then rerun "
+            f"blueprint preflight and deploy for env={env_name}."
+        )
     if not any(marker in lowered for marker in _GCP_CAPACITY_MARKERS):
         return ""
 

--- a/hyops/drivers/iac/terragrunt/_internal/preflight.py
+++ b/hyops/drivers/iac/terragrunt/_internal/preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -15,6 +16,276 @@ from hyops.runtime.module_state import read_module_state
 from hyops.runtime.terraform_cloud import preflight_cloud_backend
 
 from .netbox import hydrate_netbox_env, netbox_state_status
+
+
+_GCP_VM_MODULE = "platform/gcp/platform-vm"
+_GCP_GLOBAL_CPU_QUOTA = "CPUS_ALL_REGIONS"
+_GCP_QUOTA_ACTIVE_STATUSES = {
+    "PROVISIONING",
+    "REPAIRING",
+    "RUNNING",
+    "STAGING",
+    "STOPPING",
+}
+
+
+def _gcloud_json(args: list[str], *, env: dict[str, str]) -> tuple[Any | None, str]:
+    command = ["gcloud", *args, "--format=json"]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except FileNotFoundError:
+        return None, "gcloud is unavailable"
+    except Exception as exc:
+        return None, f"gcloud could not be executed: {exc}"
+    if completed.returncode != 0:
+        detail = str(completed.stderr or completed.stdout or "").strip()
+        return None, detail or f"gcloud exited with status {completed.returncode}"
+    try:
+        return json.loads(completed.stdout or "null"), ""
+    except json.JSONDecodeError:
+        return None, "gcloud returned invalid JSON"
+
+
+def _gcp_resource_name(value: Any) -> str:
+    return str(value or "").rstrip("/").rsplit("/", 1)[-1]
+
+
+def _gcp_vm_name(prefix: str, context_id: str, key: str) -> str:
+    prefix_raw = "-".join(token for token in (prefix.strip(), context_id.strip()) if token)
+    normalized_prefix = re.sub(r"[^0-9a-z-]", "-", prefix_raw).lower()
+    normalized_prefix = re.sub(r"-+", "-", normalized_prefix).strip("-")
+    raw = f"{normalized_prefix}-{key}" if normalized_prefix else key
+    name = re.sub(r"[^0-9a-z-]", "-", raw).lower()
+    name = re.sub(r"-+", "-", name).strip("-")
+    if name and not name[0].isalpha():
+        name = f"v-{name}"
+    return name[:63].rstrip("-")
+
+
+def _planned_gcp_vms(inputs: dict[str, Any]) -> tuple[list[dict[str, str]], str]:
+    vms = inputs.get("vms")
+    if not isinstance(vms, dict) or not vms:
+        return [], "GCP CPU quota preflight failed: inputs.vms must contain at least one VM"
+
+    default_machine_type = str(inputs.get("machine_type") or "").strip()
+    default_zone = str(inputs.get("zone") or "").strip()
+    prefix = str(inputs.get("name_prefix") or "")
+    context_id = str(inputs.get("context_id") or "")
+    planned: list[dict[str, str]] = []
+    for key in sorted(vms):
+        raw_config = vms.get(key)
+        config = raw_config if isinstance(raw_config, dict) else {}
+        machine_type = str(config.get("machine_type") or default_machine_type).strip()
+        zone = str(config.get("zone") or default_zone).strip()
+        name = _gcp_vm_name(prefix, context_id, str(key))
+        if not name or not machine_type or not zone:
+            return [], (
+                "GCP CPU quota preflight failed: each planned VM requires a resolvable "
+                "name, machine type, and zone"
+            )
+        planned.append({"name": name, "machine_type": machine_type, "zone": zone})
+    return planned, ""
+
+
+def _quota_number(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return -1.0
+
+
+def _format_quota_number(value: float) -> str:
+    return str(int(value)) if float(value).is_integer() else f"{value:g}"
+
+
+def _preflight_gcp_vm_cpu_quota(
+    *,
+    lifecycle_command: str,
+    module_ref: str,
+    profile_ref: str,
+    runtime: dict[str, Any],
+    inputs: dict[str, Any],
+    env: dict[str, str],
+) -> tuple[str, dict[str, Any]]:
+    if str(module_ref or "").strip() != _GCP_VM_MODULE:
+        return "", {}
+    if not str(profile_ref or "").strip().lower().startswith("gcp"):
+        return "", {}
+    if str(lifecycle_command or "").strip().lower() not in {"apply", "deploy"}:
+        return "", {}
+
+    project_id = _resolve_gcp_project_id(runtime=runtime, inputs=inputs)
+    if not project_id:
+        return (
+            "GCP CPU quota preflight failed: project id could not be resolved from "
+            "module inputs or init credentials",
+            {},
+        )
+
+    planned, planned_error = _planned_gcp_vms(inputs)
+    if planned_error:
+        return planned_error, {}
+
+    instances_payload, instances_error = _gcloud_json(
+        ["compute", "instances", "list", "--project", project_id],
+        env=env,
+    )
+    if instances_error or not isinstance(instances_payload, list):
+        return (
+            f"GCP CPU quota preflight failed: could not list instances in project "
+            f"{project_id}: {instances_error or 'unexpected response'}",
+            {},
+        )
+    instances = {
+        (
+            _gcp_resource_name(item.get("zone")),
+            str(item.get("name") or "").strip(),
+        ): item
+        for item in instances_payload
+        if isinstance(item, dict)
+        and _gcp_resource_name(item.get("zone"))
+        and str(item.get("name") or "").strip()
+    }
+
+    project_payload, project_error = _gcloud_json(
+        ["compute", "project-info", "describe", "--project", project_id],
+        env=env,
+    )
+    quotas = project_payload.get("quotas") if isinstance(project_payload, dict) else None
+    if project_error or not isinstance(quotas, list):
+        return (
+            f"GCP CPU quota preflight failed: could not inspect project quota for "
+            f"{project_id}: {project_error or 'unexpected response'}",
+            {},
+        )
+    quota = next(
+        (
+            item
+            for item in quotas
+            if isinstance(item, dict)
+            and str(item.get("metric") or "").strip().upper() == _GCP_GLOBAL_CPU_QUOTA
+        ),
+        None,
+    )
+    limit = _quota_number(quota.get("limit") if isinstance(quota, dict) else None)
+    usage = _quota_number(quota.get("usage") if isinstance(quota, dict) else None)
+    if limit < 0 or usage < 0:
+        return (
+            f"GCP CPU quota preflight failed: project {project_id} did not return a "
+            f"valid {_GCP_GLOBAL_CPU_QUOTA} quota",
+            {},
+        )
+
+    cpu_cache: dict[tuple[str, str], int] = {}
+
+    def machine_cpus(zone: str, machine_type: str) -> tuple[int, str]:
+        key = (zone, machine_type)
+        if key in cpu_cache:
+            return cpu_cache[key], ""
+        payload, detail = _gcloud_json(
+            [
+                "compute",
+                "machine-types",
+                "describe",
+                machine_type,
+                "--project",
+                project_id,
+                "--zone",
+                zone,
+            ],
+            env=env,
+        )
+        try:
+            cpus = int(payload.get("guestCpus")) if isinstance(payload, dict) else 0
+        except (TypeError, ValueError):
+            cpus = 0
+        if detail or cpus < 1:
+            return 0, detail or "machine type response did not contain guestCpus"
+        cpu_cache[key] = cpus
+        return cpus, ""
+
+    planned_additional = 0
+    for vm in planned:
+        desired_cpus, shape_error = machine_cpus(vm["zone"], vm["machine_type"])
+        if shape_error:
+            return (
+                f"GCP CPU quota preflight failed: could not resolve {vm['machine_type']} "
+                f"in {vm['zone']}: {shape_error}",
+                {},
+            )
+        existing = instances.get((vm["zone"], vm["name"]))
+        if not isinstance(existing, dict):
+            planned_additional += desired_cpus
+            continue
+        current_zone = _gcp_resource_name(existing.get("zone")) or vm["zone"]
+        current_machine_type = _gcp_resource_name(existing.get("machineType"))
+        current_cpus, current_error = machine_cpus(current_zone, current_machine_type)
+        if current_error:
+            return (
+                f"GCP CPU quota preflight failed: could not resolve the current machine "
+                f"type for {vm['name']}: {current_error}",
+                {},
+            )
+        planned_additional += max(0, desired_cpus - current_cpus)
+
+    available = max(0.0, limit - usage)
+    shortfall = max(0.0, float(planned_additional) - available)
+    active_instances: list[dict[str, str]] = []
+    for (zone, name), item in sorted(instances.items()):
+        status = str(item.get("status") or "").strip().upper()
+        if status not in _GCP_QUOTA_ACTIVE_STATUSES:
+            continue
+        labels = item.get("labels") if isinstance(item.get("labels"), dict) else {}
+        active_instances.append(
+            {
+                "name": name,
+                "zone": zone,
+                "machine_type": _gcp_resource_name(item.get("machineType")) or "unknown-shape",
+                "status": status,
+                "role": str(labels.get("role") or "").strip(),
+                "workload": str(labels.get("workload") or "").strip(),
+            }
+        )
+
+    summary = {
+        "project_id": project_id,
+        "metric": _GCP_GLOBAL_CPU_QUOTA,
+        "limit": limit,
+        "usage": usage,
+        "available": available,
+        "planned_additional": planned_additional,
+        "shortfall": shortfall,
+        "active_instances": active_instances,
+    }
+    if shortfall <= 0:
+        return "", summary
+
+    consumers: list[str] = []
+    for item in active_instances:
+        ownership = f", role={item['role']}" if item["role"] else ""
+        consumers.append(
+            f"{item['name']} ({item['machine_type']}, {item['status']}{ownership})"
+        )
+    consumer_detail = "; ".join(consumers[:5]) or "none visible to the active identity"
+    if len(consumers) > 5:
+        consumer_detail += f"; and {len(consumers) - 5} more"
+
+    return (
+        f"GCP CPU quota preflight failed: project={project_id} "
+        f"metric={_GCP_GLOBAL_CPU_QUOTA} limit={_format_quota_number(limit)} "
+        f"used={_format_quota_number(usage)} available={_format_quota_number(available)} "
+        f"planned_additional={planned_additional} shortfall={_format_quota_number(shortfall)}. "
+        f"Active instances: {consumer_detail}. No resources were changed. "
+        "Release an existing VM through its owning HybridOps environment, choose a "
+        "smaller machine type, or request more global CPU quota, then rerun preflight.",
+        summary,
+    )
 
 
 def _resolve_gke_project_id(*, runtime_root: Path, inputs: dict[str, Any]) -> str:
@@ -212,6 +483,21 @@ def run_preflight_phase(
     if billing_error:
         return True, billing_error
 
+    quota_error, quota_summary = _preflight_gcp_vm_cpu_quota(
+        lifecycle_command=str(runtime.get("lifecycle_command") or ""),
+        module_ref=module_ref,
+        profile_ref=profile_ref,
+        runtime=runtime,
+        inputs=inputs,
+        env=env,
+    )
+    if quota_summary:
+        normalized = result.setdefault("normalized_outputs", {})
+        preflight_output = normalized.setdefault("preflight", {})
+        preflight_output["gcp_cpu_quota"] = quota_summary
+    if quota_error:
+        return True, quota_error
+
     if module_ref == "platform/gcp/gke-cluster":
         gke_default_sa_error = _preflight_gke_default_compute_sa(
             runtime_root=runtime_root,
@@ -291,13 +577,14 @@ def run_preflight_phase(
             )
 
     result["status"] = "ok"
-    result["normalized_outputs"] = {
-        "preflight": {
+    preflight_output = result.setdefault("normalized_outputs", {}).setdefault("preflight", {})
+    preflight_output.update(
+        {
             "module_ref": module_ref,
             "profile_ref": profile_ref,
             "pack_id": pack_id,
             "required_credentials": required_credentials,
             "effective_zone_name": str(inputs.get("zone_name") or ""),
         }
-    }
+    )
     return True, ""

--- a/hyops/drivers/iac/terragrunt/tests/test_execution.py
+++ b/hyops/drivers/iac/terragrunt/tests/test_execution.py
@@ -4,6 +4,31 @@ from hyops.drivers.iac.terragrunt._internal.execution import translate_gcp_capac
 
 
 class GcpCapacityErrorTest(TestCase):
+    def test_translates_global_cpu_quota_failure(self):
+        stderr = (
+            "Error waiting for instance to create: Quota 'CPUS_ALL_REGIONS' "
+            "exceeded. Limit: 12.0 globally."
+        )
+        stdout = (
+            'machine_type = "n2-standard-8"\n'
+            'project = "student-project"\n'
+        )
+
+        message = translate_gcp_capacity_error(
+            command_name="apply",
+            stdout=stdout,
+            stderr=stderr,
+            env={"HYOPS_ENV": "demo-lab2"},
+        )
+
+        self.assertIn("quota CPUS_ALL_REGIONS is insufficient", message)
+        self.assertIn("project student-project", message)
+        self.assertIn("for n2-standard-8", message)
+        self.assertIn("limit=12", message)
+        self.assertIn("requested VM was not created", message)
+        self.assertIn("owning HybridOps environment", message)
+        self.assertIn("env=demo-lab2", message)
+
     def test_translates_zonal_capacity_failure(self):
         stderr = (
             "The zone 'projects/student-project/zones/europe-west2-a' does not "

--- a/hyops/drivers/iac/terragrunt/tests/test_gcp_cpu_quota_preflight.py
+++ b/hyops/drivers/iac/terragrunt/tests/test_gcp_cpu_quota_preflight.py
@@ -1,0 +1,291 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from hyops.drivers.iac.terragrunt._internal.preflight import (
+    _gcp_vm_name,
+    _preflight_gcp_vm_cpu_quota,
+    run_preflight_phase,
+)
+
+
+def _inputs(*, machine_type: str = "n2-standard-8") -> dict:
+    return {
+        "project_id": "student-project",
+        "name_prefix": "platform",
+        "context_id": "labs",
+        "zone": "europe-west2-a",
+        "machine_type": machine_type,
+        "vms": {"eve-ng-01": {"role": "eve-ng"}},
+    }
+
+
+def _gcloud_response(
+    *,
+    instances: list[dict],
+    limit: float = 12,
+    usage: float = 8,
+    shapes: dict[str, int] | None = None,
+):
+    shape_cpus = shapes or {"n2-standard-8": 8, "n2-standard-4": 4}
+
+    def response(args, *, env):
+        del env
+        if args[:3] == ["compute", "instances", "list"]:
+            return instances, ""
+        if args[:3] == ["compute", "project-info", "describe"]:
+            return {
+                "quotas": [
+                    {
+                        "metric": "CPUS_ALL_REGIONS",
+                        "limit": limit,
+                        "usage": usage,
+                    }
+                ]
+            }, ""
+        if args[:3] == ["compute", "machine-types", "describe"]:
+            machine_type = args[3]
+            return {"guestCpus": shape_cpus[machine_type]}, ""
+        raise AssertionError(f"unexpected gcloud request: {args}")
+
+    return response
+
+
+class GcpVmCpuQuotaPreflightTest(TestCase):
+    def _run(self, inputs: dict) -> tuple[str, dict]:
+        return _preflight_gcp_vm_cpu_quota(
+            lifecycle_command="deploy",
+            module_ref="platform/gcp/platform-vm",
+            profile_ref="gcp-local@v1.0",
+            runtime={},
+            inputs=inputs,
+            env={"HYOPS_ENV": "demo-lab2"},
+        )
+
+    def test_vm_name_matches_terraform_normalization(self):
+        self.assertEqual(
+            _gcp_vm_name("platform", "gns3-lab", "gns3-01"),
+            "platform-gns3-lab-gns3-01",
+        )
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight._gcloud_json")
+    def test_blocks_when_existing_vm_consumes_global_quota(self, gcloud_json):
+        gcloud_json.side_effect = _gcloud_response(
+            instances=[
+                {
+                    "name": "platform-gns3-lab-gns3-01",
+                    "zone": "zones/europe-west2-a",
+                    "machineType": "machineTypes/n2-standard-8",
+                    "status": "RUNNING",
+                    "labels": {"role": "gns3", "workload": "network-lab"},
+                }
+            ]
+        )
+
+        error, summary = self._run(_inputs())
+
+        self.assertIn("metric=CPUS_ALL_REGIONS", error)
+        self.assertIn("limit=12", error)
+        self.assertIn("used=8", error)
+        self.assertIn("available=4", error)
+        self.assertIn("planned_additional=8", error)
+        self.assertIn("shortfall=4", error)
+        self.assertIn("platform-gns3-lab-gns3-01", error)
+        self.assertIn("role=gns3", error)
+        self.assertIn("No resources were changed", error)
+        self.assertEqual(summary["shortfall"], 4)
+        self.assertEqual(summary["active_instances"][0]["role"], "gns3")
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight._gcloud_json")
+    def test_allows_request_that_fits_remaining_global_quota(self, gcloud_json):
+        gcloud_json.side_effect = _gcloud_response(
+            instances=[
+                {
+                    "name": "platform-gns3-lab-gns3-01",
+                    "zone": "zones/europe-west2-a",
+                    "machineType": "machineTypes/n2-standard-8",
+                    "status": "RUNNING",
+                }
+            ],
+            limit=16,
+            usage=8,
+        )
+
+        error, summary = self._run(_inputs())
+
+        self.assertEqual(error, "")
+        self.assertEqual(summary["planned_additional"], 8)
+        self.assertEqual(summary["shortfall"], 0)
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight._gcloud_json")
+    def test_does_not_double_count_existing_planned_vm(self, gcloud_json):
+        gcloud_json.side_effect = _gcloud_response(
+            instances=[
+                {
+                    "name": "platform-labs-eve-ng-01",
+                    "zone": "zones/europe-west2-a",
+                    "machineType": "machineTypes/n2-standard-8",
+                    "status": "RUNNING",
+                }
+            ],
+            limit=12,
+            usage=8,
+        )
+
+        error, summary = self._run(_inputs())
+
+        self.assertEqual(error, "")
+        self.assertEqual(summary["planned_additional"], 0)
+        self.assertEqual(summary["available"], 4)
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight._gcloud_json")
+    def test_counts_only_resize_increase_for_existing_vm(self, gcloud_json):
+        gcloud_json.side_effect = _gcloud_response(
+            instances=[
+                {
+                    "name": "platform-labs-eve-ng-01",
+                    "zone": "zones/europe-west2-a",
+                    "machineType": "machineTypes/n2-standard-4",
+                    "status": "RUNNING",
+                }
+            ],
+            limit=6,
+            usage=4,
+        )
+
+        error, summary = self._run(_inputs(machine_type="n2-standard-8"))
+
+        self.assertIn("planned_additional=4", error)
+        self.assertIn("shortfall=2", error)
+        self.assertEqual(summary["shortfall"], 2)
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight._gcloud_json")
+    def test_same_name_in_another_zone_is_not_treated_as_planned_vm(self, gcloud_json):
+        gcloud_json.side_effect = _gcloud_response(
+            instances=[
+                {
+                    "name": "platform-labs-eve-ng-01",
+                    "zone": "zones/europe-west2-b",
+                    "machineType": "machineTypes/n2-standard-8",
+                    "status": "RUNNING",
+                }
+            ],
+            limit=12,
+            usage=8,
+        )
+
+        error, summary = self._run(_inputs())
+
+        self.assertIn("planned_additional=8", error)
+        self.assertEqual(summary["shortfall"], 4)
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight._gcloud_json")
+    def test_fails_closed_when_global_quota_is_missing(self, gcloud_json):
+        def response(args, *, env):
+            del env
+            if args[:3] == ["compute", "instances", "list"]:
+                return [], ""
+            if args[:3] == ["compute", "project-info", "describe"]:
+                return {"quotas": []}, ""
+            raise AssertionError(f"unexpected gcloud request: {args}")
+
+        gcloud_json.side_effect = response
+
+        error, summary = self._run(_inputs())
+
+        self.assertIn("did not return a valid CPUS_ALL_REGIONS quota", error)
+        self.assertEqual(summary, {})
+
+    @patch("hyops.drivers.iac.terragrunt._internal.preflight._gcloud_json")
+    def test_destroy_skips_quota_calls(self, gcloud_json):
+        error, summary = _preflight_gcp_vm_cpu_quota(
+            lifecycle_command="destroy",
+            module_ref="platform/gcp/platform-vm",
+            profile_ref="gcp-local@v1.0",
+            runtime={},
+            inputs=_inputs(),
+            env={},
+        )
+
+        self.assertEqual((error, summary), ("", {}))
+        gcloud_json.assert_not_called()
+
+
+class GcpVmCpuQuotaPreflightIntegrationTest(TestCase):
+    @patch(
+        "hyops.drivers.iac.terragrunt._internal.preflight._preflight_gcp_vm_cpu_quota",
+        return_value=("", {"metric": "CPUS_ALL_REGIONS", "shortfall": 0}),
+    )
+    @patch(
+        "hyops.drivers.iac.terragrunt._internal.preflight._preflight_gcp_billing",
+        return_value="",
+    )
+    def test_success_preserves_structured_quota_summary(self, _billing, quota):
+        with TemporaryDirectory() as tmp:
+            result = {"status": "error", "normalized_outputs": {}, "warnings": []}
+            handled, error = run_preflight_phase(
+                command_name="preflight",
+                result=result,
+                policy_defaults={"min_free_disk_mb": 0},
+                runtime_root=Path(tmp),
+                backend_mode="local",
+                env={},
+                env_name="demo-lab2",
+                export_infra_hook=None,
+                contract=Mock(),
+                module_ref="platform/gcp/platform-vm",
+                runtime={"lifecycle_command": "deploy"},
+                profile_ref="gcp-local@v1.0",
+                pack_id="gcp/platform-vm",
+                required_credentials=["gcp"],
+                inputs=_inputs(),
+            )
+
+        self.assertTrue(handled)
+        self.assertEqual(error, "")
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(
+            result["normalized_outputs"]["preflight"]["gcp_cpu_quota"]["metric"],
+            "CPUS_ALL_REGIONS",
+        )
+        quota.assert_called_once()
+
+    @patch(
+        "hyops.drivers.iac.terragrunt._internal.preflight._preflight_gcp_vm_cpu_quota",
+        return_value=(
+            "quota shortage",
+            {"metric": "CPUS_ALL_REGIONS", "shortfall": 4},
+        ),
+    )
+    @patch(
+        "hyops.drivers.iac.terragrunt._internal.preflight._preflight_gcp_billing",
+        return_value="",
+    )
+    def test_failure_keeps_quota_summary_for_run_record(self, _billing, _quota):
+        with TemporaryDirectory() as tmp:
+            result = {"status": "error", "normalized_outputs": {}, "warnings": []}
+            handled, error = run_preflight_phase(
+                command_name="preflight",
+                result=result,
+                policy_defaults={"min_free_disk_mb": 0},
+                runtime_root=Path(tmp),
+                backend_mode="local",
+                env={},
+                env_name="demo-lab2",
+                export_infra_hook=None,
+                contract=Mock(),
+                module_ref="platform/gcp/platform-vm",
+                runtime={"lifecycle_command": "deploy"},
+                profile_ref="gcp-local@v1.0",
+                pack_id="gcp/platform-vm",
+                required_credentials=["gcp"],
+                inputs=_inputs(),
+            )
+
+        self.assertTrue(handled)
+        self.assertEqual(error, "quota shortage")
+        self.assertEqual(
+            result["normalized_outputs"]["preflight"]["gcp_cpu_quota"]["shortfall"],
+            4,
+        )


### PR DESCRIPTION
## Summary

- calculate the additional global CPU quota required by planned GCP platform VMs
- block preflight before mutation when `CPUS_ALL_REGIONS` cannot fit the request
- avoid double-counting existing VMs and count only CPU growth during resize
- record the quota calculation in normalized preflight output
- translate provider-side quota races into concise operator guidance

Closes #334.

## Validation

- `python3 -m unittest discover -s hyops -p 'test_*.py'` (362 tests)
- `bash tools/ci/check-python.sh`
- `bash tools/ci/check-ruff.sh`
- focused coverage for shortage, sufficient quota, existing VMs, resize growth, missing quota data, destroy, and apply-time translation

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.