### PR TITLE
docs: tighten network lab blueprint entry pages

### DIFF
--- a/blueprints/gcp/containerlab@v1/README.md
+++ b/blueprints/gcp/containerlab@v1/README.md
@@ -1,169 +1,30 @@
-# GCP Containerlab v1
+# Containerlab on GCP
 
-This blueprint runs Containerlab on private GCP compute that HybridOps can release after the selected recovery state has been copied off-host and verified.
+`gcp/containerlab@v1` runs an operator-supplied Containerlab topology on private, nested-virtualisation-capable GCP compute. The VM has no public address; configuration and access use IAP.
 
-## Responsibilities
+Containerlab remains authoritative for topology, nodes, links and native save or snapshot behaviour. HybridOps manages host readiness, private access, recovery verification, reconstruction and compute release.
 
-Containerlab remains responsible for:
+## Execution chain
 
-- `.clab.yml` topology semantics
-- nodes and links
-- topology validation and convergence
-- native configuration save
-- vrnetlab snapshot and restore where supported by the node type
-- generated lab runtime state
-- startup-config and licence handling supported by Containerlab
+```text
+private network
+  -> execution host
+  -> Containerlab runtime
+  -> native topology deployment
+  -> health verification
+  -> recovery gate
+```
 
-HybridOps governs the GCP execution lifecycle around the lab: private infrastructure, KVM readiness, Containerlab version verification, recovery policy, off-host retention, compute-release and rebuild order, cost context, and run evidence.
-
-This separation keeps topology and native recovery authority with Containerlab while HybridOps governs when the execution host can be released and reconstructed.
-
-## Feature status
-
-The GCP lifecycle is implemented on Core `main` and has completed end-to-end real-environment validation. The accepted path proved private GCP execution, IAP/SSH access, nested virtualisation and KVM readiness, Containerlab `0.78.0` deployment, independent lab health, off-host recovery verification before original VM deletion, reconstruction on a fresh VM with a different resource identity, one native Containerlab recovery deployment, final health, and final compute cleanup.
-
-See [VALIDATION.md](VALIDATION.md) for the validation record.
-
-## Prepare the runtime blueprint
-
-Create and edit the environment copy:
+The executable contract is [blueprint.yml](blueprint.yml). Initialise an environment copy and set `containerlab_lab_source_dir` to the controller-side directory containing `lab.clab.yml` and its relative files:
 
 ```bash
-ref=gcp/containerlab@v1
-hyops blueprint init --env <env> --ref "$ref"
-hyops blueprint edit --env <env> --ref "$ref"
+hyops blueprint init --env <env> --ref gcp/containerlab@v1 --edit
 ```
 
-Set:
+Container images remain native references in the topology. The blueprint can verify declared references and optionally permit registry pulls. Licence material remains in its authorised source and must not be embedded in the public blueprint.
 
-```text
-gcp_containerlab_lab.inputs.containerlab_lab_source_dir
-```
+## Documentation
 
