### PR TITLE
docs: add repository structure map to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,21 @@ Run records are written under stable paths such as:
 - Python >= 3.11
 - Module-specific execution dependencies are documented with the relevant module and runbook
 
-## Research and external review
+## Research and external review.
 
 HybridOps Core is the public reference implementation for ongoing work in platform engineering and infrastructure automation.
 
 See [Research and External Review](RESEARCH.md) for published papers, implementation maps, and external technical reviews.
+
+## Repository Structure
+
+To help you navigate the codebase, here is a breakdown of the core directories:
+
+- [**`blueprints/`**](blueprints/): Contains the high-level lifecycle definitions and governance contracts.
+- [**`packs/`**](packs/): Reusable implementation assets and versioned code logic.
+- [**`src/`**](src/): The core Python source code for the HybridOps platform.
+- [**`tests/`**](tests/): Automated test suites ensuring platform stability.
+- [**`.github/`**](.github/): CI/CD workflows and repository templates
 
 ## Documentation
 


### PR DESCRIPTION
Added a "Repository Structure" section to the README to improve project navigability.

Summary
New contributors and users often face a "discovery" hurdle when first exploring the repository. This PR addresses this onboarding gap by:
Providing a high-level map of the primary directories.
Linking directly to the folders within GitHub for faster navigation.
Briefly explaining the purpose of blueprints, packs, and src to align with the project's terminology.
This helps newcomers understand where the "logic" lives versus where the "definitions" live.

Validation

Verified that all directory links point to the correct relative paths in the repo.

Confirmed Markdown rendering is clean and lists are aligned.
Scope

This pull request is focused on one change.

I have not included credentials or private data.

I updated documentation where the change needs it.