### PR TITLE
Fix GNS3 managed image validation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Fixed
 
+- Aligned GNS3 image validation with compact archive declarations, optional checksums, secondary QEMU disks, and host-bound IOU licence diagnostics.
 - Rendered parent-managed destroy steps as pending rather than failed while the parent step is still running.
 - Allowed disposable GNS3 guest operations to be cleared with their parent VM when guest SSH is unavailable during teardown.
 - Preserved concise module failure details after a blueprint progress step fails.

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -181,6 +181,8 @@ steps:
       # load_vault_env: true
       # required_env: ["GNS3_SERVER_PASSWORD", "GNS3_IOU_LICENSE"]
       # gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
+      # filename is required. checksum is optional. An archive must contain one
+      # image payload for registration.
       gns3_images_items:
         - name: "Alpine Linux 3.24"
           url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -149,6 +149,8 @@ steps:
       # load_vault_env: true
       # required_env: ["GNS3_SERVER_PASSWORD", "GNS3_IOU_LICENSE"]
       # gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
+      # filename is required. checksum is optional. An archive must contain one
+      # image payload for registration.
       gns3_images_items:
         - name: "Alpine Linux 3.24"
           url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"

--- a/hyops/drivers/config/ansible/results.py
+++ b/hyops/drivers/config/ansible/results.py
@@ -18,6 +18,11 @@ _IOL_HOST_IDENTIFIER = re.compile(
     r"Host ID:\s*([A-Za-z0-9][A-Za-z0-9_.:-]*)",
     re.IGNORECASE,
 )
+_GNS3_IOU_HOST_MISMATCH = re.compile(
+    r"does not contain a valid licence entry for this GNS3 host\.\s+Hostname:\s*"
+    r"([A-Za-z0-9][A-Za-z0-9_.-]*)",
+    re.IGNORECASE,
+)
 
 
 def ansible_error_hint(
@@ -60,6 +65,25 @@ def ansible_error_hint(
             "IOL licence does not match this EVE-NG host. "
             f"Hostname: {hostname}.{host_identifier} "
             "Update EVENG_IOL_LICENSE with an authorised iourc for this host, then rerun. "
+            "No images were changed."
+        )
+
+    gns3_iou_host_mismatch = _GNS3_IOU_HOST_MISMATCH.search(tail)
+    if (
+        module_ref.strip().lower() == "platform/linux/gns3-images"
+        and gns3_iou_host_mismatch
+    ):
+        hostname = gns3_iou_host_mismatch.group(1).rstrip(".")
+        host_identifier_match = _IOL_HOST_IDENTIFIER.search(tail)
+        host_identifier = (
+            f" Host ID: {host_identifier_match.group(1).rstrip('.')}."
+            if host_identifier_match
+            else ""
+        )
+        return (
+            "IOU licence does not match this GNS3 host. "
+            f"Hostname: {hostname}.{host_identifier} "
+            "Update GNS3_IOU_LICENSE with an authorised iourc for this host, then rerun. "
             "No images were changed."
         )
 

--- a/hyops/tests/test_ansible_results.py
+++ b/hyops/tests/test_ansible_results.py
@@ -65,6 +65,35 @@ class AnsibleResultHintTests(unittest.TestCase):
             "No images were changed.",
         )
 
+    def test_gns3_images_reports_iou_hostname_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            (evidence_dir / "ansible_apply.stdout.txt").write_text(
+                "fatal: [gns3-01]: FAILED! => {\n"
+                '  "msg": "The supplied iourc document does not contain a valid '
+                "licence entry for this GNS3 host. Hostname: "
+                "platform-gns3-lab-gns3-01. Host ID: 007f0100. Obtain an authorised "
+                "iourc for this host, update GNS3_IOU_LICENSE, and rerun.\"\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            hint = ansible_error_hint(
+                command_name="apply",
+                module_ref="platform/linux/gns3-images",
+                inputs={},
+                evidence_dir=evidence_dir,
+                label="ansible_apply",
+            )
+
+        self.assertEqual(
+            hint,
+            "IOU licence does not match this GNS3 host. "
+            "Hostname: platform-gns3-lab-gns3-01. Host ID: 007f0100. "
+            "Update GNS3_IOU_LICENSE with an authorised iourc for this host, then rerun. "
+            "No images were changed.",
+        )
+
     def test_eve_ng_archive_reports_running_nodes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             evidence_dir = Path(tmp)

--- a/hyops/validators/platform/linux/gns3_images.py
+++ b/hyops/validators/platform/linux/gns3_images.py
@@ -39,6 +39,7 @@ def _validate_template(value: Any, label: str) -> None:
         "category",
         "console_type",
         "hda_disk_interface",
+        "hdb_disk_interface",
         "platform",
         "qemu_path",
         "symbol",