-to an absolute controller-side directory containing `lab.clab.yml` and any relative local files it uses.
-
-HybridOps copies the source tree while preserving the native Containerlab topology format.
-
-Containerlab-generated `clab-*` data stays outside that source tree using native `CLAB_LABDIR_BASE`:
-
-```text
-/var/lib/hybridops/containerlab/labdirs
-```
-
-For proprietary or VM-backed NOS images, the operator supplies an authorised image source reachable by the managed host. Remote startup-config and licence assets remain at their authoritative locations and are referenced through Containerlab's native mechanisms.
-
-## Reference host
-
-The validated reference profile uses:
-
-- `n2-highmem-8`
-- 8 vCPU
-- 64 GB RAM
-- Ubuntu 22.04
-- 128 GB boot disk
-- private IP
-- nested virtualisation
-- IAP/SSH access
-
-Use this as the validated baseline and size other labs according to their workload requirements.
-
-Containerlab `0.78.0` is pinned. HybridOps verifies the package against an explicit digest, a known pinned digest when available, or the release checksum file, then records the actual downloaded SHA-256.
-
-## Deploy and rebuild flow
-
-The deploy order is:
-
-1. private GCP network
-2. private GCP VM
-3. Containerlab runtime and KVM check
-4. native Containerlab deploy
-5. independent health check
-6. recovery check
-
-The recovery check is last in deploy order, so reverse-order destroy reaches it before the lab, runtime, or VM is removed.
-
-During destroy or rebuild HybridOps:
-
-1. asks Containerlab for the native save output required by the selected policy
-2. creates an immutable recovery archive
-3. copies the archive to the HybridOps controller
-4. verifies the SHA-256 off-host
-5. writes the latest pointer, checksum, and metadata
-6. allows Containerlab cleanup and GCP compute release after verification passes
-
-On fresh compute, HybridOps verifies the latest recovery metadata, imports the archive, restores the managed source path, and performs one native Containerlab deployment. Vrnetlab snapshots are returned through `containerlab deploy --restore-all` when the selected node types support that recovery path.
-
-## Recovery modes
-
-### `rebuild`
-
-Default. Keeps the source tree and native `save --copy` output produced by the topology.
-
-Saved configuration is reused when the topology references that native output.
-
-### `snapshot`
-
-Adds Containerlab-supported vrnetlab snapshots to the retained recovery set and returns them through native restore semantics on reconstruction.
-
-### `ephemeral`
-
-Keeps source intent and starts runtime state fresh on the next execution host.
-
-The selected mode expresses the continuity outcome HybridOps must protect before compute release.
-
-## Off-host storage
-
-Recovery archives are stored under the HybridOps runtime on the controller, outside the disposable GCP VM. This establishes the first durable boundary beyond the host being released. The environment's backup policy can then protect that controller-side recovery store according to its retention requirements.
-
-The timestamped archive is the retained object. `latest.tar.gz` is a symlink with matching checksum and metadata, so one immutable archive can also have a stable current pointer.
-
-Recovery archives may contain configuration or licence material and should remain private.
-
-## Cost visibility
-
-The blueprint shows the estimated fixed VM and boot-disk cost, resource age, access-session cost context, and the effect of compute release on declared resources.
-
-The estimate provides lifecycle decision context. GCP billing remains authoritative for realised spend, while retained recovery storage, registries, and other continuing resources remain visible as separate cost-bearing components.
-
-## Private host access
-
-`hyops blueprint access` opens an IAP-backed local SSH forward. The default local endpoint is:
-
-```text
-127.0.0.1:2222
-```
-
-Use `--session-minutes <minutes> --on-expiry protected-release` to set a
-planned access limit. The foreground process supervises the limit; the expiry
-action does not continue after that process exits. At expiry, Core runs the
-declared recovery gate before teardown. A failed recovery gate retains the
-environment. Use `hyops blueprint session` to inspect, extend or cancel the
-expiry action.
-
-Use the private node-management path with:
-
-```bash
-hyops blueprint access --env <env> --ref gcp/containerlab@v1 --automation
-hyops blueprint device list --env <env> --ref gcp/containerlab@v1
-hyops blueprint device web --env <env> --ref gcp/containerlab@v1 <device> --scheme http --port 80
-```
-
-HybridOps reads running node addresses from Containerlab inspection output. The default management network is `172.20.20.0/24`; change the runtime blueprint when the topology declares another subnet.
-
-For several interfaces, use `hyops blueprint device edit` to declare each target's web service. The generated file documents the available fields. Open named targets together or use `--all`. One Ctrl-C closes every tunnel. Add `--open-all` to open every URL in the workstation browser.
-
-## Validated lifecycle
-
-The GCP acceptance path established that:
-
-- private GCP compute and IAP/SSH access were usable
-- nested virtualisation and KVM readiness passed
-- Containerlab `0.78.0` deployed the supplied topology and independent health passed
-- the selected recovery set was copied and checksum-verified off-host before the original VM was deleted
-- replacement compute had a different resource identity
-- retained recovery state verified and imported on the fresh host
-- reconstruction used one native Containerlab deployment
-- final lab health passed
-- final declared GCP compute was removed
-
-This establishes a complete GCP continuity lifecycle around Containerlab: continuity policy selects the required recovery fidelity, off-host verification gates compute release, and reconstruction returns state through Containerlab's native capabilities on fresh execution capacity.
+- [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-containerlab/)
+- [Lifecycle and ownership](ARCHITECTURE.md)
+- [Acceptance record](VALIDATION.md)

--- a/blueprints/gcp/containerlab@v1/blueprint.yml
+++ b/blueprints/gcp/containerlab@v1/blueprint.yml
@@ -159,6 +159,8 @@ steps:
       # Native Containerlab-generated clab-* runtime artifacts stay outside the
       # authoritative source tree so source preservation does not absorb them.
       containerlab_lab_labdir_base: "/var/lib/hybridops/containerlab/labdirs"
+      # Container images remain native references from the topology. List
+      # required references here for an explicit availability check.
       containerlab_lab_required_images: []
       containerlab_lab_pull_missing_images: false
       containerlab_lab_restore_latest: true

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -1,22 +1,8 @@
-# EVE-NG network lab
+# EVE-NG on GCP
 
