### PR TITLE
chore: pin network lab collections to 0.1.10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 ### Changed
 
 - Applied the controlled keep, archive or destroy decision when GNS3 access closes.
-- Pinned `hybridops.app` and `hybridops.helper` to `0.1.9` for the Containerlab and device-automation release set.
+- Pinned `hybridops.app` and `hybridops.helper` to `0.1.10` for the network-lab lifecycle release set.
 - Expanded CI coverage across the public CLI surface and every shipped blueprint.
 - Aligned source package and runtime version metadata with the `v0.1.4` release line and added regression coverage for installed version reporting.
 - Kept lifecycle output independent of the selected execution tool and simplified GCP initialization and vault readiness output.

--- a/hyops/setup/tests/test_command.py
+++ b/hyops/setup/tests/test_command.py
@@ -317,49 +317,50 @@ class SetupCommandTests(unittest.TestCase):
 
     def test_targeted_collection_install_has_no_yaml_runtime_dependency(self) -> None:
         installer = REPO_ROOT / "tools" / "setup" / "setup-ansible.sh"
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            runtime = root / "runtime"
-            bin_dir = root / "bin"
-            invocation_log = root / "ansible-galaxy.args"
-            bin_dir.mkdir()
+        for collection in ("helper", "app"):
+            with self.subTest(collection=collection), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                runtime = root / "runtime"
+                bin_dir = root / "bin"
+                invocation_log = root / "ansible-galaxy.args"
+                bin_dir.mkdir()
 
-            (bin_dir / "python3").write_text(
-                f'#!/bin/sh\nexec "{sys.executable}" -S "$@"\n',
-                encoding="utf-8",
-            )
-            (bin_dir / "ansible-galaxy").write_text(
-                '#!/bin/sh\nprintf "%s\\n" "$@" > "$HYOPS_TEST_INVOCATION_LOG"\n',
-                encoding="utf-8",
-            )
-            (bin_dir / "python3").chmod(0o755)
-            (bin_dir / "ansible-galaxy").chmod(0o755)
+                (bin_dir / "python3").write_text(
+                    f'#!/bin/sh\nexec "{sys.executable}" -S "$@"\n',
+                    encoding="utf-8",
+                )
+                (bin_dir / "ansible-galaxy").write_text(
+                    '#!/bin/sh\nprintf "%s\\n" "$@" > "$HYOPS_TEST_INVOCATION_LOG"\n',
+                    encoding="utf-8",
+                )
+                (bin_dir / "python3").chmod(0o755)
+                (bin_dir / "ansible-galaxy").chmod(0o755)
 
-            env = os.environ.copy()
-            env["PATH"] = f"{bin_dir}:{env['PATH']}"
-            env["HYOPS_TEST_INVOCATION_LOG"] = str(invocation_log)
-            result = subprocess.run(
-                [
-                    "bash",
-                    str(installer),
-                    "--root",
-                    str(runtime),
-                    "--collection",
-                    "helper",
-                ],
-                capture_output=True,
-                check=False,
-                env=env,
-                text=True,
-            )
-            invocation = (
-                invocation_log.read_text(encoding="utf-8")
-                if invocation_log.exists()
-                else ""
-            )
+                env = os.environ.copy()
+                env["PATH"] = f"{bin_dir}:{env['PATH']}"
+                env["HYOPS_TEST_INVOCATION_LOG"] = str(invocation_log)
+                result = subprocess.run(
+                    [
+                        "bash",
+                        str(installer),
+                        "--root",
+                        str(runtime),
+                        "--collection",
+                        collection,
+                    ],
+                    capture_output=True,
+                    check=False,
+                    env=env,
+                    text=True,
+                )
+                invocation = (
+                    invocation_log.read_text(encoding="utf-8")
+                    if invocation_log.exists()
+                    else ""
+                )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("hybridops.helper:0.1.9", invocation)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(f"hybridops.{collection}:0.1.10", invocation)
 
     def test_collection_is_rejected_for_non_galaxy_setup(self) -> None:
         output = io.StringIO()

--- a/tools/setup/requirements/ansible.galaxy.yml
+++ b/tools/setup/requirements/ansible.galaxy.yml
@@ -3,10 +3,10 @@ collections:
     version: "0.1.6"
 
   - name: hybridops.helper
-    version: "0.1.9"
+    version: "0.1.10"
 
   - name: hybridops.app
-    version: "0.1.9"
+    version: "0.1.10"
 
   - name: ansible.posix
     version: "1.6.2"


### PR DESCRIPTION
## Summary

- pin `hybridops.app` and `hybridops.helper` to their published 0.1.10 Galaxy releases
- verify targeted setup resolves both exact collection versions without a YAML runtime dependency
- align the current candidate changelog with the released collection set

## Validation

- installed both 0.1.10 artifacts from Ansible Galaxy
- `python3 -m unittest hyops.setup.tests.test_command`
- `bash tools/ci/check-python.sh`
- `bash tools/ci/check-ruff.sh`
- `bash tools/ci/check-yaml.sh`

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.