### PR TITLE
docs: add smoke test and installation verification to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ hyops blueprint plan --ref onprem/authoritative-foundation@v1
 
 See the [authoritative foundation blueprint](blueprints/onprem/authoritative-foundation@v1/) or browse the [Blueprint Index](https://docs.hybridops.tech/platform/blueprints/).
 
+### Verify Installation
+Run a "smoke test" to ensure the CLI is correctly installed and the core logic is functional:
+
+```bash
+# Check version
+hyops --version
+
+# Validate a core blueprint (requires no credentials)
+hyops blueprint validate --ref onprem/authoritative-foundation@v1
+```
+
 ## Execution model
 
 ```mermaid


### PR DESCRIPTION
## Improved Description

Added a dedicated section to the README for verifying successful installation via a smoke test.

## Summary

Currently, the onboarding flow skips from installation to advanced usage. This PR addresses a specific onboarding gap by providing users with a "Smoke Test."

## Why this change is necessary:

  - It allows new users to confirm their environment is correctly configured before attempting complex deployments.
  - It provides immediate feedback if the CLI was not added to the user's $PATH correctly.
  - It demonstrates a basic, "read-only" command (blueprint validate) that requires no credentials, lowering the barrier to the first "success" moment.

## Validation

- [x] Manually verified the Markdown syntax and rendering.
- [x] Verified that the hyops --version command is the standard way to check CLI health.
- [x] Confirmed the blueprint validate command works as an unauthenticated check.

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.