-`gcp/eve-ng@v1` delivers a private EVE-NG execution environment with governed access, health verification, device automation access, continuity preservation, rebuild and compute release.
+`gcp/eve-ng@v1` deploys a private EVE-NG environment on nested-virtualisation-capable GCP compute. The VM has no public address; configuration and access use IAP.
 
-The blueprint uses shared EVE-NG capability modules that are also used by the Proxmox path. Provider-specific infrastructure supplies the execution host; EVE-NG remains authoritative for topology and node behavior.
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the lifecycle and ownership model.
-
-## What it delivers
-
-- private nested-virtualization-capable execution compute with no public VM address
-- EVE-NG installation and configuration through `platform/linux/eve-ng`
-- declared starter images through `platform/linux/eve-ng-images`
-- guest internet access through the EVE-NG `Cloud9` network
-- private topology-node management through `Cloud8`
-- service, database, API and KVM health verification
-- archive-before-release through `platform/linux/eve-ng-lab-archive`
-- verified restoration of lab definitions and selected stopped-QEMU overlay state
-- structured run records and resource-age/cost context
+EVE-NG remains authoritative for topology and node behaviour. HybridOps manages host readiness, declared images, health verification, private access, lab preservation, reconstruction and compute release.
 
 ## Execution chain
 
@@ -28,121 +14,16 @@ private network
   -> EVE-NG health verification
 ```
 
-The executable contract is [blueprint.yml](blueprint.yml).
-
-## Prepare and deploy
+The executable contract is [blueprint.yml](blueprint.yml). Initialise an environment copy before changing image sources, host sizing or optional licence inputs:
 
 ```bash
