### PR TITLE
chore: add project metadata and links to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,10 @@ include = ["hyops*"]
 
 [project.scripts]
 hyops = "hyops.cli:main"
+
+[project.urls]
+"Homepage" = "https://hybridops.tech"
+"Documentation" = "https://docs.hybridops.tech"
+"Bug Tracker" = "https://github.com/hybridops-tech/hybridops-core/issues"
+"Repository" = "https://github.com/hybridops-tech/hybridops-core"
+"Changelog" = "https://github.com/hybridops-tech/hybridops-core/blob/main/CHANGELOG"


### PR DESCRIPTION
**Description**
Added project URLs for homepage, documentation, bug tracker, repository, and changelog.

**Summary**
Currently, the pyproject.toml file is missing specific project metadata. This change adds the [project.urls] table, which ensures that:
The GitHub "About" sidebar automatically displays links to the website and documentation.
If the package is published to PyPI, these links will appear on the project page, making it easier for users to find support and documentation.
It improves the discoverability of the project's resources for new contributors.

**Validation**
I validated this change by:
Manually inspecting the pyproject.toml for syntax errors.
Running a local mock build check (optional, but good to mention): pip install . to ensure the file remains valid and doesn't break the installation process.
Verified that the URLs point to the correct existing paths for the HybridOps project.
Scope


> This pull request is focused on one change.

> - I have not included credentials, tokens, private addresses, or customer data.

> - I updated documentation, examples, or tests where the change needs them.