### PR TITLE
fix: enforce downstream blueprint preflight gates

### DIFF
--- a/hyops/blueprint/planner.py
+++ b/hyops/blueprint/planner.py
@@ -358,29 +358,6 @@ def compute_preflight(
             )
             step_status_by_id[step_id] = "deferred"
             continue
-        pending_configuration = [
-            str(dep_id)
-            for dep_id in (raw_deps or [])
-            if step_status_by_id.get(str(dep_id)) == "ready"
-            and str((by_id.get(str(dep_id)) or {}).get("module_ref") or "").startswith("platform/linux/")
-            and not bool((by_id.get(str(dep_id)) or {}).get("skip_if_state_ok", False))
-        ]
-        if pending_configuration:
-            step_results.append(
-                {
-                    "id": step["id"],
-                    "module_ref": step["module_ref"],
-                    "module_state_ref": step_state_ref(step),
-                    "action": step["action"],
-                    "phase": step["phase"],
-                    "optional": bool(step.get("optional", False)),
-                    "checks": [{"name": "dependencies", "ok": True, "detail": "remote checks deferred until configuration runs: " + ", ".join(pending_configuration)}],
-                    "status": "ready",
-                }
-            )
-            step_status_by_id[step_id] = "ready"
-            assumed_state_ok.add(step_state_ref(step))
-            continue
         for dep_id in raw_deps or []:
             dep_step = by_id.get(str(dep_id))
             if not isinstance(dep_step, dict):

--- a/hyops/blueprint/tests/test_planner.py
+++ b/hyops/blueprint/tests/test_planner.py
@@ -96,11 +96,10 @@ class PlannedDependencyPreflightTest(TestCase):
                 },
             ],
         }
-        preflight_step.return_value = {
-            "id": "config",
-            "status": "ready",
-            "optional": False,
-        }
+        preflight_step.side_effect = [
+            {"id": "config", "status": "ready", "optional": False},
+            {"id": "health", "status": "ready", "optional": False},
+        ]
 
         results, required_failures, optional_failures = compute_preflight(
             payload,
@@ -109,10 +108,77 @@ class PlannedDependencyPreflightTest(TestCase):
         )
 
         self.assertEqual([item["status"] for item in results], ["ready", "ready"])
-        self.assertIn("configuration runs", results[1]["checks"][0]["detail"])
         self.assertEqual(required_failures, [])
         self.assertEqual(optional_failures, [])
-        preflight_step.assert_called_once()
+        self.assertEqual(preflight_step.call_count, 2)
+        health_call = preflight_step.call_args_list[1]
+        self.assertEqual(
+            health_call.kwargs["deferred_driver_preflight_refs"],
+            {"platform/linux/eve-ng#student_config"},
+        )
+
+    @patch(
+        "hyops.drivers.config.ansible.runtime_env.ensure_hybridops_collections_available",
+        return_value="",
+    )
+    @patch("hyops.blueprint.planner.preflight_step")
+    def test_local_requirements_block_after_planned_configuration(
+        self,
+        preflight_step,
+        _collections,
+    ):
+        payload = {
+            "order": ["config", "images"],
+            "steps": [
+                {
+                    "id": "config",
+                    "module_ref": "platform/linux/eve-ng",
+                    "state_instance": "student_config",
+                    "action": "deploy",
+                    "phase": "operations",
+                    "optional": False,
+                },
+                {
+                    "id": "images",
+                    "module_ref": "platform/linux/eve-ng-images",
+                    "state_instance": "student_images",
+                    "action": "deploy",
+                    "phase": "operations",
+                    "optional": False,
+                    "requires": ["config"],
+                },
+            ],
+        }
+        preflight_step.side_effect = [
+            {"id": "config", "status": "ready", "optional": False},
+            {
+                "id": "images",
+                "status": "blocked",
+                "optional": False,
+                "checks": [
+                    {
+                        "name": "required_env",
+                        "ok": False,
+                        "detail": "missing required env vars: EVENG_IOL_LICENSE",
+                    }
+                ],
+            },
+        ]
+
+        results, required_failures, optional_failures = compute_preflight(
+            payload,
+            SimpleNamespace(),
+            SimpleNamespace(state_dir="/tmp/state", root=Path("/tmp/runtime")),
+        )
+
+        self.assertEqual([item["status"] for item in results], ["ready", "blocked"])
+        self.assertEqual(required_failures, ["images"])
+        self.assertEqual(optional_failures, [])
+        images_call = preflight_step.call_args_list[1]
+        self.assertEqual(
+            images_call.kwargs["deferred_driver_preflight_refs"],
+            {"platform/linux/eve-ng#student_config"},
+        )
 
     @patch("hyops.blueprint.planner.module_state_ok", return_value=True)
     @patch("hyops.blueprint.planner.preflight_step")