-hyops setup gcp
-hyops init gcp --env <env>
-hyops secrets ensure --env <env> EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
-
-ref=gcp/eve-ng@v1
-hyops blueprint init --env <env> --ref "$ref"
-hyops blueprint validate --env <env> --ref "$ref"
-hyops blueprint plan --env <env> --ref "$ref"
-hyops blueprint preflight --env <env> --ref "$ref"
-hyops blueprint deploy --env <env> --ref "$ref" --execute
+hyops blueprint init --env <env> --ref gcp/eve-ng@v1 --edit
 ```
 
-The shipped host profile uses an `n2-standard-8` VM with 32 GB RAM, a 256 GB disk, Ubuntu 22.04 and nested virtualization. It is a reference profile that can be adjusted through the environment blueprint.
+EVE-NG credentials and authorised IOL licence content belong in the encrypted environment vault, not in the blueprint.
 
-## Private access
+## Documentation
 
-Open the EVE-NG interface through the managed private path:
-
-```bash
-hyops blueprint access --env <env> --ref gcp/eve-ng@v1
-```
-
-Set a planned session limit when the environment must not remain active:
-
-```bash
-hyops blueprint access \
-  --env <env> \
-  --ref gcp/eve-ng@v1 \
-  --session-minutes 120 \
-  --on-expiry protected-release
-```
-
-The foreground access process supervises the limit and shows the UTC deadline
-and warning intervals. The expiry action does not continue after that process
-exits. At expiry, Core verifies the declared lab archive before teardown. A
-failed archive retains the environment.
-
-Use `hyops blueprint session status`, `hyops blueprint session extend` or
-`hyops blueprint session cancel` with the same environment and blueprint
-reference. Extension also requires `--minutes <minutes>`.
-
-The access session resolves the current host from HybridOps state and forwards the EVE-NG interface through IAP. The VM and EVE-NG HTTP service remain private.
-
-Add `--native-consoles` to follow active QEMU VNC ports during the session. New node consoles are forwarded on loopback as they start. The workstation must have a VNC handler registered for links opened by EVE-NG.
-
-For direct automation of topology nodes, connect a management interface to `Cloud8` and run:
-
-```bash
-hyops blueprint access --env <env> --ref gcp/eve-ng@v1 --automation
-```
-
-HybridOps discovers management leases and produces session-scoped SSH configuration and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
-
-While that session remains open, expose one device web interface on loopback:
-
-```bash
-hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 <device> --scheme http --port 80
-```
-
-The device may be identified by target name or management IP. For several interfaces, use `hyops blueprint device edit` to declare each target's web service. The generated file documents the available fields. Open named targets together, or every declared service:
-
-```bash
-hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 <device-1> <device-2>
-hyops blueprint device web --env <env> --ref gcp/eve-ng@v1 --all
-```
-
-One Ctrl-C closes every tunnel. Add `--open-all` to open every URL in the workstation browser. Appliance certificates may produce the expected local browser warning.
-
-## Continuity and compute release
-
-The blueprint declares `platform/linux/eve-ng-lab-archive` as its archive-before-release contract.
-
-The retained set can contain:
-
-- learner-created lab definitions under `/opt/unetlab/labs`;
-- device configurations saved through EVE-NG's native export; and
-- stopped QEMU overlay state when node-state preservation is selected by the blueprint.
-
-Save intended device changes to startup configuration before teardown. Before overlay capture, running QEMU nodes are stopped. Each retained archive is checksummed on the controller. Base images remain separately managed, so restored QEMU overlays reconnect to matching installed base images rather than copying those bases into the checkpoint.
-
-For an explicit protected destroy:
-
-```bash
-hyops blueprint destroy --env <env> --ref gcp/eve-ng@v1 --execute --yes \
-  --archive-before-destroy
-```
-
-A later deployment can restore the latest verified set:
-
-```bash
-hyops blueprint deploy --env <env> --ref gcp/eve-ng@v1 --execute --restore-labs
-```
-
-Restore verifies the lab archive and any node-state companion checksum before applying retained state. Existing content remains protected unless replacement is explicitly authorised.
-
-## Rebuild
-
-```bash
-hyops blueprint rebuild --env <env> --ref gcp/eve-ng@v1 --execute
-```
-
-Rebuild applies the same lifecycle boundary: preserve the selected continuity state, release the current execution resources, recreate the host, restore verified state and return the lab through the normal EVE-NG readiness path.
-
-## Shared implementation
-
-The lab-platform layer is composed from:
-
-- [EVE-NG configuration](../../../modules/platform/linux/eve-ng)
-- [EVE-NG images](../../../modules/platform/linux/eve-ng-images)
-- [EVE-NG health check](../../../modules/platform/linux/eve-ng-healthcheck)
-- [EVE-NG lab archive](../../../modules/platform/linux/eve-ng-lab-archive)
-
-The sibling [Proxmox implementation](../../onprem/eve-ng@v1) uses the same EVE-NG, health, access and archive contracts around a different execution-host lifecycle.
+- [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
+- [Lifecycle and ownership](ARCHITECTURE.md)
+- [Proxmox blueprint](../../onprem/eve-ng@v1/blueprint.yml)

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -1,22 +1,8 @@
-# GNS3 network lab
+# GNS3 on GCP
 
-`gcp/gns3@v1` delivers a private GNS3 execution environment with governed access, deep health verification, device automation access, project continuity, rebuild and compute release.
+`gcp/gns3@v1` deploys an authenticated GNS3 server on private, nested-virtualisation-capable GCP compute. The VM has no public address; configuration and access use IAP.
 
-The blueprint uses shared GNS3 capability modules that are also used by the Proxmox path. Provider-specific infrastructure supplies the execution host; GNS3 remains authoritative for projects, topology and node execution.
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the lifecycle and ownership model.
-
-## What it delivers
-
-- private nested-virtualization-capable execution compute with no public VM address
-- authenticated GNS3 server through `platform/linux/gns3-server`
-- declared image handling through `platform/linux/gns3-images`
-- a starter project through `platform/linux/gns3-starter-lab`
-- deep GNS3, KVM and local-compute health verification
-- private topology-node management through `hyops-mgmt0`
-- archive-before-release through `platform/linux/gns3-lab-archive`
-- verified restoration of projects, controller metadata and writable node disks
-- structured run records and resource-age/cost context
+GNS3 remains authoritative for projects, topology and node execution. HybridOps manages host readiness, declared image registration, health verification, private access, project preservation, reconstruction and compute release.
 
 ## Execution chain
 
@@ -29,120 +15,16 @@ private network
   -> GNS3 health verification
 ```
 
-The executable contract is [blueprint.yml](blueprint.yml).
-
-## Prepare and deploy
+The executable contract is [blueprint.yml](blueprint.yml). Initialise an environment copy before changing image declarations, host sizing or optional licence inputs:
 
 ```bash
-hyops setup gcp
-hyops init gcp --env <env>
-hyops secrets ensure --env <env> GNS3_SERVER_PASSWORD
-
-ref=gcp/gns3@v1
-hyops blueprint init --env <env> --ref "$ref"
-hyops blueprint validate --env <env> --ref "$ref"
-hyops blueprint plan --env <env> --ref "$ref"
-hyops blueprint preflight --env <env> --ref "$ref"
-hyops blueprint deploy --env <env> --ref "$ref" --execute
+hyops blueprint init --env <env> --ref gcp/gns3@v1 --edit
 ```
 
-The shipped host profile uses an `n2-standard-8` VM with 32 GB RAM, a 128 GB disk, Ubuntu 22.04 and nested virtualization. It is a reference profile that can be adjusted through the environment blueprint.
+The GNS3 server password and authorised IOU licence content belong in the encrypted environment vault.
 
-## Private access
+## Documentation
 
