### PR TITLE
chore: add .editorconfig to standardize indentation and formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Revised the Quickstart section to include a CLI entry point check and blueprint
validation in a single flow.

## Summary

Following the maintainer's feedback, I have:

  - Folded the hyops --version command into the existing Quickstart code block.
  - Removed the redundant "Verify Installation" header to keep the documentation
    concise.
  - Refined the wording to focus specifically on confirming the CLI entry point
    and validating a shipped blueprint.
  - Streamlined the user experience so new contributors can verify their setup
    in one copy-paste step.

## Validation

- [ ] Verified that all commands are within the correct Markdown code blocks.
- [ ] Confirmed the wording matches the requested scope: "Confirm the CLI entry
  point and validate a shipped blueprint."
- [ ] Checked that no duplicate sections remain in the README.

Scope

- [ ] This pull request is focused on one change.
- [ ] I have not included credentials, tokens, private addresses, or customer
  data.
- [ ] I updated documentation, examples, or tests where the change needs them.
