### PR TITLE
feat: add protected time-bounded GCP lab sessions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Added
 
+- Added opt-in, time-bounded GCP lab access sessions with generation-bound
+  protected release, deterministic warnings, extension, cancellation and
+  persistent outcomes for EVE-NG, GNS3 and Containerlab.
 - Added live EVE-NG and GNS3 console discovery so native VNC, Telnet, SPICE and web-console forwards follow nodes during an access session.
 - Added targeted Galaxy collection refresh with `hyops setup galaxy --collection <name>`.
 - Added `hyops blueprint init` and `hyops blueprint edit` as the environment-local blueprint workflow. Initialized blueprints are now the default execution source, while `--file` remains an explicit override.

--- a/blueprints/gcp/containerlab@v1/README.md
+++ b/blueprints/gcp/containerlab@v1/README.md
@@ -133,6 +133,13 @@ The estimate provides lifecycle decision context. GCP billing remains authoritat
 127.0.0.1:2222
 ```
 
+Use `--session-minutes <minutes> --on-expiry protected-release` to set a
+planned access limit. The foreground process supervises the limit; the expiry
+action does not continue after that process exits. At expiry, Core runs the
+declared recovery gate before teardown. A failed recovery gate retains the
+environment. Use `hyops blueprint session` to inspect, extend or cancel the
+expiry action.
+
 Use the private node-management path with:
 
 ```bash

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -55,6 +55,25 @@ Open the EVE-NG interface through the managed private path:
 hyops blueprint access --env <env> --ref gcp/eve-ng@v1
 ```
 
+Set a planned session limit when the environment must not remain active:
+
+```bash
+hyops blueprint access \
+  --env <env> \
+  --ref gcp/eve-ng@v1 \
+  --session-minutes 120 \
+  --on-expiry protected-release
+```
+
+The foreground access process supervises the limit and shows the UTC deadline
+and warning intervals. The expiry action does not continue after that process
+exits. At expiry, Core verifies the declared lab archive before teardown. A
+failed archive retains the environment.
+
+Use `hyops blueprint session status`, `hyops blueprint session extend` or
+`hyops blueprint session cancel` with the same environment and blueprint
+reference. Extension also requires `--minutes <minutes>`.
+
 The access session resolves the current host from HybridOps state and forwards the EVE-NG interface through IAP. The VM and EVE-NG HTTP service remain private.
 
 Add `--native-consoles` to follow active QEMU VNC ports during the session. New node consoles are forwarded on loopback as they start. The workstation must have a VNC handler registered for links opened by EVE-NG.

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -56,6 +56,25 @@ Open the GNS3 server through the managed private path:
 hyops blueprint access --env <env> --ref gcp/gns3@v1
 ```
 
+Set a planned session limit when the environment must not remain active:
+
+```bash
+hyops blueprint access \
+  --env <env> \
+  --ref gcp/gns3@v1 \
+  --session-minutes 120 \
+  --on-expiry protected-release
+```
+
+The foreground access process supervises the limit and shows the UTC deadline
+and warning intervals. The expiry action does not continue after that process
+exits. At expiry, Core verifies the declared project archive before teardown.
+A failed archive retains the environment.
+
+Use `hyops blueprint session status`, `hyops blueprint session extend` or
+`hyops blueprint session cancel` with the same environment and blueprint
+reference. Extension also requires `--minutes <minutes>`.
+
 The access session resolves the current host from HybridOps state and forwards the authenticated GNS3 API/UI endpoint through IAP. The VM and GNS3 service remain private.
 
 Add `--native-consoles` when using the desktop client's Telnet, VNC, SPICE or web console handlers. HybridOps reads node console assignments from the authenticated GNS3 API and maintains matching loopback forwards while access remains open.