-Open the GNS3 server through the managed private path:
-
-```bash
-hyops blueprint access --env <env> --ref gcp/gns3@v1
-```
-
-Set a planned session limit when the environment must not remain active:
-
-```bash
-hyops blueprint access \
-  --env <env> \
-  --ref gcp/gns3@v1 \
-  --session-minutes 120 \
-  --on-expiry protected-release
-```
-
-The foreground access process supervises the limit and shows the UTC deadline
-and warning intervals. The expiry action does not continue after that process
-exits. At expiry, Core verifies the declared project archive before teardown.
-A failed archive retains the environment.
-
-Use `hyops blueprint session status`, `hyops blueprint session extend` or
-`hyops blueprint session cancel` with the same environment and blueprint
-reference. Extension also requires `--minutes <minutes>`.
-
-The access session resolves the current host from HybridOps state and forwards the authenticated GNS3 API/UI endpoint through IAP. The VM and GNS3 service remain private.
-
-Add `--native-consoles` when using the desktop client's Telnet, VNC, SPICE or web console handlers. HybridOps reads node console assignments from the authenticated GNS3 API and maintains matching loopback forwards while access remains open.
-
-For direct automation of topology nodes, map a GNS3 Cloud node to `hyops-mgmt0`, connect device management interfaces to it and run:
-
-```bash
-hyops blueprint access --env <env> --ref gcp/gns3@v1 --automation
-```
-
-HybridOps discovers management leases and produces session-scoped SSH configuration, target data and automation inventory. Linux and WSL can optionally use `--route-lab`; Windows and macOS clients can use the generated SSH configuration or local proxy path.
-
-While that session remains open, expose one device web interface on loopback:
-
-```bash
-hyops blueprint device web --env <env> --ref gcp/gns3@v1 <device> --scheme http --port 80
-```
-
-The device may be identified by target name or management IP. For several interfaces, use `hyops blueprint device edit` to declare each target's web service. The generated file documents the available fields. Open named targets together, or every declared service:
-
-```bash
-hyops blueprint device web --env <env> --ref gcp/gns3@v1 <device-1> <device-2>
-hyops blueprint device web --env <env> --ref gcp/gns3@v1 --all
-```
-
-One Ctrl-C closes every tunnel. Add `--open-all` to open every URL in the workstation browser. Appliance certificates may produce the expected local browser warning.
-
-Closing an interactive access session offers the same keep, archive or destroy decision as an explicit blueprint teardown.
-
-## Continuity and compute release
-
-The blueprint declares `platform/linux/gns3-lab-archive` as its archive-before-release contract.
-
-The retained set contains GNS3 project directories and controller metadata. Project directories carry topology files, project files and writable node disks. The archive role stops the GNS3 server while controller state is copied or restored, then returns the service to its operating state.
-
-Base images are separately managed by default and can be reconstructed from their declarations. The retained project archive therefore carries the mutable project state needed for continuation without coupling that state to the lifetime of the execution host.
-
-For an explicit protected destroy:
-
-```bash
-hyops blueprint destroy --env <env> --ref gcp/gns3@v1 --execute --yes \
-  --archive-before-destroy
-```
-
-A later deployment can restore the latest verified set:
-
-```bash
-hyops blueprint deploy --env <env> --ref gcp/gns3@v1 --execute --restore-labs
-```
-
-Restore verifies the recorded SHA-256 before applying the retained controller and project state.
-
-## Rebuild
-
-```bash
-hyops blueprint rebuild --env <env> --ref gcp/gns3@v1 --execute
-```
-
-Rebuild applies the same lifecycle boundary: preserve the project state, release the current execution resources, recreate the host, restore the verified archive and return the lab through the normal GNS3 health path.
-
-## Shared implementation
-
-The lab-platform layer is composed from:
-
-- [GNS3 server](../../../modules/platform/linux/gns3-server)
-- [GNS3 images](../../../modules/platform/linux/gns3-images)
-- [GNS3 starter lab](../../../modules/platform/linux/gns3-starter-lab)
-- [GNS3 health check](../../../modules/platform/linux/gns3-healthcheck)
-- [GNS3 lab archive](../../../modules/platform/linux/gns3-lab-archive)
-
-The sibling [Proxmox implementation](../../onprem/gns3@v1) uses the same GNS3, health, access and archive contracts around a different execution-host lifecycle.
+- [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-gns3/)
+- [Lifecycle and ownership](ARCHITECTURE.md)
+- [Proxmox blueprint](../../onprem/gns3@v1/blueprint.yml)

--- a/blueprints/gcp/gns3@v1/blueprint.yml
+++ b/blueprints/gcp/gns3@v1/blueprint.yml
@@ -181,8 +181,9 @@ steps:
       # load_vault_env: true
       # required_env: ["GNS3_SERVER_PASSWORD", "GNS3_IOU_LICENSE"]
       # gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
