### PR TITLE
fix: verify local EVE-NG image installs

### DIFF
--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -188,7 +188,12 @@ steps:
       target_port: 22
       ssh_private_key_file: "~/.ssh/id_ed25519"
       ssh_access_mode: "gcp-iap"
+      # Select one source. "url" installs eveng_images_list. To import every
+      # supported file from one workstation folder, use "local" and set the
+      # path below. The URL list is ignored in local mode.
       eveng_images_source: "url"
+      # Local folder scanning is recursive.
+      # eveng_images_local_path: "/path/to/eve-ng-images"
       eveng_images_logging_enabled: true
       eveng_images_generate_report: true
       # Keep authorised IOL licence content in the environment vault, not in

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -168,7 +168,12 @@ steps:
       ssh_proxy_jump_user: "root"
       become: true
       become_user: "root"
+      # Select one source. "url" installs eveng_images_list. To import every
+      # supported file from one workstation folder, use "local" and set the
+      # path below. The URL list is ignored in local mode.
       eveng_images_source: "url"
+      # Local folder scanning is recursive.
+      # eveng_images_local_path: "/path/to/eve-ng-images"
       eveng_images_logging_enabled: true
       eveng_images_generate_report: true
       # Keep authorised IOL licence content in the environment vault, not in

--- a/hyops/tests/test_eve_ng_images_module.py
+++ b/hyops/tests/test_eve_ng_images_module.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from unittest import TestCase
+
+import yaml
+
+
+class EVENGImagesModuleTest(TestCase):
+    def setUp(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        self.spec = yaml.safe_load(
+            (root / "modules/platform/linux/eve-ng-images/spec.yml").read_text()
+        )
+        self.playbook = yaml.safe_load(
+            (
+                root
+                / "packs/config/ansible/linux/common/platform/"
+                "41-eve-ng-images@v1.0/stack/playbook.yml"
+            ).read_text()
+        )[0]
+
+    def test_module_publishes_requested_and_installed_counts(self) -> None:
+        published = self.spec["outputs"]["publish"]
+        self.assertIn("eveng_images_requested_count", published)
+        self.assertIn("eveng_images_installed_count", published)
+
+    def test_stack_verifies_the_discovered_image_count(self) -> None:
+        verification = self.playbook["post_tasks"][0]["ansible.builtin.assert"]
+        self.assertIn(
+            "eveng_images_requested_count | default(0) | int",
+            verification["that"][1],
+        )
+        output_document = self.playbook["post_tasks"][2]["ansible.builtin.copy"][
+            "content"
+        ]
+        self.assertIn("'eveng_images_requested_count'", output_document)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/modules/platform/linux/eve-ng-images/examples/inputs.min.yml
+++ b/modules/platform/linux/eve-ng-images/examples/inputs.min.yml
@@ -2,7 +2,10 @@ target_host: "CHANGE_ME_TARGET_HOST"
 target_user: "opsadmin"
 ssh_private_key_file: "~/.ssh/id_ed25519"
 
+# Select "url" for eveng_images_list or "local" for one controller folder.
 eveng_images_source: "url"
+# Local folder scanning is recursive.
+# eveng_images_local_path: "/path/to/eve-ng-images"
 # Optional for authorised IOL images on EVE-NG Community Edition:
 # load_vault_env: true
 # required_env: ["EVENG_IOL_LICENSE"]

--- a/packs/config/ansible/linux/common/platform/41-eve-ng-images@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/41-eve-ng-images@v1.0/stack/playbook.yml
@@ -68,10 +68,9 @@
           - eveng_images_install_ready | default(false) | bool
           - >-
             (eveng_images_installed_count | default(0) | int)
-            == ((_hyops_input_eveng_images_list | default([])) | length)
+            == (eveng_images_requested_count | default(0) | int)
         fail_msg: >-
-          The image role did not verify every requested image in the EVE-NG
-          addons layout. Install the pinned hybridops.helper collection and rerun.
+          EVE-NG image installation did not verify every discovered image.
       when: _hyops_input_eveng_images_install | bool
 
     - name: Require verified IOL licence installation
@@ -93,7 +92,11 @@
           {{ {
             'cap.lab.eveng.images': 'ready',
             'eveng_images_source': (eveng_images_source | default('url')),
-            'eveng_images_requested_count': ((eveng_images_list | default([])) | length),
+            'eveng_images_requested_count': (
+              eveng_images_requested_count
+              | default((_hyops_input_eveng_images_list | default([])) | length)
+              | int
+            ),
             'eveng_images_installed_count': (eveng_images_installed_count | default(0) | int),
             'eveng_images_iol_license_ready': (
               eveng_images_iol_license_ready | default(false) | bool


### PR DESCRIPTION
## Summary

- compare EVE-NG readiness with the files discovered from a local source
- publish the requested local image count from the helper result
- document URL and local-folder source selection in the shipped blueprints

## Validation

- `python3 -m unittest -v hyops.blueprint.tests.test_gcp_eve_ng hyops.blueprint.tests.test_onprem_eve_ng hyops.validators.platform.linux.tests.test_eve_ng_images`
- Core quality workflow, including macOS ARM install and uninstall acceptance
- operator acceptance in progress against the macOS candidate package

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.