### PR TITLE
fix: preserve multiline vault values by key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,15 @@
 
 This changelog records significant operator-facing capabilities, lifecycle changes, compatibility fixes, and release engineering updates. Individual commits and maintenance-only changes remain available through the linked comparisons.
 
+## Unreleased
+
+### Fixed
+
+- Kept multiline vault values within their owning environment key so
+  `hyops secrets keys` cannot emit value fragments from legacy vault files.
+- Removed password-command temporary files from non-default temporary
+  directories after vault reads and writes.
+
 ## [v0.1.5-rc.1] - 2026-09-02
 
 ### Added

--- a/hyops/runtime/tests/test_vault.py
+++ b/hyops/runtime/tests/test_vault.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+from hyops.runtime.vault import VaultAuth, _parse_env
+
+
+class VaultEnvParsingTest(unittest.TestCase):
+    def test_parses_escaped_and_legacy_multiline_values(self) -> None:
+        parsed = _parse_env(
+            """\
+SIMPLE=value
+ESCAPED="line-one\\nline-two"
+LEGACY_JSON="{\n  \\"private_key\\": \\"first=second\\nthird\\"\n}"
+"""
+        )
+
+        self.assertEqual(parsed["SIMPLE"], "value")
+        self.assertEqual(parsed["ESCAPED"], "line-one\nline-two")
+        self.assertEqual(
+            parsed["LEGACY_JSON"],
+            '{\n  "private_key": "first=second\nthird"\n}',
+        )
+        self.assertEqual(set(parsed), {"SIMPLE", "ESCAPED", "LEGACY_JSON"})
+
+    def test_ignores_non_environment_assignment_fragments(self) -> None:
+        parsed = _parse_env(
+            'SAFE=value\n"private_key": "base64=fragment"\ninvalid-name=value\n'
+        )
+
+        self.assertEqual(parsed, {"SAFE": "value"})
+
+    def test_rejects_unterminated_quoted_value(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unterminated quoted value for SECRET"):
+            _parse_env('SECRET="unfinished\n')
+
+
+class VaultAuthTest(unittest.TestCase):
+    def test_owns_materialized_password_file_outside_system_tmp(self) -> None:
+        auth = VaultAuth(password_command="password-command")
+
+        self.assertTrue(
+            auth.owns_password_file(Path("/workspace/tmp/hyops.vaultpass.example"))
+        )
+
+    def test_does_not_own_explicit_password_file(self) -> None:
+        auth = VaultAuth(password_file="/workspace/tmp/hyops.vaultpass.explicit")
+
+        self.assertFalse(
+            auth.owns_password_file(Path("/workspace/tmp/hyops.vaultpass.explicit"))
+        )
+
+    def test_does_not_own_password_file_from_environment(self) -> None:
+        auth = VaultAuth(password_command="password-command")
+        with patch.dict(
+            os.environ,
+            {"HYOPS_VAULT_PASSWORD_FILE": "/workspace/password-file"},
+            clear=False,
+        ):
+            self.assertFalse(
+                auth.owns_password_file(Path("/workspace/tmp/hyops.vaultpass.example"))
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hyops/runtime/vault.py
+++ b/hyops/runtime/vault.py
@@ -11,11 +11,15 @@ from pathlib import Path
 from typing import Mapping
 
 import os
+import re
 import shlex
 import subprocess
 import tempfile
 
 from hyops.runtime.proc import run as run_proc
+
+
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _ansible_vault_env() -> dict[str, str]:
@@ -226,6 +230,18 @@ class VaultAuth:
                 pass
             raise
 
+    def owns_password_file(self, path: Path | None) -> bool:
+        """Return whether ``path`` was materialized from a password command."""
+        if path is None:
+            return False
+        password_file = (
+            self.password_file
+            or os.environ.get("HYOPS_VAULT_PASSWORD_FILE")
+            or os.environ.get("ANSIBLE_VAULT_PASSWORD_FILE")
+            or ""
+        ).strip()
+        return not password_file and path.name.startswith("hyops.vaultpass.")
+
 
 def _parse_env(text: str) -> dict[str, str]:
     def _unescape_env_value(value: str) -> str:
@@ -254,8 +270,23 @@ def _parse_env(text: str) -> dict[str, str]:
             idx += 2
         return "".join(out)
 
+    def _quoted_value_complete(value: str, quote: str) -> bool:
+        stripped = value.rstrip()
+        if not stripped or stripped[-1] != quote:
+            return False
+        slash_count = 0
+        index = len(stripped) - 2
+        while index >= 0 and stripped[index] == "\\":
+            slash_count += 1
+            index -= 1
+        return slash_count % 2 == 0
+
     out: dict[str, str] = {}
-    for raw in (text or "").splitlines():
+    lines = (text or "").splitlines()
+    index = 0
+    while index < len(lines):
+        raw = lines[index]
+        index += 1
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
@@ -264,11 +295,17 @@ def _parse_env(text: str) -> dict[str, str]:
         k, v = line.split("=", 1)
         k = k.strip()
         v = v.strip()
-        if not k:
+        if not _ENV_KEY_RE.fullmatch(k):
             continue
-        # remove surrounding quotes if present
-        if len(v) >= 2 and ((v[0] == v[-1] == '"') or (v[0] == v[-1] == "'")):
-            v = v[1:-1]
+        if v.startswith(('"', "'")):
+            quote = v[0]
+            collected = v[1:]
+            while not _quoted_value_complete(collected, quote):
+                if index >= len(lines):
+                    raise ValueError(f"unterminated quoted value for {k}")
+                collected += "\n" + lines[index]
+                index += 1
+            v = collected.rstrip()[:-1]
         v = _unescape_env_value(v)
         out[k] = v
     return out
@@ -320,7 +357,7 @@ def read_env(vault_file: Path, auth: VaultAuth) -> dict[str, str]:
             raise RuntimeError(f"ansible-vault view failed{suffix}")
         return _parse_env(r.stdout)
     finally:
-        if auth.password_command and pwf and str(pwf).startswith("/tmp/"):
+        if auth.owns_password_file(pwf):
             try:
                 pwf.unlink()
             except FileNotFoundError:
@@ -359,7 +396,7 @@ def write_env(vault_file: Path, auth: VaultAuth, env: Mapping[str, str]) -> None
             tmp_plain_path.unlink()
         except FileNotFoundError:
             pass
-        if auth.password_command and pwf and str(pwf).startswith("/tmp/"):
+        if auth.owns_password_file(pwf):
             try:
                 pwf.unlink()
             except FileNotFoundError:


### PR DESCRIPTION
## Summary

- preserve multiline secret values within their owning environment key
- prevent value fragments from appearing as keys in legacy vault files
- remove password-command temporary files outside the default temporary directory

## Validation

- `python3 -m unittest hyops.runtime.tests.test_vault`
- Ruff on the changed runtime and test files

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.