-      # filename is required. checksum is optional. An archive must contain one
-      # image payload for registration.
+      # Declare each URL separately because GNS3 registration also requires
+      # image metadata. filename is required and checksum is optional. An
+      # archive must contain one image payload for registration.
       gns3_images_items:
         - name: "Alpine Linux 3.24"
           url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -1,168 +1,28 @@
-# On-Prem EVE-NG Platform Stack
+# EVE-NG on Proxmox
 
-Build a rebuildable EVE-NG host on Proxmox instead of hand-maintaining a long-lived VM.
+`onprem/eve-ng@v1` builds a verified Ubuntu 22.04 template, provisions an EVE-NG VM on Proxmox, configures the lab service, installs declared images and verifies health.
 
-This blueprint builds a verified Ubuntu Jammy template image, provisions a standalone EVE-NG VM from that template, configures EVE-NG, installs a starter image set, and runs a health check.
+EVE-NG remains authoritative for topology and node behaviour. HybridOps manages the template and VM lifecycle, private access, lab preservation and reconstruction.
 
-Use this when you want the EVE-NG platform itself to be reproducible, not just the topologies that run inside it.
-
-## What This Delivers
-
-- a Proxmox-hosted EVE-NG VM
-- an Ubuntu 22.04 template image built through `core/onprem/template-image`
-- post-build template smoke validation before the VM consumes the image
-- standalone VM provisioning through `platform/onprem/platform-vm`
-- EVE-NG installation and configuration through `platform/linux/eve-ng`
-- a small public starter-image set through `platform/linux/eve-ng-images`
-- a managed `Cloud9` guest network with DHCP and outbound connectivity
-- a basic EVE-NG health check through `platform/linux/eve-ng-healthcheck`
-- structured run records for each module step
-
-## Execution Chain
+## Execution chain
 
 ```text
-core/onprem/template-image
-  -> platform/onprem/platform-vm
-  -> platform/linux/eve-ng
-  -> platform/linux/eve-ng-images
-  -> platform/linux/eve-ng-healthcheck
+template image
+  -> execution host
+  -> EVE-NG configuration
+  -> lab images
+  -> EVE-NG health verification
 ```
 
-The blueprint file is [blueprint.yml](blueprint.yml).
+The executable contract is [blueprint.yml](blueprint.yml). Initialise an environment copy before changing Proxmox settings, image sources or optional licence inputs:
+
+```bash
+hyops blueprint init --env <env> --ref onprem/eve-ng@v1 --edit
+```
+
+The target bridge must provide VM connectivity. EVE-NG credentials and authorised IOL licence content belong in the encrypted environment vault.
 
 ## Documentation
 