@@ -71,16 +72,39 @@ def _validate_images(value: Any) -> bool:
     if not isinstance(value, list) or not value:
         raise ValueError("inputs.gns3_images_items must be a non-empty list")
 
-    names: set[str] = set()
-    filenames: set[str] = set()
+    template_names: set[str] = set()
     iou_requested = False
     for index, raw in enumerate(value, start=1):
         label = f"inputs.gns3_images_items[{index}]"
         item = require_mapping(raw, label)
-        name = require_non_empty_str(item.get("name"), f"{label}.name")
+        name_value = item.get("name")
+        filename_value = item.get("filename")
+        template_label_value = item.get("label")
+        if name_value is None and template_label_value is None:
+            raise ValueError(f"{label} requires name or label")
+        if name_value is None and filename_value is None:
+            raise ValueError(f"{label} requires name or filename")
+        name = (
+            require_non_empty_str(name_value, f"{label}.name")
+            if name_value is not None
+            else None
+        )
+        template_name = (
+            require_non_empty_str(template_label_value, f"{label}.label")
+            if template_label_value is not None
+            else re.sub(r"(?i)\.(tar\.gz|tgz|zip|gz)$", "", name or "")
+        )
         url = require_non_empty_str(item.get("url"), f"{label}.url")
-        filename = require_non_empty_str(item.get("filename"), f"{label}.filename")
-        checksum = require_non_empty_str(item.get("checksum"), f"{label}.checksum")
+        filename = (
+            require_non_empty_str(filename_value, f"{label}.filename")
+            if filename_value is not None
+            else None
+        )
+        checksum = (
+            require_non_empty_str(item.get("checksum"), f"{label}.checksum")
+            if item.get("checksum") is not None
+            else None
+        )
         image_type = require_non_empty_str(
             item.get("type", "qemu"), f"{label}.type"
         )
@@ -88,13 +112,20 @@ def _validate_images(value: Any) -> bool:
         parsed = urlparse(url)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             raise ValueError(f"{label}.url must be an HTTP or HTTPS URL")
-        if filename != PurePath(filename).name or filename in {".", ".."}:
+        if name is not None and (
+            name != PurePath(name).name or name in {".", ".."}
+        ):
+            raise ValueError(f"{label}.name must be a safe basename")
+        if filename is not None and (
+            filename != PurePath(filename).name or filename in {".", ".."}
+        ):
             raise ValueError(f"{label}.filename must be a safe basename")
-        if not _SHA256_RE.fullmatch(checksum):
+        if checksum is not None and not _SHA256_RE.fullmatch(checksum):
             raise ValueError(f"{label}.checksum must use sha256:<64 hex characters>")
-        if image_type not in {"qemu", "iou"}:
-            raise ValueError(f"{label}.type must be qemu or iou")
-        if image_type == "qemu":
+        if image_type not in {"qemu", "iou", "iol"}:
+            raise ValueError(f"{label}.type must be qemu, iou, or iol")
+        normalized_type = "iou" if image_type in {"iou", "iol"} else "qemu"
+        if normalized_type == "qemu":
             disk_type = require_non_empty_str(
                 item.get("disk_type", "hda"), f"{label}.disk_type"
             ).lower()
@@ -102,30 +133,26 @@ def _validate_images(value: Any) -> bool:
                 raise ValueError(f"{label}.disk_type must be hda or cdrom")
         else:
             iou_requested = True
-            if not filename.endswith(".bin"):
-                raise ValueError(f"{label}.filename must end with .bin for IOU")
             if "disk_type" in item:
                 raise ValueError(f"{label}.disk_type is not valid for IOU")
+            source_name = filename or name or ""
             architecture = require_non_empty_str(
                 item.get(
                     "architecture",
-                    "i386" if filename.lower().startswith("i86bi") else "x86_64",
+                    "i386" if "i86bi" in source_name.lower() else "x86_64",
                 ),
                 f"{label}.architecture",
             )
             if architecture not in {"i386", "x86_64"}:
                 raise ValueError(f"{label}.architecture must be i386 or x86_64")
-        if name in names:
-            raise ValueError(f"{label}.name duplicates an earlier declaration")
-        if filename in filenames:
-            raise ValueError(f"{label}.filename duplicates an earlier declaration")
-        names.add(name)
-        filenames.add(filename)
+        if template_name in template_names:
+            raise ValueError(f"{label} resolves to a duplicate template name")
+        template_names.add(template_name)
 
         if item.get("timeout") is not None:
             _positive_int(item["timeout"], f"{label}.timeout")
         if item.get("template") is not None:
-            if image_type == "iou":
+            if normalized_type == "iou":
                 _validate_iou_template(item["template"], f"{label}.template")
             else:
                 _validate_template(item["template"], f"{label}.template")