--- a/hyops/blueprint/tests/test_planner.py
+++ b/hyops/blueprint/tests/test_planner.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
-from hyops.blueprint.planner import _required_env_error, compute_preflight
+from hyops.blueprint.planner import _required_env_error, compute_preflight, preflight_step
 
 
 class RequiredEnvironmentPreflightTest(TestCase):
@@ -117,68 +117,59 @@ class PlannedDependencyPreflightTest(TestCase):
             {"platform/linux/eve-ng#student_config"},
         )
 
+    @patch("hyops.blueprint.planner.run_module_driver_preflight")
+    @patch("hyops.blueprint.planner.resolve_module")
+    @patch("hyops.blueprint.planner.resolve_module_root", return_value=Path("/tmp/modules"))
+    @patch("hyops.blueprint.planner.enforce_step_contracts")
     @patch(
-        "hyops.drivers.config.ansible.runtime_env.ensure_hybridops_collections_available",
-        return_value="",
+        "hyops.blueprint.planner.resolved_step_inputs_file",
+        return_value=Path("/tmp/images.inputs.yml"),
     )
-    @patch("hyops.blueprint.planner.preflight_step")
     def test_local_requirements_block_after_planned_configuration(
         self,
-        preflight_step,
-        _collections,
+        _inputs_file,
+        _contracts,
+        _module_root,
+        resolve_module,
+        driver_preflight,
     ):
-        payload = {
-            "order": ["config", "images"],
-            "steps": [
-                {
-                    "id": "config",
-                    "module_ref": "platform/linux/eve-ng",
-                    "state_instance": "student_config",
-                    "action": "deploy",
-                    "phase": "operations",
-                    "optional": False,
-                },
-                {
-                    "id": "images",
-                    "module_ref": "platform/linux/eve-ng-images",
-                    "state_instance": "student_images",
-                    "action": "deploy",
-                    "phase": "operations",
-                    "optional": False,
-                    "requires": ["config"],
-                },
-            ],
+        step = {
+            "id": "images",
+            "module_ref": "platform/linux/eve-ng-images",
+            "state_instance": "student_images",
+            "action": "deploy",
+            "phase": "operations",
+            "optional": False,
+            "requires": ["config"],
         }
-        preflight_step.side_effect = [
-            {"id": "config", "status": "ready", "optional": False},
-            {
-                "id": "images",
-                "status": "blocked",
-                "optional": False,
-                "checks": [
-                    {
-                        "name": "required_env",
-                        "ok": False,
-                        "detail": "missing required env vars: EVENG_IOL_LICENSE",
-                    }
-                ],
-            },
-        ]
-
-        results, required_failures, optional_failures = compute_preflight(
-            payload,
-            SimpleNamespace(),
-            SimpleNamespace(state_dir="/tmp/state", root=Path("/tmp/runtime")),
+        resolve_module.return_value = SimpleNamespace(
+            inputs={"required_env": ["EVENG_IOL_LICENSE"]},
+            required_credentials=[],
+            outputs_publish=[],
         )
 
-        self.assertEqual([item["status"] for item in results], ["ready", "blocked"])
-        self.assertEqual(required_failures, ["images"])
-        self.assertEqual(optional_failures, [])
-        images_call = preflight_step.call_args_list[1]
-        self.assertEqual(
-            images_call.kwargs["deferred_driver_preflight_refs"],
-            {"platform/linux/eve-ng#student_config"},
+        with patch.dict("hyops.blueprint.planner.os.environ", {}, clear=True):
+            result = preflight_step(
+                step,
+                {"steps": [step]},
+                SimpleNamespace(env="student-lab", module_root="modules"),
+                SimpleNamespace(
+                    state_dir=Path("/tmp/state"),
+                    root=Path("/tmp/runtime"),
+                    credentials_dir=Path("/tmp/credentials"),
+                ),
+                assumed_state_ok={"platform/linux/eve-ng#student_config"},
+                deferred_driver_preflight_refs={
+                    "platform/linux/eve-ng#student_config"
+                },
+            )
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertIn(
+            "missing required env vars: EVENG_IOL_LICENSE",
+            result["checks"][-1]["detail"],
         )
+        driver_preflight.assert_not_called()
 
     @patch("hyops.blueprint.planner.module_state_ok", return_value=True)
     @patch("hyops.blueprint.planner.preflight_step")


### PR DESCRIPTION
## Summary

- run local contract, input and required-secret checks for every planned blueprint step
- defer only remote driver checks while upstream configuration is still planned
- prevent infrastructure mutation when a downstream step is missing required input such as `EVENG_IOL_LICENSE`

## Validation

- `python3 -m unittest hyops.blueprint.tests.test_planner`
- Ruff on the changed planner and test files
- full 476-test Core suite on the acceptance branch
- macOS ARM and x86_64 candidate build and installation checks

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.