-- [Deploy EVE-NG blueprint runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
-- [Reusable EVE-NG training environment reference scenario](https://docs.hybridops.tech/reference-scenarios/eveng-lab-foundation/)
-
-## Prerequisites
-
-The standalone path requires:
-
-- Proxmox access is configured for HybridOps.
-- The Proxmox `vmbr0` bridge provides DHCP connectivity for the VM.
-- EVE-NG secrets are seeded for the target environment.
-
-NetBox and shared Proxmox SDN remain available for managed platform deployments, but they are not required for this lab blueprint.
-
-Seed the EVE-NG secrets before deployment:
-
-```bash
-hyops secrets ensure --env <env> EVENG_ROOT_PASSWORD EVENG_ADMIN_PASSWORD
-```
-
-## Usage
-
-Validate the blueprint:
-
-```bash
-hyops blueprint validate \
-  --ref onprem/eve-ng@v1 \
-  --blueprints-root blueprints
-```
-
-Run preflight:
-
-```bash
-hyops blueprint preflight \
-  --env <env> \
-  --ref onprem/eve-ng@v1 \
-  --blueprints-root blueprints
-```
-
-Deploy:
-
-```bash
-hyops blueprint deploy \
-  --env <env> \
-  --ref onprem/eve-ng@v1 \
-  --blueprints-root blueprints \
-  --execute
-```
-
-Open the private UI:
-
-```bash
-hyops blueprint access --env <env> --ref onprem/eve-ng@v1
-```
-
-Add `--native-consoles` to follow active QEMU VNC ports during the session. New node consoles are forwarded on loopback as they start. The workstation must have a VNC handler registered for links opened by EVE-NG.
-
-Connect a device management interface to `Cloud8`, then add `--automation` to
-open a private workstation-to-device path. HybridOps writes the SSH config,
-device target file and automation inventory under the selected environment.
-The access session must remain open. DHCP supplies the management gateway;
-static devices must use `172.29.128.1`. On Linux or WSL, optional
-`--route-lab` creates a temporary layer-3 route when `172.29.128.0/24` does not
-conflict locally. Windows and macOS applications use the generated SSH
-configuration or local proxy.
-
-When access closes, HybridOps offers to keep the environment, preserve saved
-lab state before teardown, or destroy without preservation. Preservation
-refreshes saved device configurations in the lab definitions and includes
-stopped QEMU overlay state when present. Direct interactive destroy uses the
-same choices. Automation must pass either
-`--archive-before-destroy` or `--skip-archive` with `--yes`.
-
-After redeployment, an interactive deploy offers to restore a verified archive.
-For non-interactive recovery:
-
-```bash
-hyops blueprint deploy \
-  --env <env> \
-  --ref onprem/eve-ng@v1 \
-  --execute \
-  --restore-labs
-```
-
-The archive checksum is verified before restoration. Existing lab definitions
-are protected unless `--overwrite-labs` is also supplied.
-
-## Default Shape
-
-The shipped blueprint provisions one VM:
-
-- logical name: `eve-ng-01`
-- role: `eve-ng`
-- CPU: `8` cores
-- memory: `32768` MB
-- disk: `256` GB
-- network: `vmbr0` with DHCP
-- guest egress network: `Cloud9` (`172.29.129.0/24`)
-- private automation network: `Cloud8` (`172.29.128.0/24`)
-- SSH user: `opsadmin`
-
-The VM consumes the template state from:
-
-```text
-core/onprem/template-image#template_image_ubuntu_22_04
-```
-
-The VM obtains its management address through DHCP on the normal Proxmox uplink. No address is hardcoded into the blueprint.
-
-## Why This Exists
-
-EVE-NG is often treated as a manually built appliance: install it once, patch it carefully, and hope nobody needs to recreate it from scratch.
-
-This blueprint turns that host into a normal platform outcome:
-
-- the base image is built from a repeatable definition
-- the template is smoke-checked before use
-- the VM is provisioned from state, not from a remembered VMID
-- EVE-NG configuration is a module step, not a manual shell session
-- the declared starter images are installed as a separate repeatable step
-- the final health check records whether the EVE-NG host is reachable
-
-That makes the EVE-NG host disposable enough to rebuild and predictable enough to use as part of a wider training or network-emulation platform.
-
-## Related Modules
-
-- [core/onprem/template-image](../../../modules/core/onprem/template-image)
-- [platform/onprem/platform-vm](../../../modules/platform/onprem/platform-vm)
-- [platform/linux/eve-ng](../../../modules/platform/linux/eve-ng)
-- [platform/linux/eve-ng-images](../../../modules/platform/linux/eve-ng-images)
-- [platform/linux/eve-ng-healthcheck](../../../modules/platform/linux/eve-ng-healthcheck)
-
-## Cloud Alternative
-
-If you do not have Proxmox, the sibling [gcp/eve-ng@v1](../../gcp/eve-ng@v1) blueprint provisions a private nested-virtualization-capable GCP VM, configures EVE-NG over IAP, and runs the same health-check pattern.
+- [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
+- [GCP blueprint](../../gcp/eve-ng@v1/blueprint.yml)

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -1,101 +1,29 @@
-# On-Prem GNS3 Platform Stack
+# GNS3 on Proxmox
 
-Build a dedicated GNS3 server on Proxmox from a verified Ubuntu 22.04
-template. The blueprint provisions the VM and configures the authenticated
-GNS3 API through the provider-neutral Linux module.
+`onprem/gns3@v1` builds a verified Ubuntu 22.04 template, provisions a dedicated GNS3 VM on Proxmox, configures the authenticated server, registers declared images and verifies health.
 
-The API listens on the VM loopback interface. The access command opens a private
-SSH tunnel for the bundled Web UI and GNS3 desktop client; the server is not
-exposed to the local network by this blueprint.
+GNS3 remains authoritative for projects, topology and node execution. HybridOps manages the template and VM lifecycle, private access, project preservation and reconstruction.
 
 ## Execution chain
 
 ```text
-core/onprem/template-image
-  -> platform/onprem/platform-vm
-  -> platform/linux/gns3-server
-  -> platform/linux/gns3-images
-  -> platform/linux/gns3-starter-lab
-  -> platform/linux/gns3-healthcheck
+template image
+  -> execution host
+  -> GNS3 server
+  -> lab images
+  -> starter project
+  -> GNS3 health verification
 ```
 
-## Prerequisites
-
-- Proxmox access is configured through `hyops init proxmox`.
-- The configured Proxmox bridge provides DHCP connectivity.
-- The Proxmox host permits nested virtualization for a VM using CPU type
-  `host`.
-- The GNS3 API password is stored in the environment vault.
+The executable contract is [blueprint.yml](blueprint.yml). Initialise an environment copy before changing Proxmox settings, images or optional licence inputs:
 
 ```bash
-hyops secrets ensure --env gns3-lab GNS3_SERVER_PASSWORD
+hyops blueprint init --env <env> --ref onprem/gns3@v1 --edit
 ```
 
-## Validate and deploy
+The target bridge must provide VM connectivity. The GNS3 server password and authorised IOU licence content belong in the encrypted environment vault.
 
-```bash
-hyops blueprint validate --ref onprem/gns3@v1
+## Documentation
 
-hyops blueprint preflight \
-  --env gns3-lab \
-  --ref onprem/gns3@v1
-
-hyops blueprint deploy \
-  --env gns3-lab \
-  --ref onprem/gns3@v1 \
-  --execute
-```
-
-## Connect to GNS3
-
-```bash
-hyops blueprint access \
-  --env gns3-lab \
-  --ref onprem/gns3@v1
-```
-
-For workstation automation, add a GNS3 Cloud node mapped to `hyops-mgmt0`,
-connect device management interfaces to it, and add `--automation`. The command
-writes a scoped SSH config, target file and automation inventory. Optional
-`--route-lab` routing requires Linux or WSL with TUN support and a
-non-conflicting `172.29.130.0/24` local route. Windows and macOS applications
-use the generated SSH configuration or local proxy. DHCP supplies the
-management gateway; static devices must use `172.29.130.1`.
-
-Keep the command running. Open `http://127.0.0.1:3080/` in a browser or
-configure the GNS3 desktop client to use host `127.0.0.1`, port `3080` and
-protocol `HTTP`. The default username is `gns3`. Retrieve the generated
-password from the environment vault:
-
-```bash
-hyops secrets show --env gns3-lab --raw GNS3_SERVER_PASSWORD
-```
-
-Add `--native-consoles` to forward the Telnet, VNC, SPICE and web console ports declared for GNS3 nodes. Keep the access command running while using the desktop client.
-
-Press Ctrl-C in the access terminal to close the tunnel. HybridOps then offers to keep the environment, archive its projects before teardown, or destroy without an archive.
-
-## Default VM
-
-- name: `gns3-01`
-- CPU: 4 cores, type `host`
-- memory: 16 GB
-- disk: 128 GB
-- management network: `vmbr0` with DHCP
-- API: authenticated HTTP on VM loopback port 3080
-
-Ordinary blueprint destroy removes the workload VM and retains the reusable
-Ubuntu template. The interactive destroy flow can export and verify GNS3
-projects before teardown. Project topology, controller metadata and writable
-node disks are preserved; downloadable base images are rebuilt from their
-declarations.
-
-Restore the latest verified archive during redeployment:
-
-```bash
-hyops blueprint deploy \
-  --env gns3-lab \
-  --ref onprem/gns3@v1 \
-  --execute \
-  --restore-labs
-```
+- [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-gns3/)
+- [GCP blueprint](../../gcp/gns3@v1/blueprint.yml)

--- a/blueprints/onprem/gns3@v1/blueprint.yml
+++ b/blueprints/onprem/gns3@v1/blueprint.yml
@@ -149,8 +149,9 @@ steps:
       # load_vault_env: true
       # required_env: ["GNS3_SERVER_PASSWORD", "GNS3_IOU_LICENSE"]
       # gns3_images_iou_license_env: "GNS3_IOU_LICENSE"
-      # filename is required. checksum is optional. An archive must contain one
-      # image payload for registration.
+      # Declare each URL separately because GNS3 registration also requires
+      # image metadata. filename is required and checksum is optional. An
+      # archive must contain one image payload for registration.
       gns3_images_items:
         - name: "Alpine Linux 3.24"
           url: "https://dl-cdn.alpinelinux.org/alpine/v3.24/releases/x86_64/alpine-virt-3.24.1-x86_64.iso"


### PR DESCRIPTION
## Summary

- reduce EVE-NG, GNS3 and Containerlab blueprint READMEs to scope, execution order and authoritative links
- keep operating procedures in the public runbooks
- clarify GNS3 registration metadata and Containerlab native image references in blueprint comments

## Validation

- `python3 -m unittest -q hyops.blueprint.tests.test_gcp_eve_ng hyops.blueprint.tests.test_onprem_eve_ng hyops.blueprint.tests.test_gcp_gns3 hyops.blueprint.tests.test_onprem_gns3 hyops.blueprint.tests.test_gcp_containerlab`
- `git diff --check`

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.