--- a/hyops/validators/platform/linux/tests/test_gns3_images.py
+++ b/hyops/validators/platform/linux/tests/test_gns3_images.py
@@ -39,12 +39,16 @@ class GNS3ImagesValidatorTests(unittest.TestCase):
                     "disk_type": "hda",
                 }
             ],
-            "missing checksum": [
+            "missing name and label": [
                 {
-                    "name": "test",
                     "url": "https://example.test/image.qcow2",
                     "filename": "image.qcow2",
-                    "disk_type": "hda",
+                }
+            ],
+            "missing source filename": [
+                {
+                    "label": "Test image",
+                    "url": "https://example.test/download",
                 }
             ],
             "unsupported URL": [
@@ -64,17 +68,48 @@ class GNS3ImagesValidatorTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     validate(inputs)
 
-    def test_duplicate_names_and_filenames_are_rejected(self) -> None:
-        for key in ("name", "filename"):
-            with self.subTest(key=key):
-                inputs = valid_inputs()
-                duplicate = deepcopy(inputs["gns3_images_items"][0])
-                duplicate["name"] = "Another image"
-                duplicate["filename"] = "another.iso"
-                duplicate[key] = inputs["gns3_images_items"][0][key]
-                inputs["gns3_images_items"].append(duplicate)
-                with self.assertRaises(ValueError):
-                    validate(inputs)
+    def test_duplicate_template_names_are_rejected(self) -> None:
+        inputs = valid_inputs()
+        duplicate = deepcopy(inputs["gns3_images_items"][0])
+        duplicate["filename"] = "another.iso"
+        inputs["gns3_images_items"].append(duplicate)
+        with self.assertRaisesRegex(ValueError, "duplicate template name"):
+            validate(inputs)
+
+    def test_compact_iol_archive_declaration_is_valid(self) -> None:
+        inputs = valid_inputs()
+        inputs["required_env"].append("GNS3_IOU_LICENSE")
+        inputs["gns3_images_items"] = [
+            {
+                "url": "https://example.test/iol-router.tar.gz",
+                "name": "iol-router.tar.gz",
+                "type": "iol",
+                "label": "Authorised IOL router",
+            }
+        ]
+        validate(inputs)
+
+    def test_label_and_explicit_filename_declaration_is_valid(self) -> None:
+        inputs = valid_inputs()
+        inputs["gns3_images_items"] = [
+            {
+                "label": "Test appliance",
+                "url": "https://example.test/download",
+                "filename": "appliance.qcow2",
+                "template": {"hdb_disk_interface": "virtio"},
+            }
+        ]
+        validate(inputs)
+
+    def test_checksum_remains_optional_but_is_validated_when_present(self) -> None:
+        inputs = valid_inputs()
+        image = inputs["gns3_images_items"][0]
+        image.pop("checksum")
+        validate(inputs)
+
+        image["checksum"] = "sha256:not-a-digest"
+        with self.assertRaisesRegex(ValueError, "checksum must use sha256"):
+            validate(inputs)
 
     def test_iou_image_requires_a_preflighted_license(self) -> None:
         inputs = valid_inputs()

--- a/modules/platform/linux/gns3-images/README.md
+++ b/modules/platform/linux/gns3-images/README.md
@@ -1,9 +1,10 @@
 # platform/linux/gns3-images
 
 Install declared QEMU or IOU images and register them as templates on an
-authenticated GNS3 server. Every URL requires a SHA-256 checksum. Existing
-matching templates are retained; conflicting template names fail without
-replacement.
+authenticated GNS3 server. HTTP, HTTPS and MEGA sources may be raw images or
+archives. A SHA-256 checksum is optional and is verified when supplied.
+Existing matching templates are retained; conflicting template names fail
+without replacement.
 
 ```bash
 hyops apply --env lab \

--- a/modules/platform/linux/gns3-images/spec.yml
+++ b/modules/platform/linux/gns3-images/spec.yml
@@ -5,7 +5,7 @@ module_ref: "platform/linux/gns3-images"
 
 metadata:
   title: "Linux GNS3 Images"
-  description: "Install checksum-verified QEMU images and register usable GNS3 templates."
+  description: "Install declared QEMU or IOU images and register usable GNS3 templates."
 
 requirements:
   credentials: []


### PR DESCRIPTION
Closes #340

## Summary

- Align the Core validator with the pinned GNS3 image role for compact and explicit QEMU, IOU and IOL declarations.
- Keep URL, optional SHA-256, safe filename, template-name and licence-preflight validation at the Core boundary.
- Report the GNS3 hostname and host ID when an IOU licence is bound to another host.
- Correct the module description and README to match the supported contract.

## Validation

- `python3 -m unittest hyops.validators.platform.linux.tests.test_gns3_images hyops.tests.test_ansible_results`
- `bash tools/ci/check-python.sh` (363 tests)
- `bash tools/ci/check-ruff.sh`
- `bash tools/ci/check-yaml.sh`
- `git diff --check`

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.