--- a/hyops/blueprint/access_session.py
+++ b/hyops/blueprint/access_session.py
@@ -1,0 +1,331 @@
+"""Persistent state and locking for time-bounded blueprint access sessions."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import re
+import socket
+from typing import Any
+
+from hyops.runtime.state import read_json, write_json_atomic
+
+
+SESSION_SCHEMA_VERSION = 1
+SESSION_FINAL_STATES = frozenset(
+    {
+        "cancelled",
+        "completed",
+        "interrupted",
+        "released",
+        "retained-after-failure",
+        "stale-generation",
+    }
+)
+
+
+class LifecycleBusy(RuntimeError):
+    """Raised when another lifecycle operation owns the environment lock."""
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def format_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_utc(value: str) -> datetime:
+    text = str(value or "").strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        raise ValueError("session timestamp must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _token(value: str) -> str:
+    token = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value)).strip("._")
+    return token or "blueprint"
+
+
+def session_state_path(paths, blueprint_ref: str) -> Path:
+    return paths.meta_dir / "access_sessions" / f"{_token(blueprint_ref)}.json"
+
+
+def session_run_record_path(paths, blueprint_ref: str, session_id: str) -> Path:
+    return (
+        paths.logs_dir
+        / "blueprint"
+        / _token(blueprint_ref)
+        / _token(session_id)
+        / "session.json"
+    )
+
+
+def load_session(paths, blueprint_ref: str) -> dict[str, Any] | None:
+    path = session_state_path(paths, blueprint_ref)
+    if not path.is_file():
+        return None
+    record = read_json(path)
+    if str(record.get("blueprint_ref") or "") != blueprint_ref:
+        raise ValueError(f"session state does not belong to {blueprint_ref}")
+    return record
+
+
+def save_session(paths, record: dict[str, Any], *, now: datetime | None = None) -> Path:
+    current = now or utc_now()
+    payload = dict(record)
+    payload["updated_at"] = format_utc(current)
+    blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
+    session_id = str(payload.get("session_id") or "").strip()
+    if not blueprint_ref or not session_id:
+        raise ValueError("session record requires blueprint_ref and session_id")
+    state_path = session_state_path(paths, blueprint_ref)
+    run_record = session_run_record_path(paths, blueprint_ref, session_id)
+    payload["run_record"] = str(run_record)
+    write_json_atomic(state_path, payload)
+    write_json_atomic(run_record, payload)
+    record.clear()
+    record.update(payload)
+    return run_record
+
+
+def supervisor_running(record: dict[str, Any]) -> bool:
+    supervisor = record.get("supervisor")
+    if not isinstance(supervisor, dict):
+        return False
+    if str(supervisor.get("host") or "") != socket.gethostname():
+        return False
+    try:
+        pid = int(supervisor.get("pid") or 0)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def effective_status(
+    record: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    supervisor_is_running: bool | None = None,
+) -> str:
+    status = str(record.get("status") or "unknown")
+    if status in SESSION_FINAL_STATES:
+        return status
+    running = (
+        supervisor_running(record)
+        if supervisor_is_running is None
+        else supervisor_is_running
+    )
+    if running:
+        return status
+    try:
+        overdue = (now or utc_now()) >= parse_utc(str(record.get("deadline_at") or ""))
+    except (TypeError, ValueError):
+        overdue = False
+    return "overdue-unsupervised" if overdue else "unsupervised"
+
+
+def start_session(
+    paths,
+    *,
+    env_name: str,
+    blueprint_ref: str,
+    state_ref: str,
+    resource_generation: str,
+    duration_seconds: int,
+    expiry_action: str,
+    now: datetime | None = None,
+    pid: int | None = None,
+) -> dict[str, Any]:
+    current = now or utc_now()
+    existing = load_session(paths, blueprint_ref)
+    if existing is not None and effective_status(existing, now=current) in {
+        "active",
+        "executing",
+    }:
+        raise LifecycleBusy(
+            "a supervised access session is already active for this blueprint"
+        )
+    session_id = (
+        f"access-session-{current.strftime('%Y%m%dT%H%M%SZ')}-"
+        f"{os.urandom(4).hex()}"
+    )
+    record: dict[str, Any] = {
+        "schema_version": SESSION_SCHEMA_VERSION,
+        "session_id": session_id,
+        "env": env_name,
+        "blueprint_ref": blueprint_ref,
+        "state_ref": state_ref,
+        "resource_generation": resource_generation,
+        "status": "active",
+        "started_at": format_utc(current),
+        "deadline_at": format_utc(current + timedelta(seconds=duration_seconds)),
+        "duration_seconds": duration_seconds,
+        "expiry_action": expiry_action,
+        "supervisor": {
+            "host": socket.gethostname(),
+            "pid": int(pid if pid is not None else os.getpid()),
+        },
+        "outcome": {},
+    }
+    if existing is not None:
+        record["supersedes"] = str(existing.get("session_id") or "")
+    save_session(paths, record, now=current)
+    return record
+
+
+def set_session_status(
+    paths,
+    record: dict[str, Any],
+    status: str,
+    *,
+    reason: str = "",
+    now: datetime | None = None,
+) -> None:
+    current = now or utc_now()
+    record["status"] = status
+    if reason:
+        record["outcome"] = {"reason": reason}
+    if status in SESSION_FINAL_STATES:
+        record["completed_at"] = format_utc(current)
+    save_session(paths, record, now=current)
+
+
+def extend_session(
+    paths,
+    record: dict[str, Any],
+    *,
+    seconds: int,
+    now: datetime | None = None,
+) -> None:
+    if str(record.get("status") or "") != "active":
+        raise ValueError("only an active session can be extended")
+    current = now or utc_now()
+    deadline = parse_utc(str(record.get("deadline_at") or ""))
+    if deadline <= current:
+        raise ValueError("the session deadline has already passed")
+    record["deadline_at"] = format_utc(deadline + timedelta(seconds=seconds))
+    record["extension_count"] = int(record.get("extension_count") or 0) + 1
+    save_session(paths, record, now=current)
+
+
+def _pid_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+class LifecycleLock(AbstractContextManager["LifecycleLock"]):
+    def __init__(self, paths, operation: str) -> None:
+        meta_dir = getattr(paths, "meta_dir", None)
+        if meta_dir is None:
+            state_dir = getattr(paths, "state_dir", None)
+            if state_dir is not None:
+                meta_dir = Path(state_dir).parent / "meta"
+            else:
+                meta_dir = Path(getattr(paths, "root")) / "meta"
+        self.path = Path(meta_dir) / "blueprint_lifecycle.lock"
+        self.owner_path = self.path / "owner.json"
+        self.operation = operation
+        self.token = os.urandom(8).hex()
+        self.acquired = False
+
+    def _owner(self) -> dict[str, Any]:
+        try:
+            data = json.loads(self.owner_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _clear_stale(self) -> bool:
+        owner = self._owner()
+        if not owner:
+            try:
+                age = utc_now().timestamp() - self.path.stat().st_mtime
+            except OSError:
+                return False
+            if age < 30:
+                return False
+        elif str(owner.get("host") or "") != socket.gethostname():
+            return False
+        else:
+            try:
+                pid = int(owner.get("pid") or 0)
+            except (TypeError, ValueError):
+                pid = 0
+            if _pid_running(pid):
+                return False
+        try:
+            self.owner_path.unlink(missing_ok=True)
+            self.path.rmdir()
+        except OSError:
+            return False
+        return True
+
+    def __enter__(self) -> "LifecycleLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        for _attempt in range(2):
+            try:
+                self.path.mkdir(mode=0o700)
+            except FileExistsError:
+                if self._clear_stale():
+                    continue
+                owner = self._owner()
+                detail = str(owner.get("operation") or "another lifecycle operation")
+                raise LifecycleBusy(f"environment lifecycle is busy: {detail}")
+            owner = {
+                "token": self.token,
+                "operation": self.operation,
+                "pid": os.getpid(),
+                "host": socket.gethostname(),
+                "started_at": format_utc(utc_now()),
+            }
+            try:
+                write_json_atomic(self.owner_path, owner)
+            except Exception:
+                try:
+                    self.path.rmdir()
+                except OSError:
+                    pass
+                raise
+            self.acquired = True
+            return self
+        raise LifecycleBusy("environment lifecycle lock could not be acquired")
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        if not self.acquired:
+            return None
+        owner = self._owner()
+        if str(owner.get("token") or "") == self.token:
+            self.owner_path.unlink(missing_ok=True)
+            try:
+                self.path.rmdir()
+            except OSError:
+                pass
+        self.acquired = False
+        return None

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -59,6 +59,19 @@ from .automation_access import (
     local_route_conflicts,
     prepare_automation_session,
 )
+from .access_session import (
+    LifecycleBusy,
+    LifecycleLock,
+    effective_status as effective_session_status,
+    extend_session,
+    format_utc,
+    load_session,
+    parse_utc,
+    save_session,
+    set_session_status,
+    start_session,
+    utc_now,
+)
 from .contracts import (
     enforce_step_contracts,
     explicit_step_inputs_changed,
@@ -781,7 +794,57 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Route the declared management subnet through a Linux TUN interface.",
     )
+    a.add_argument(
+        "--session-minutes",
+        type=int,
+        default=0,
+        help="Set a foreground-supervised access limit in minutes.",
+    )
+    a.add_argument(
+        "--on-expiry",
+        choices=("protected-release",),
+        default="",
+        help="Action authorised when the access-session limit expires.",
+    )
     a.set_defaults(_handler=run_access)
+
+    session = ssp.add_parser(
+        "session",
+        help="Inspect or change a time-bounded access session.",
+    )
+    session_commands = session.add_subparsers(dest="session_cmd", required=True)
+
+    def add_session_args(sub: argparse.ArgumentParser) -> None:
+        add_common_args(sub)
+        sub.add_argument("--root", default=None, help="Override runtime root.")
+        sub.add_argument("--env", default=None, help="Runtime environment namespace.")
+
+    session_status = session_commands.add_parser(
+        "status",
+        help="Show the current access-session state.",
+    )
+    add_session_args(session_status)
+    session_status.set_defaults(_handler=run_session)
+
+    session_extend = session_commands.add_parser(
+        "extend",
+        help="Extend an active access-session deadline.",
+    )
+    add_session_args(session_extend)
+    session_extend.add_argument(
+        "--minutes",
+        type=int,
+        required=True,
+        help="Minutes to add to the current deadline.",
+    )
+    session_extend.set_defaults(_handler=run_session)
+
+    session_cancel = session_commands.add_parser(
+        "cancel",
+        help="Cancel the expiry action without closing access.",
+    )
+    add_session_args(session_cancel)
+    session_cancel.set_defaults(_handler=run_session)
 
     device = ssp.add_parser(
         "device",
@@ -2243,6 +2306,214 @@ def _offer_access_close_destroy(
     return run_destroy(destroy_ns)
 
 
+def _expire_access_session(
+    ns,
+    payload: dict[str, Any],
+    paths,
+    session_record: dict[str, Any],
+    *,
+    cost_estimate: CostEstimate | None = None,
+) -> int:
+    print("access session expired; preserving declared state before teardown")
+    try:
+        with LifecycleLock(paths, "access-session protected release"):
+            current = load_session(paths, str(payload["blueprint_ref"]))
+            if current is None or str(current.get("session_id") or "") != str(
+                session_record.get("session_id") or ""
+            ):
+                raise ValueError("access-session authority record changed before expiry")
+            if str(current.get("status") or "") != "active":
+                raise ValueError(
+                    f"access-session expiry is not authorised in state "
+                    f"{current.get('status', 'unknown')}"
+                )
+            access = payload.get("access")
+            state_ref = str((access if isinstance(access, dict) else {}).get("state_ref") or "")
+            module_ref, state_instance = split_module_state_ref(state_ref)
+            state = read_module_state(
+                paths.state_dir,
+                module_ref,
+                state_instance=state_instance,
+            )
+            generation = _access_resource_generation(payload, state)
+            if generation != str(current.get("resource_generation") or ""):
+                set_session_status(
+                    paths,
+                    current,
+                    "stale-generation",
+                    reason="resource generation changed before expiry",
+                )
+                print("ERR: access-session generation changed; environment retained")
+                return OPERATOR_ERROR
+
+            current["status"] = "executing"
+            current["executing_at"] = format_utc(utc_now())
+            save_session(paths, current)
+            destroy_ns = argparse.Namespace(**vars(ns))
+            destroy_ns.execute = True
+            destroy_ns.yes = True
+            destroy_ns.archive_before_destroy = bool(
+                payload.get("archive_before_destroy")
+            )
+            destroy_ns.skip_archive = False
+            destroy_ns._cost_estimate = cost_estimate
+            destroy_ns._lifecycle_lock_held = True
+            rc = run_destroy(destroy_ns)
+            current["status"] = "released" if rc == 0 else "retained-after-failure"
+            current["outcome"] = {
+                "destroy_rc": int(rc),
+                "resources_released": rc == 0,
+            }
+            if rc != 0:
+                current["outcome"]["reason"] = "protected lifecycle did not complete"
+            current["completed_at"] = format_utc(utc_now())
+            save_session(paths, current)
+    except LifecycleBusy as exc:
+        print(f"ERR: protected release did not start: {exc}")
+        print("review the active lifecycle operation before releasing the environment")
+        return OPERATOR_ERROR
+    except Exception as exc:
+        try:
+            current = load_session(paths, str(payload["blueprint_ref"]))
+            if current is not None and str(current.get("session_id") or "") == str(
+                session_record.get("session_id") or ""
+            ):
+                set_session_status(
+                    paths,
+                    current,
+                    "retained-after-failure",
+                    reason=str(exc),
+                )
+        except (OSError, ValueError):
+            pass
+        print(f"ERR: protected release did not complete: {exc}")
+        print("environment retained")
+        return OPERATOR_ERROR
+    if rc != 0:
+        print("ERR: scheduled teardown did not complete; review the session run record")
+    return rc
+
+
+def _close_access_session(
+    paths,
+    session_record: dict[str, Any] | None,
+    status: str,
+    *,
+    reason: str = "",
+) -> None:
+    if session_record is None:
+        return
+    try:
+        with LifecycleLock(paths, f"access-session {status}"):
+            current = load_session(paths, str(session_record["blueprint_ref"]))
+            if current is None or str(current.get("session_id") or "") != str(
+                session_record.get("session_id") or ""
+            ):
+                return
+            if str(current.get("status") or "") != "active":
+                return
+            set_session_status(paths, current, status, reason=reason)
+    except (LifecycleBusy, OSError, ValueError):
+        return
+
+
+def _current_access_generation(payload: dict[str, Any], paths) -> str:
+    access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
+    state_ref = str(access.get("state_ref") or "").strip()
+    module_ref, state_instance = split_module_state_ref(state_ref)
+    state = read_module_state(
+        paths.state_dir,
+        module_ref,
+        state_instance=state_instance,
+    )
+    return _access_resource_generation(payload, state)
+
+
+def _session_output(record: dict[str, Any]) -> dict[str, Any]:
+    output = dict(record)
+    output["effective_status"] = effective_session_status(record)
+    return output
+
+
+def _print_session(output: dict[str, Any]) -> None:
+    print(f"session={output.get('session_id', '')}")
+    print(f"status={output.get('effective_status', output.get('status', 'unknown'))}")
+    print(f"blueprint={output.get('blueprint_ref', '')}")
+    print(f"deadline={output.get('deadline_at', '')}")
+    print(f"expiry_action={output.get('expiry_action', '')}")
+    outcome = output.get("outcome")
+    if isinstance(outcome, dict) and outcome:
+        if "resources_released" in outcome:
+            print(
+                "resources_released="
+                f"{'yes' if bool(outcome['resources_released']) else 'no'}"
+            )
+        if outcome.get("reason"):
+            print(f"reason={outcome['reason']}")
+    print(f"run record: {output.get('run_record', '')}")
+
+
+def run_session(ns) -> int:
+    try:
+        payload = _resolve_and_validate(ns)
+        require_runtime_selection(
+            ns.root,
+            getattr(ns, "env", None),
+            command_label="hyops blueprint session",
+        )
+        paths = resolve_runtime_paths(ns.root, getattr(ns, "env", None))
+        blueprint_ref = str(payload["blueprint_ref"])
+        record = load_session(paths, blueprint_ref)
+        if record is None:
+            raise ValueError("no access-session record exists for this blueprint")
+
+        command = str(getattr(ns, "session_cmd", "") or "")
+        if command == "status":
+            output = _session_output(record)
+        else:
+            with LifecycleLock(paths, f"access-session {command}"):
+                record = load_session(paths, blueprint_ref)
+                if record is None:
+                    raise ValueError("access-session record disappeared")
+                if command == "extend":
+                    minutes = int(getattr(ns, "minutes", 0) or 0)
+                    if minutes < 1 or minutes > 7 * 24 * 60:
+                        raise ValueError("--minutes must be between 1 and 10080")
+                    if effective_session_status(record) != "active":
+                        raise ValueError("only a supervised active session can be extended")
+                    if _current_access_generation(payload, paths) != str(
+                        record.get("resource_generation") or ""
+                    ):
+                        set_session_status(
+                            paths,
+                            record,
+                            "stale-generation",
+                            reason="resource generation changed before extension",
+                        )
+                        raise ValueError("resource generation changed; session not extended")
+                    extend_session(paths, record, seconds=minutes * 60)
+                elif command == "cancel":
+                    if str(record.get("status") or "") != "active":
+                        raise ValueError("only an active session can be cancelled")
+                    set_session_status(
+                        paths,
+                        record,
+                        "cancelled",
+                        reason="expiry cancelled by operator",
+                    )
+                else:
+                    raise ValueError(f"unsupported session command: {command}")
+                output = _session_output(record)
+        if bool(getattr(ns, "json", False)):
+            print(json.dumps(output, indent=2, sort_keys=True))
+        else:
+            _print_session(output)
+        return 0
+    except (LifecycleBusy, OSError, ValueError) as exc:
+        print(f"ERR: blueprint session failed: {exc}")
+        return OPERATOR_ERROR
+
+
 def _destroyed_blueprint_cost_cleared(payload: dict[str, Any], paths) -> bool:
     """Return true only when every declared step has terminal resource state."""
 
@@ -2649,6 +2920,140 @@ def _wait_for_access_processes(
         time.sleep(0.5)
 
 
+def _session_options(ns, payload: dict[str, Any]) -> tuple[int, str]:
+    minutes = int(getattr(ns, "session_minutes", 0) or 0)
+    if minutes < 0 or minutes > 7 * 24 * 60:
+        raise ValueError("--session-minutes must be between 0 and 10080")
+    action = str(getattr(ns, "on_expiry", "") or "").strip()
+    if minutes == 0 and action:
+        raise ValueError("--on-expiry requires --session-minutes")
+    if minutes > 0 and not action:
+        raise ValueError(
+            "--session-minutes requires --on-expiry protected-release"
+        )
+    if minutes == 0:
+        return 0, ""
+    if str(payload.get("blueprint_ref") or "") not in {
+        "gcp/eve-ng@v1",
+        "gcp/gns3@v1",
+        "gcp/containerlab@v1",
+    }:
+        raise ValueError(
+            "time-bounded access is supported for the GCP EVE-NG, GNS3, "
+            "and Containerlab blueprints"
+        )
+    return minutes * 60, action
+
+
+def _access_resource_generation(
+    payload: dict[str, Any],
+    state: dict[str, Any],
+) -> str:
+    access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
+    outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
+    vms = outputs.get("vms") if isinstance(outputs.get("vms"), dict) else {}
+    identities: dict[str, dict[str, str]] = {}
+    for name, raw in sorted(vms.items()):
+        vm = raw if isinstance(raw, dict) else {}
+        identities[str(name)] = {
+            key: str(vm.get(key) or "")
+            for key in ("vm_id", "vm_name", "zone")
+        }
+    material = {
+        "blueprint_ref": str(payload.get("blueprint_ref") or ""),
+        "state_ref": str(access.get("state_ref") or ""),
+        "state_run_id": str(state.get("run_id") or ""),
+        "state_updated_at": str(state.get("updated_at") or ""),
+        "vms": identities,
+    }
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _session_warning_seconds(duration_seconds: int) -> tuple[int, ...]:
+    return tuple(
+        threshold
+        for threshold in (1800, 600, 300, 60)
+        if threshold < duration_seconds
+    )
+
+
+def _wait_for_managed_access(
+    access_proc: subprocess.Popen,
+    route_proc: subprocess.Popen | None,
+    *,
+    maintenance: Callable[[], None] | None,
+    paths,
+    session_record: dict[str, Any] | None,
+) -> int | None:
+    if session_record is None:
+        return _wait_for_access_processes(
+            access_proc,
+            route_proc,
+            maintenance=maintenance,
+        )
+
+    session_id = str(session_record["session_id"])
+    duration_seconds = int(session_record["duration_seconds"])
+    warned: set[tuple[str, int]] = set()
+    next_maintenance = time.monotonic() + 3
+    while True:
+        access_rc = access_proc.poll()
+        if access_rc is not None:
+            return int(access_rc)
+        if route_proc is not None:
+            route_rc = route_proc.poll()
+            if route_rc is not None:
+                return int(route_rc)
+
+        current = load_session(paths, str(session_record["blueprint_ref"]))
+        if current is None or str(current.get("session_id") or "") != session_id:
+            print("session supervision replaced; access remains open without expiry")
+            return _wait_for_access_processes(
+                access_proc,
+                route_proc,
+                maintenance=maintenance,
+            )
+        session_record.clear()
+        session_record.update(current)
+        status = str(session_record.get("status") or "")
+        if status == "cancelled":
+            print("session expiry cancelled; access remains open")
+            return _wait_for_access_processes(
+                access_proc,
+                route_proc,
+                maintenance=maintenance,
+            )
+        if status != "active":
+            return _wait_for_access_processes(
+                access_proc,
+                route_proc,
+                maintenance=maintenance,
+            )
+
+        deadline = parse_utc(str(session_record["deadline_at"]))
+        now = utc_now()
+        remaining = (deadline - now).total_seconds()
+        if remaining <= 0:
+            print("access session limit reached")
+            return None
+        deadline_key = str(session_record["deadline_at"])
+        for threshold in _session_warning_seconds(duration_seconds):
+            warning = (deadline_key, threshold)
+            if remaining <= threshold and warning not in warned:
+                print(f"session expires in {threshold // 60} minutes")
+                warned.add(warning)
+
+        if maintenance is not None and time.monotonic() >= next_maintenance:
+            try:
+                maintenance()
+            except Exception as exc:
+                if verbose_enabled():
+                    print(f"WARN: device discovery refresh failed: {exc}")
+            next_maintenance = time.monotonic() + 8
+        time.sleep(0.5)
+
+
 def _combine_maintenance(
     *callbacks: Callable[[], None] | None,
 ) -> Callable[[], None] | None:
@@ -2672,8 +3077,11 @@ def _combine_maintenance(
 
 def run_access(ns) -> int:
     native_console_stop: Callable[[], None] | None = None
+    session_record: dict[str, Any] | None = None
+    paths = None
     try:
         payload = _resolve_and_validate(ns)
+        session_seconds, expiry_action = _session_options(ns, payload)
         access = payload.get("access") if isinstance(payload.get("access"), dict) else {}
         if not access:
             raise ValueError("blueprint does not declare an access path")
@@ -2682,6 +3090,21 @@ def run_access(ns) -> int:
         state_ref = str(access.get("state_ref") or "").strip()
         module_ref, state_instance = split_module_state_ref(state_ref)
         state = read_module_state(paths.state_dir, module_ref, state_instance=state_instance)
+        if session_seconds:
+            env_name = str(getattr(ns, "env", None) or paths.root.name).strip()
+            with LifecycleLock(paths, "start access session"):
+                session_record = start_session(
+                    paths,
+                    env_name=env_name,
+                    blueprint_ref=str(payload["blueprint_ref"]),
+                    state_ref=state_ref,
+                    resource_generation=_access_resource_generation(payload, state),
+                    duration_seconds=session_seconds,
+                    expiry_action=expiry_action,
+                )
+            print(f"session deadline: {session_record['deadline_at']}")
+            print(f"expiry action: {session_record['expiry_action']}")
+            print(f"session run record: {session_record['run_record']}")
         outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
         vms = outputs.get("vms") if isinstance(outputs.get("vms"), dict) else {}
         if not vms:
@@ -2817,6 +3240,12 @@ def run_access(ns) -> int:
             proc = subprocess.Popen(argv, cwd=str(Path.home()))
             time.sleep(2)
             if proc.poll() is not None:
+                _close_access_session(
+                    paths,
+                    session_record,
+                    "interrupted",
+                    reason=f"access tunnel exited during startup with rc={proc.returncode}",
+                )
                 return OPERATOR_ERROR
             if native_console_mode == "gns3-api":
                 _wait_for_local_port(port, proc)
@@ -2883,15 +3312,31 @@ def run_access(ns) -> int:
                 open_operator_url(url)
             print("press Ctrl-C to close access")
             try:
-                rc = _wait_for_access_processes(
+                rc = _wait_for_managed_access(
                     proc,
                     route_proc,
                     maintenance=maintenance,
+                    paths=paths,
+                    session_record=session_record,
                 )
                 _stop_lab_route(route_proc, route_plan)
                 if native_console_stop is not None:
                     native_console_stop()
                 _stop_process(proc)
+                if rc is None:
+                    print("access closed")
+                    return _expire_access_session(
+                        ns,
+                        payload,
+                        paths,
+                        session_record,
+                    )
+                _close_access_session(
+                    paths,
+                    session_record,
+                    "completed",
+                    reason=f"access process exited with rc={rc}",
+                )
                 return rc
             except KeyboardInterrupt:
                 _stop_lab_route(route_proc, route_plan)
@@ -2899,6 +3344,12 @@ def run_access(ns) -> int:
                     native_console_stop()
                 _stop_process(proc)
                 print("access closed")
+                _close_access_session(
+                    paths,
+                    session_record,
+                    "cancelled",
+                    reason="access closed by operator",
+                )
                 return _offer_access_close_destroy(ns, payload, state)
 
         vm_id = str(vm.get("vm_id") or "").strip()
@@ -3039,6 +3490,12 @@ def run_access(ns) -> int:
         time.sleep(2)
         if proc.poll() is not None:
             _stop_process(iap_proc)
+            _close_access_session(
+                paths,
+                session_record,
+                "interrupted",
+                reason=f"access tunnel exited during startup with rc={proc.returncode}",
+            )
             return OPERATOR_ERROR
         if native_console_mode == "gns3-api":
             _wait_for_local_port(port, proc)
@@ -3104,16 +3561,33 @@ def run_access(ns) -> int:
             open_operator_url(url)
         print("press Ctrl-C to close access")
         try:
-            rc = _wait_for_access_processes(
+            rc = _wait_for_managed_access(
                 proc,
                 route_proc,
                 maintenance=maintenance,
+                paths=paths,
+                session_record=session_record,
             )
             _stop_lab_route(route_proc, route_plan)
             if native_console_stop is not None:
                 native_console_stop()
             _stop_process(proc)
             _stop_process(iap_proc)
+            if rc is None:
+                print("access closed")
+                return _expire_access_session(
+                    ns,
+                    payload,
+                    paths,
+                    session_record,
+                    cost_estimate=cost_estimate,
+                )
+            _close_access_session(
+                paths,
+                session_record,
+                "completed",
+                reason=f"access process exited with rc={rc}",
+            )
             return rc
         except KeyboardInterrupt:
             _stop_lab_route(route_proc, route_plan)
@@ -3122,6 +3596,12 @@ def run_access(ns) -> int:
             _stop_process(proc)
             _stop_process(iap_proc)
             print("access closed")
+            _close_access_session(
+                paths,
+                session_record,
+                "cancelled",
+                reason="access closed by operator",
+            )
             return _offer_access_close_destroy(
                 ns,
                 payload,
@@ -3130,11 +3610,39 @@ def run_access(ns) -> int:
                 cost_estimate=cost_estimate,
                 access_started_at=access_started_at,
             )
+    except KeyboardInterrupt:
+        if native_console_stop is not None:
+            native_console_stop()
+        if "route_proc" in locals():
+            _stop_lab_route(route_proc, route_plan)
+        if "proc" in locals():
+            _stop_process(proc)
+        if "iap_proc" in locals():
+            _stop_process(iap_proc)
+        if paths is not None:
+            _close_access_session(
+                paths,
+                session_record,
+                "cancelled",
+                reason="access interrupted by operator",
+            )
+        raise
     except Exception as exc:
         if native_console_stop is not None:
             native_console_stop()
+        if "route_proc" in locals():
+            _stop_lab_route(route_proc, route_plan)
+        if "proc" in locals():
+            _stop_process(proc)
         if "iap_proc" in locals():
             _stop_process(iap_proc)
+        if paths is not None:
+            _close_access_session(
+                paths,
+                session_record,
+                "interrupted",
+                reason=str(exc),
+            )
         print(f"ERR: blueprint access failed: {exc}")
         return OPERATOR_ERROR
 
@@ -4058,6 +4566,33 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
 
 
 def run_destroy(ns) -> int:
+    if not bool(getattr(ns, "execute", False)) or bool(
+        getattr(ns, "_lifecycle_lock_held", False)
+    ):
+        return _run_destroy_unlocked(ns)
+    try:
+        require_runtime_selection(
+            getattr(ns, "root", None),
+            getattr(ns, "env", None),
+            command_label="hyops blueprint destroy",
+        )
+        paths = resolve_runtime_paths(
+            getattr(ns, "root", None),
+            getattr(ns, "env", None),
+        )
+        ensure_layout(paths)
+        with LifecycleLock(paths, "blueprint destroy"):
+            setattr(ns, "_lifecycle_lock_held", True)
+            try:
+                return _run_destroy_unlocked(ns)
+            finally:
+                setattr(ns, "_lifecycle_lock_held", False)
+    except (LifecycleBusy, OSError, ValueError) as exc:
+        print(f"ERR: blueprint destroy failed: {exc}")
+        return OPERATOR_ERROR
+
+
+def _run_destroy_unlocked(ns) -> int:
     try:
         payload = _resolve_and_validate(ns)
     except Exception as exc:
@@ -4525,6 +5060,33 @@ def run_destroy(ns) -> int:
 
 
 def run_rebuild(ns) -> int:
+    if not bool(getattr(ns, "execute", False)) or bool(
+        getattr(ns, "_lifecycle_lock_held", False)
+    ):
+        return _run_rebuild_unlocked(ns)
+    try:
+        require_runtime_selection(
+            getattr(ns, "root", None),
+            getattr(ns, "env", None),
+            command_label="hyops blueprint rebuild",
+        )
+        paths = resolve_runtime_paths(
+            getattr(ns, "root", None),
+            getattr(ns, "env", None),
+        )
+        ensure_layout(paths)
+        with LifecycleLock(paths, "blueprint rebuild"):
+            setattr(ns, "_lifecycle_lock_held", True)
+            try:
+                return _run_rebuild_unlocked(ns)
+            finally:
+                setattr(ns, "_lifecycle_lock_held", False)
+    except (LifecycleBusy, OSError, ValueError) as exc:
+        print(f"ERR: blueprint rebuild failed: {exc}")
+        return OPERATOR_ERROR
+
+
+def _run_rebuild_unlocked(ns) -> int:
     try:
         payload = _resolve_and_validate(ns)
     except Exception as exc:
@@ -4668,6 +5230,7 @@ __all__ = [
     "run_validate",
     "run_preflight",
     "run_plan",
+    "run_session",
     "run_deploy",
     "run_destroy",
     "run_rebuild",

--- a/hyops/blueprint/tests/test_access.py
+++ b/hyops/blueprint/tests/test_access.py
@@ -6,6 +6,8 @@ import io
 import socket
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,8 +15,10 @@ from unittest.mock import Mock, patch
 
 from hyops.blueprint.command import (
     _access_known_hosts_file,
+    _access_resource_generation,
     _combine_maintenance,
     _discover_gns3_consoles,
+    _expire_access_session,
     _extract_access_host,
     _gns3_console_refresher,
     _native_console_refresher,
@@ -24,11 +28,16 @@ from hyops.blueprint.command import (
     _print_native_console_client_guidance,
     _require_local_ports_available,
     _runtime_access_secret,
+    _session_options,
+    _session_warning_seconds,
     _ssh_access_error,
     _ssh_access_trust_options,
     _wait_for_local_port,
+    _wait_for_managed_access,
 )
+from hyops.blueprint.schema import load_blueprint
 from hyops.runtime.cost import CostEstimate
+from hyops.runtime.exitcodes import OPERATOR_ERROR
 
 
 class _TTY(io.StringIO):
@@ -37,6 +46,260 @@ class _TTY(io.StringIO):
 
 
 class BlueprintAccessTests(unittest.TestCase):
+    def test_session_limit_requires_explicit_protected_release(self) -> None:
+        payload = {"blueprint_ref": "gcp/eve-ng@v1"}
+        self.assertEqual(
+            _session_options(
+                SimpleNamespace(
+                    session_minutes=90,
+                    on_expiry="protected-release",
+                ),
+                payload,
+            ),
+            (5400, "protected-release"),
+        )
+        self.assertEqual(
+            _session_options(
+                SimpleNamespace(session_minutes=0, on_expiry=""),
+                payload,
+            ),
+            (0, ""),
+        )
+        with self.assertRaisesRegex(ValueError, "requires --on-expiry"):
+            _session_options(
+                SimpleNamespace(session_minutes=90, on_expiry=""),
+                payload,
+            )
+        with self.assertRaisesRegex(ValueError, "between 0 and 10080"):
+            _session_options(
+                SimpleNamespace(
+                    session_minutes=10081,
+                    on_expiry="protected-release",
+                ),
+                payload,
+            )
+        with self.assertRaisesRegex(ValueError, "supported for the GCP"):
+            _session_options(
+                SimpleNamespace(
+                    session_minutes=90,
+                    on_expiry="protected-release",
+                ),
+                {"blueprint_ref": "onprem/eve-ng@v1"},
+            )
+
+    def test_session_warning_schedule_is_deterministic(self) -> None:
+        self.assertEqual(_session_warning_seconds(3600), (1800, 600, 300, 60))
+        self.assertEqual(_session_warning_seconds(600), (300, 60))
+
+    def test_managed_access_stops_waiting_at_the_deadline(self) -> None:
+        process = Mock()
+        process.poll.return_value = None
+        record = {
+            "session_id": "session-one",
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "status": "active",
+            "deadline_at": "2026-08-26T12:00:00Z",
+            "duration_seconds": 3600,
+        }
+        with (
+            patch("hyops.blueprint.command.load_session", return_value=dict(record)),
+            patch(
+                "hyops.blueprint.command.utc_now",
+                return_value=datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc),
+            ),
+            redirect_stdout(io.StringIO()),
+        ):
+            rc = _wait_for_managed_access(
+                process,
+                None,
+                maintenance=None,
+                paths=SimpleNamespace(),
+                session_record=record,
+            )
+
+        self.assertIsNone(rc)
+
+    def test_managed_access_observes_external_cancellation(self) -> None:
+        process = Mock()
+        process.poll.return_value = None
+        record = {
+            "session_id": "session-one",
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "status": "active",
+            "deadline_at": "2026-08-26T13:00:00Z",
+            "duration_seconds": 3600,
+        }
+        cancelled = dict(record, status="cancelled")
+        with (
+            patch("hyops.blueprint.command.load_session", return_value=cancelled),
+            patch(
+                "hyops.blueprint.command._wait_for_access_processes",
+                return_value=0,
+            ) as wait,
+            redirect_stdout(io.StringIO()),
+        ):
+            rc = _wait_for_managed_access(
+                process,
+                None,
+                maintenance=None,
+                paths=SimpleNamespace(),
+                session_record=record,
+            )
+
+        self.assertEqual(rc, 0)
+        wait.assert_called_once()
+
+    def test_resource_generation_changes_with_runtime_state(self) -> None:
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {"state_ref": "platform/gcp/platform-vm#gcp_eve_ng_vm"},
+        }
+        state = {
+            "run_id": "apply-one",
+            "updated_at": "2026-08-26T12:00:00Z",
+            "outputs": {
+                "vms": {
+                    "eve-ng-01": {
+                        "vm_id": "projects/p/zones/z/instances/eve-ng-01",
+                        "vm_name": "eve-ng-01",
+                        "zone": "z",
+                    }
+                }
+            },
+        }
+        first = _access_resource_generation(payload, state)
+        state["run_id"] = "apply-two"
+        self.assertNotEqual(first, _access_resource_generation(payload, state))
+
+    def test_expired_session_selects_verified_archive_and_destroy(self) -> None:
+        ns = SimpleNamespace(env="demo-lab", archive_before_destroy=False)
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {"state_ref": "platform/test/vm#vm"},
+            "archive_before_destroy": {"module_ref": "platform/test/archive"},
+        }
+        state = {"run_id": "apply-one", "updated_at": "now", "outputs": {"vms": {}}}
+        generation = _access_resource_generation(payload, state)
+        record = {
+            "session_id": "session-one",
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "status": "active",
+            "resource_generation": generation,
+        }
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+        with (
+            patch("hyops.blueprint.command.LifecycleLock"),
+            patch("hyops.blueprint.command.load_session", return_value=record),
+            patch("hyops.blueprint.command.read_module_state", return_value=state),
+            patch("hyops.blueprint.command.save_session"),
+            patch("hyops.blueprint.command.run_destroy", return_value=0) as destroy,
+        ):
+            rc = _expire_access_session(ns, payload, paths, record)
+
+        self.assertEqual(rc, 0)
+        destroy_ns = destroy.call_args.args[0]
+        self.assertTrue(destroy_ns.execute)
+        self.assertTrue(destroy_ns.yes)
+        self.assertTrue(destroy_ns.archive_before_destroy)
+        self.assertFalse(destroy_ns.skip_archive)
+
+    def test_expiry_uses_each_blueprint_preservation_contract(self) -> None:
+        root = Path(__file__).resolve().parents[3]
+        cases = {
+            "gcp/eve-ng@v1": True,
+            "gcp/gns3@v1": True,
+            "gcp/containerlab@v1": False,
+        }
+        for blueprint_ref, expects_archive in cases.items():
+            provider, workload = blueprint_ref.split("/", 1)
+            payload = load_blueprint(root / "blueprints" / provider / workload / "blueprint.yml")
+            ns = SimpleNamespace(env="acceptance", archive_before_destroy=False)
+            state = {"run_id": "apply-one", "updated_at": "now", "outputs": {"vms": {}}}
+            generation = _access_resource_generation(payload, state)
+            record = {
+                "session_id": "session-one",
+                "blueprint_ref": blueprint_ref,
+                "status": "active",
+                "resource_generation": generation,
+            }
+            paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+            with (
+                self.subTest(blueprint_ref=blueprint_ref),
+                patch("hyops.blueprint.command.LifecycleLock"),
+                patch("hyops.blueprint.command.load_session", return_value=record),
+                patch("hyops.blueprint.command.read_module_state", return_value=state),
+                patch("hyops.blueprint.command.save_session"),
+                patch("hyops.blueprint.command.run_destroy", return_value=0) as destroy,
+                redirect_stdout(io.StringIO()),
+            ):
+                rc = _expire_access_session(ns, payload, paths, record)
+
+            self.assertEqual(rc, 0)
+            destroy_ns = destroy.call_args.args[0]
+            self.assertEqual(destroy_ns.archive_before_destroy, expects_archive)
+            self.assertTrue(destroy_ns.yes)
+
+    def test_expiry_retains_environment_when_preservation_fails(self) -> None:
+        ns = SimpleNamespace(env="demo-lab", archive_before_destroy=False)
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "access": {"state_ref": "platform/test/vm#vm"},
+            "archive_before_destroy": {"module_ref": "platform/test/archive"},
+        }
+        state = {"run_id": "apply-one", "updated_at": "now", "outputs": {"vms": {}}}
+        record = {
+            "session_id": "session-one",
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "status": "active",
+            "resource_generation": _access_resource_generation(payload, state),
+        }
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+        with (
+            patch("hyops.blueprint.command.LifecycleLock"),
+            patch("hyops.blueprint.command.load_session", return_value=record),
+            patch("hyops.blueprint.command.read_module_state", return_value=state),
+            patch("hyops.blueprint.command.save_session"),
+            patch(
+                "hyops.blueprint.command.run_destroy",
+                return_value=OPERATOR_ERROR,
+            ),
+            redirect_stdout(io.StringIO()),
+        ):
+            rc = _expire_access_session(ns, payload, paths, record)
+
+        self.assertEqual(rc, OPERATOR_ERROR)
+        self.assertEqual(record["status"], "retained-after-failure")
+        self.assertFalse(record["outcome"]["resources_released"])
+
+    def test_expiry_rejects_a_changed_resource_generation(self) -> None:
+        ns = SimpleNamespace(env="demo-lab", archive_before_destroy=False)
+        payload = {
+            "blueprint_ref": "gcp/gns3@v1",
+            "access": {"state_ref": "platform/test/vm#vm"},
+        }
+        state = {"run_id": "apply-two", "updated_at": "now", "outputs": {"vms": {}}}
+        record = {
+            "session_id": "session-one",
+            "blueprint_ref": "gcp/gns3@v1",
+            "status": "active",
+            "resource_generation": "older-generation",
+        }
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+        with (
+            patch("hyops.blueprint.command.LifecycleLock"),
+            patch("hyops.blueprint.command.load_session", return_value=record),
+            patch("hyops.blueprint.command.read_module_state", return_value=state),
+            patch("hyops.blueprint.command.save_session"),
+            patch("hyops.blueprint.access_session.save_session"),
+            patch("hyops.blueprint.command.run_destroy") as destroy,
+            redirect_stdout(io.StringIO()),
+        ):
+            rc = _expire_access_session(ns, payload, paths, record)
+
+        self.assertEqual(rc, OPERATOR_ERROR)
+        self.assertEqual(record["status"], "stale-generation")
+        destroy.assert_not_called()
+
     def test_host_key_alarm_is_replaced_with_operator_guidance(self) -> None:
         message = _ssh_access_error(
             "WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!\nHost key verification failed.",

--- a/hyops/blueprint/tests/test_access_session.py
+++ b/hyops/blueprint/tests/test_access_session.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.blueprint.access_session import (
+    LifecycleBusy,
+    LifecycleLock,
+    effective_status,
+    extend_session,
+    load_session,
+    session_state_path,
+    start_session,
+)
+from hyops.blueprint.command import run_destroy, run_rebuild, run_session
+from hyops.runtime.exitcodes import OPERATOR_ERROR
+
+
+def _paths(root: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        root=root,
+        meta_dir=root / "meta",
+        logs_dir=root / "logs",
+    )
+
+
+class AccessSessionStateTests(TestCase):
+    def test_start_persists_authority_and_run_record(self) -> None:
+        now = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record = start_session(
+                paths,
+                env_name="demo-lab",
+                blueprint_ref="gcp/eve-ng@v1",
+                state_ref="platform/gcp/platform-vm#gcp_eve_ng_vm",
+                resource_generation="generation-one",
+                duration_seconds=3600,
+                expiry_action="protected-release",
+                now=now,
+                pid=1234,
+            )
+
+            stored = load_session(paths, "gcp/eve-ng@v1")
+            self.assertEqual(stored, record)
+            self.assertEqual(record["status"], "active")
+            self.assertEqual(record["deadline_at"], "2026-08-26T13:00:00Z")
+            self.assertEqual(record["resource_generation"], "generation-one")
+            self.assertTrue(Path(record["run_record"]).is_file())
+            self.assertNotIn("credential", json.dumps(record).lower())
+
+    def test_effective_status_reports_lost_supervision(self) -> None:
+        record = {
+            "status": "active",
+            "deadline_at": "2026-08-26T13:00:00Z",
+        }
+        before = datetime(2026, 8, 26, 12, 30, tzinfo=timezone.utc)
+        after = datetime(2026, 8, 26, 13, 1, tzinfo=timezone.utc)
+        self.assertEqual(
+            effective_status(record, now=before, supervisor_is_running=False),
+            "unsupervised",
+        )
+        self.assertEqual(
+            effective_status(record, now=after, supervisor_is_running=False),
+            "overdue-unsupervised",
+        )
+
+    def test_extend_adds_to_the_existing_deadline(self) -> None:
+        now = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            record = start_session(
+                paths,
+                env_name="demo-lab",
+                blueprint_ref="gcp/gns3@v1",
+                state_ref="platform/gcp/platform-vm#gcp_gns3_vm",
+                resource_generation="generation-one",
+                duration_seconds=3600,
+                expiry_action="protected-release",
+                now=now,
+            )
+            extend_session(
+                paths,
+                record,
+                seconds=1800,
+                now=now + timedelta(minutes=10),
+            )
+
+            self.assertEqual(record["deadline_at"], "2026-08-26T13:30:00Z")
+            self.assertEqual(record["extension_count"], 1)
+
+    def test_lifecycle_lock_rejects_a_second_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            with LifecycleLock(paths, "first operation"):
+                with self.assertRaisesRegex(LifecycleBusy, "first operation"):
+                    with LifecycleLock(paths, "second operation"):
+                        pass
+            self.assertFalse((paths.meta_dir / "blueprint_lifecycle.lock").exists())
+
+    def test_session_file_is_scoped_by_blueprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = session_state_path(_paths(Path(tmp)), "gcp/containerlab@v1")
+            self.assertEqual(path.name, "gcp_containerlab_v1.json")
+
+    def test_lifecycle_lock_blocks_destroy_and_rebuild(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            cases = (
+                (run_destroy, "_run_destroy_unlocked"),
+                (run_rebuild, "_run_rebuild_unlocked"),
+            )
+            for command, implementation in cases:
+                ns = SimpleNamespace(root=tmp, env=None, execute=True)
+                with (
+                    self.subTest(command=command.__name__),
+                    LifecycleLock(paths, "active session mutation"),
+                    patch("hyops.blueprint.command.require_runtime_selection"),
+                    patch(
+                        "hyops.blueprint.command.resolve_runtime_paths",
+                        return_value=paths,
+                    ),
+                    patch("hyops.blueprint.command.ensure_layout"),
+                    patch(
+                        f"hyops.blueprint.command.{implementation}"
+                    ) as mutation,
+                    patch("sys.stdout", io.StringIO()),
+                ):
+                    self.assertEqual(command(ns), OPERATOR_ERROR)
+                mutation.assert_not_called()
+
+    def test_cancel_records_a_final_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            start_session(
+                paths,
+                env_name="demo-lab",
+                blueprint_ref="gcp/eve-ng@v1",
+                state_ref="platform/gcp/platform-vm#gcp_eve_ng_vm",
+                resource_generation="generation-one",
+                duration_seconds=3600,
+                expiry_action="protected-release",
+            )
+            ns = SimpleNamespace(
+                root=None,
+                env="demo-lab",
+                session_cmd="cancel",
+                json=False,
+            )
+            with (
+                patch(
+                    "hyops.blueprint.command._resolve_and_validate",
+                    return_value={"blueprint_ref": "gcp/eve-ng@v1"},
+                ),
+                patch("hyops.blueprint.command.require_runtime_selection"),
+                patch(
+                    "hyops.blueprint.command.resolve_runtime_paths",
+                    return_value=paths,
+                ),
+                patch("sys.stdout", io.StringIO()),
+            ):
+                self.assertEqual(run_session(ns), 0)
+
+            record = load_session(paths, "gcp/eve-ng@v1")
+            self.assertEqual(record["status"], "cancelled")
+            self.assertEqual(
+                record["outcome"]["reason"],
+                "expiry cancelled by operator",
+            )
+            run_record = json.loads(
+                Path(record["run_record"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(run_record["deadline_at"], record["deadline_at"])
+            self.assertEqual(run_record["expiry_action"], "protected-release")
+            self.assertEqual(run_record["status"], "cancelled")
+
+    def test_extend_rejects_a_changed_resource_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _paths(Path(tmp))
+            start_session(
+                paths,
+                env_name="demo-lab",
+                blueprint_ref="gcp/gns3@v1",
+                state_ref="platform/gcp/platform-vm#gcp_gns3_vm",
+                resource_generation="generation-one",
+                duration_seconds=3600,
+                expiry_action="protected-release",
+            )
+            ns = SimpleNamespace(
+                root=None,
+                env="demo-lab",
+                session_cmd="extend",
+                minutes=30,
+                json=False,
+            )
+            with (
+                patch(
+                    "hyops.blueprint.command._resolve_and_validate",
+                    return_value={"blueprint_ref": "gcp/gns3@v1"},
+                ),
+                patch("hyops.blueprint.command.require_runtime_selection"),
+                patch(
+                    "hyops.blueprint.command.resolve_runtime_paths",
+                    return_value=paths,
+                ),
+                patch(
+                    "hyops.blueprint.command._current_access_generation",
+                    return_value="generation-two",
+                ),
+                patch("sys.stdout", io.StringIO()),
+            ):
+                self.assertEqual(run_session(ns), OPERATOR_ERROR)
+
+            record = load_session(paths, "gcp/gns3@v1")
+            self.assertEqual(record["status"], "stale-generation")


### PR DESCRIPTION
## Summary

- add opt-in foreground-supervised access limits for the GCP EVE-NG, GNS3 and Containerlab blueprints
- require an explicit duration and protected-release action
- bind each session to its environment, blueprint and current resource generation
- serialize session changes with destroy and rebuild operations
- delegate expiry to the existing archive or recovery lifecycle and retain resources on failure
- persist deadline, action, supervision state and final outcome in environment-scoped run records

## Validation

- `bash tools/ci/check-python.sh` (379 tests)
- `bash tools/ci/check-ruff.sh`
- blueprint access and session CLI help checks
- live GCP expiry acceptance not run in this workspace

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.

Closes #337