### PR TITLE
feat: add existing lab migration intake

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,13 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   selected blueprint reference and restored through the existing lifecycle.
 - Added capacity gates for lab capture, migration import and target restore so
   insufficient disk space is reported before existing lab data is replaced.
+- Added optional, checksummed migration of EVE-NG base images referenced by
+  captured lab definitions. Licence material remains outside the archive.
+
+### Changed
+
+- Preferred sparse-aware, parallel level-one compression for remote lab capture
+  when `pigz` is available, with `gzip -1` as the portable fallback.
 
 ### Fixed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,16 @@
 
 This changelog records significant operator-facing capabilities, lifecycle changes, compatibility fixes, and release engineering updates. Individual commits and maintenance-only changes remain available through the linked comparisons.
 
+## Unreleased
+
+### Added
+
+- Added verified same-platform migration intake for existing EVE-NG and GNS3
+  labs. Imported bundles are inspected, checksum-verified, bound to the
+  selected blueprint reference and restored through the existing lifecycle.
+- Added capacity gates for lab capture, migration import and target restore so
+  insufficient disk space is reported before existing lab data is replaced.
+
 ## [v0.1.4] - 2026-08-29
 
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,9 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 - Preferred sparse-aware, parallel level-one compression for remote lab capture
   when `pigz` is available, with `gzip -1` as the portable fallback.
+- Required an explicit guest-quiesced acknowledgement before EVE-NG QEMU
+  node-state capture and recorded the selected consistency boundary.
+- Rejected automatic QEMU termination during protected EVE-NG teardown.
 - Staged migrated EVE-NG images before transactional promotion and rollback.
 - Reported migration capture stages, assessed source sizes, transferred bytes,
   average rate and elapsed time during long-running archive streams.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   explicit restore flag instead of a generic configuration failure.
 - Reported streamed command timeouts as exit code 124 with the configured limit
   instead of exposing the terminating signal as `rc=-9`.
+- Limited EVE-NG node-state capture to writable QEMU disks referenced by the
+  selected lab definitions.
 
 ## [v0.1.4] - 2026-08-29
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,7 +23,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   when `pigz` is available, with `gzip -1` as the portable fallback.
 - Required an explicit guest-quiesced acknowledgement before EVE-NG QEMU
   node-state capture and recorded the selected consistency boundary.
-- Rejected automatic QEMU termination during protected EVE-NG teardown.
+- Made the legacy automatic-QEMU-stop setting inert during protected EVE-NG
+  teardown so existing environment overlays fail closed without being rewritten.
 - Staged migrated EVE-NG images before transactional promotion and rollback.
 - Reported migration capture stages, assessed source sizes, transferred bytes,
   average rate and elapsed time during long-running archive streams.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,9 +16,9 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   captured lab definitions. Licence material remains outside the archive.
 - Added independent `--overwrite-images` control for explicit base-image
   replacement during migration restore.
-- Added operator-supplied EVE-NG guest quiescence actions for migration capture
-  and protected teardown, with bounded QEMU-stop verification and checksummed
-  archive evidence.
+- Added environment-managed EVE-NG guest quiescence actions for protected
+  teardown, operation-specific overrides for migration capture, bounded
+  QEMU-stop verification, and checksummed archive evidence.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Fixed
 
+- Disabled SSH connection multiplexing for GCP IAP configuration runs and
+  verified passwordless privilege escalation during connectivity preflight.
 - Assessed all requested migration streams through one SSH session before
   transferring archives.
 - Retained the verified migration image companion across later lab archive

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,11 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 - Added capacity gates for lab capture, migration import and target restore so
   insufficient disk space is reported before existing lab data is replaced.
 
+### Fixed
+
+- Assessed all requested migration streams through one SSH session before
+  transferring archives.
+
 ## [v0.1.4] - 2026-08-29
 
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   transferring archives.
 - Retained the verified migration image companion across later lab archive
   generations and rejected unreferenced bases or IOL licence material.
+- Surfaced conflicting EVE-NG lab, node-state and image paths with the matching
+  explicit restore flag instead of a generic configuration failure.
 
 ## [v0.1.4] - 2026-08-29
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   average rate and elapsed time during long-running archive streams.
 - Reported the active archive, image and node-state phase during long lab
   restores instead of displaying an unqualified spinner.
+- Applied a bounded four-hour execution window to EVE-NG, GNS3 and Containerlab
+  archive operations instead of the shared one-hour configuration limit.
 
 ### Fixed
 
@@ -39,6 +41,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   generations and rejected unreferenced bases or IOL licence material.
 - Surfaced conflicting EVE-NG lab, node-state and image paths with the matching
   explicit restore flag instead of a generic configuration failure.
+- Reported streamed command timeouts as exit code 124 with the configured limit
+  instead of exposing the terminating signal as `rc=-9`.
 
 ## [v0.1.4] - 2026-08-29
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,16 +13,21 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   insufficient disk space is reported before existing lab data is replaced.
 - Added optional, checksummed migration of EVE-NG base images referenced by
   captured lab definitions. Licence material remains outside the archive.
+- Added independent `--overwrite-images` control for explicit base-image
+  replacement during migration restore.
 
 ### Changed
 
 - Preferred sparse-aware, parallel level-one compression for remote lab capture
   when `pigz` is available, with `gzip -1` as the portable fallback.
+- Staged migrated EVE-NG images before transactional promotion and rollback.
 
 ### Fixed
 
 - Assessed all requested migration streams through one SSH session before
   transferring archives.
+- Retained the verified migration image companion across later lab archive
+  generations and rejected unreferenced bases or IOL licence material.
 
 ## [v0.1.4] - 2026-08-29
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,9 +6,10 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 
 ### Added
 
-- Added verified same-platform migration intake for existing EVE-NG and GNS3
-  labs. Imported bundles are inspected, checksum-verified, bound to the
-  selected blueprint reference and restored through the existing lifecycle.
+- Added verified same-platform migration intake for existing EVE-NG, GNS3 and
+  Containerlab labs. Imported bundles are inspected, checksum-verified, bound
+  to the selected blueprint reference and restored through the existing
+  lifecycle.
 - Added capacity gates for lab capture, migration import and target restore so
   insufficient disk space is reported before existing lab data is replaced.
 - Added optional, checksummed migration of EVE-NG base images referenced by

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 - Preferred sparse-aware, parallel level-one compression for remote lab capture
   when `pigz` is available, with `gzip -1` as the portable fallback.
 - Staged migrated EVE-NG images before transactional promotion and rollback.
+- Reported migration capture stages, assessed source sizes, transferred bytes,
+  average rate and elapsed time during long-running archive streams.
 
 ### Fixed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,9 @@ This changelog records significant operator-facing capabilities, lifecycle chang
   captured lab definitions. Licence material remains outside the archive.
 - Added independent `--overwrite-images` control for explicit base-image
   replacement during migration restore.
+- Added operator-supplied EVE-NG guest quiescence actions for migration capture
+  and protected teardown, with bounded QEMU-stop verification and checksummed
+  archive evidence.
 
 ### Changed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,8 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 - Staged migrated EVE-NG images before transactional promotion and rollback.
 - Reported migration capture stages, assessed source sizes, transferred bytes,
   average rate and elapsed time during long-running archive streams.
+- Reported the active archive, image and node-state phase during long lab
+  restores instead of displaying an unqualified spinner.
 
 ### Fixed
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -160,7 +160,8 @@ hyops lab migrate capture \
   --host <existing-host> \
   --user <ssh-user> \
   --output ./eve-ng-labs.tar.gz \
-  --include-node-state
+  --include-node-state \
+  --include-images
 ```
 
 OpenSSH uses its configured agent or keys and prompts for the account password
@@ -169,7 +170,10 @@ password. Capture assesses all requested streams before transferring data.
 
 Capture refuses to proceed while EVE-NG QEMU nodes or the GNS3 server are
 running. Use `--become` when the SSH account has passwordless sudo access.
-GNS3 images remain separate unless `--include-images` is selected.
+For EVE-NG, `--include-images` creates a separate archive containing only the
+base images referenced by the captured labs. For GNS3, it includes the image
+library in the primary archive. Capture uses `pigz -1` when available and
+otherwise uses `gzip -1`. Sparse virtual disks remain sparse in the archive.
 
 Inspect an archive first:
 
@@ -177,7 +181,8 @@ Inspect an archive first:
 hyops lab migrate inspect \
   --platform eve-ng \
   --archive ./eve-ng-labs.tar.gz \
-  --node-state ./eve-ng-labs.node-state.tar.gz
+  --node-state ./eve-ng-labs.node-state.tar.gz \
+  --images ./eve-ng-labs.images.tar.gz
 ```
 
 Stage the verified bundle for an initialized environment:
@@ -188,7 +193,8 @@ hyops lab migrate import \
   --ref gcp/eve-ng@v1 \
   --platform eve-ng \
   --archive ./eve-ng-labs.tar.gz \
-  --node-state ./eve-ng-labs.node-state.tar.gz
+  --node-state ./eve-ng-labs.node-state.tar.gz \
+  --images ./eve-ng-labs.images.tar.gz
 
 hyops blueprint deploy \
   --env <env> \
@@ -199,10 +205,10 @@ hyops blueprint deploy \
 
 The EVE-NG primary archive must be relative to `/opt/unetlab/labs`. Its
 optional node-state companion contains stopped QEMU overlays using the EVE-NG
-tenant, lab and node path layout. A GNS3 archive must be relative to its data
-root and contain `projects/` state. Base images and licence material remain
-separately managed. Use `--expected-sha256` and
-`--node-state-expected-sha256` when checksums were recorded at the source.
+tenant, lab and node path layout. Its optional image companion contains only
+referenced QEMU, IOL or Dynamips bases. Licence material is never included. A
+GNS3 archive must be relative to its data root and contain `projects/` state.
+Use the matching checksum options when checksums were recorded at the source.
 Capture and import retain 64 MiB free on the controller filesystem. Restore
 checks the target filesystem before existing lab data is replaced.
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -163,6 +163,10 @@ hyops lab migrate capture \
   --include-node-state
 ```
 
+OpenSSH uses its configured agent or keys and prompts for the account password
+in an interactive terminal when required. HybridOps does not store that
+password. Capture assesses all requested streams before transferring data.
+
 Capture refuses to proceed while EVE-NG QEMU nodes or the GNS3 server are
 running. Use `--become` when the SSH account has passwordless sudo access.
 GNS3 images remain separate unless `--include-images` is selected.

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -173,8 +173,12 @@ password. Capture assesses all requested streams before transferring data.
 Before EVE-NG node-state capture, shut down each stateful guest inside its
 operating system and pass `--guest-quiesced`. Stopping a node in EVE-NG does
 not establish a clean guest shutdown. Capture also refuses to proceed while
-EVE-NG QEMU nodes or the GNS3 server are running. Use `--become` when the SSH
-account has passwordless sudo access.
+EVE-NG QEMU nodes or the GNS3 server are running. For a repeatable action,
+replace `--guest-quiesced` with `--quiesce-script ./quiesce-lab.sh`. The script
+runs on the EVE-NG host; Core verifies that QEMU has stopped and records the
+script checksum. Use `--become` when the SSH account has passwordless sudo
+access.
+
 For EVE-NG, `--include-images` creates a separate archive containing only the
 base images referenced by the captured labs. For GNS3, it includes the image
 library in the primary archive. Capture uses `pigz -1` when available and

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -148,11 +148,12 @@ runbook.
 
 ## Existing lab migration
 
-Existing EVE-NG and GNS3 labs can be inspected and staged before a new
-HybridOps-managed host is deployed. Migration remains within the same lab
-platform. The source host is not modified.
+Existing EVE-NG, GNS3 and Containerlab labs can be inspected and staged before
+a new HybridOps-managed host is deployed. Migration remains within the same
+lab platform. The source host is not modified.
 
-Save intended device configurations and stop the source nodes before capture:
+For EVE-NG and GNS3, save intended device configurations and stop the source
+nodes before capture:
 
 ```bash
 hyops lab migrate capture \
@@ -174,6 +175,26 @@ For EVE-NG, `--include-images` creates a separate archive containing only the
 base images referenced by the captured labs. For GNS3, it includes the image
 library in the primary archive. Capture uses `pigz -1` when available and
 otherwise uses `gzip -1`. Sparse virtual disks remain sparse in the archive.
+
+For Containerlab, identify the authoritative source tree and topology:
+
+```bash
+hyops lab migrate capture \
+  --platform containerlab \
+  --host <existing-host> \
+  --user <ssh-user> \
+  --source-root /srv/containerlab/<lab> \
+  --topology-relpath lab.clab.yml \
+  --output ./containerlab-lab.tar.gz
+```
+
+Capture retains the source tree and asks Containerlab to copy supported saved
+configurations into it. Generated top-level `clab-*` runtime directories are
+excluded. Container images remain topology references and must be available to
+the target host through their authorised registry or image-loading process.
+Use `--source-labdir-base` only when the existing host overrides Containerlab's
+native lab-data location. `--target-labdir-base` must match the target blueprint
+when its managed default has been changed.
 
 Inspect an archive first:
 
@@ -206,6 +227,27 @@ hyops blueprint deploy \
 Existing lab definitions and base images are protected independently. Add
 `--overwrite-labs` to replace lab definitions or `--overwrite-images` to
 replace referenced base images. Neither flag is required on a new host.
+
+A Containerlab import must match the target topology path and native lab-data
+base. It publishes the verified archive through the existing latest-recovery
+contract, and the next normal blueprint deployment restores it automatically.
+
+```bash
+hyops lab migrate inspect \
+  --platform containerlab \
+  --archive ./containerlab-lab.tar.gz
+
+hyops lab migrate import \
+  --env <env> \
+  --ref gcp/containerlab@v1 \
+  --platform containerlab \
+  --archive ./containerlab-lab.tar.gz
+
+hyops blueprint deploy \
+  --env <env> \
+  --ref gcp/containerlab@v1 \
+  --execute
+```
 
 The EVE-NG primary archive must be relative to `/opt/unetlab/labs`. Its
 optional node-state companion contains stopped QEMU overlays using the EVE-NG

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -236,6 +236,11 @@ Existing lab definitions and base images are protected independently. Add
 `--overwrite-labs` to replace lab definitions or `--overwrite-images` to
 replace referenced base images. Neither flag is required on a new host.
 
+Bundle verification proves archive integrity and path compatibility. A
+cross-target EVE-NG migration is complete only after the restored appliances
+pass their own boot and service checks. Restore rejects structural QCOW2
+corruption and does not modify captured overlays to repair a guest.
+
 A Containerlab import must match the target topology path and native lab-data
 base. It publishes the verified archive through the existing latest-recovery
 contract, and the next normal blueprint deployment restores it automatically.

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -143,8 +143,64 @@ hyops blueprint deploy --env <env> \
 ```
 
 Use `--root /tmp/hyops-runtime` when an explicit runtime root is required. The
-[GCP EVE-NG blueprint](gcp/eve-ng@v1/README.md) contains the complete operating
-sequence.
+[GCP EVE-NG blueprint](gcp/eve-ng@v1/README.md) links to the complete operator
+runbook.
+
+## Existing lab migration
+
+Existing EVE-NG and GNS3 labs can be inspected and staged before a new
+HybridOps-managed host is deployed. Migration remains within the same lab
+platform. The source host is not modified.
+
+Save intended device configurations and stop the source nodes before capture:
+
+```bash
+hyops lab migrate capture \
+  --platform eve-ng \
+  --host <existing-host> \
+  --user <ssh-user> \
+  --output ./eve-ng-labs.tar.gz \
+  --include-node-state
+```
+
+Capture refuses to proceed while EVE-NG QEMU nodes or the GNS3 server are
+running. Use `--become` when the SSH account has passwordless sudo access.
+GNS3 images remain separate unless `--include-images` is selected.
+
+Inspect an archive first:
+
+```bash
+hyops lab migrate inspect \
+  --platform eve-ng \
+  --archive ./eve-ng-labs.tar.gz \
+  --node-state ./eve-ng-labs.node-state.tar.gz
+```
+
+Stage the verified bundle for an initialized environment:
+
+```bash
+hyops lab migrate import \
+  --env <env> \
+  --ref gcp/eve-ng@v1 \
+  --platform eve-ng \
+  --archive ./eve-ng-labs.tar.gz \
+  --node-state ./eve-ng-labs.node-state.tar.gz
+
+hyops blueprint deploy \
+  --env <env> \
+  --ref gcp/eve-ng@v1 \
+  --execute \
+  --restore-labs
+```
+
+The EVE-NG primary archive must be relative to `/opt/unetlab/labs`. Its
+optional node-state companion contains stopped QEMU overlays using the EVE-NG
+tenant, lab and node path layout. A GNS3 archive must be relative to its data
+root and contain `projects/` state. Base images and licence material remain
+separately managed. Use `--expected-sha256` and
+`--node-state-expected-sha256` when checksums were recorded at the source.
+Capture and import retain 64 MiB free on the controller filesystem. Restore
+checks the target filesystem before existing lab data is replaced.
 
 ## Shipped Blueprint Boundary
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -203,6 +203,10 @@ hyops blueprint deploy \
   --restore-labs
 ```
 
+Existing lab definitions and base images are protected independently. Add
+`--overwrite-labs` to replace lab definitions or `--overwrite-images` to
+replace referenced base images. Neither flag is required on a new host.
+
 The EVE-NG primary archive must be relative to `/opt/unetlab/labs`. Its
 optional node-state companion contains stopped QEMU overlays using the EVE-NG
 tenant, lab and node path layout. Its optional image companion contains only
@@ -210,7 +214,7 @@ referenced QEMU, IOL or Dynamips bases. Licence material is never included. A
 GNS3 archive must be relative to its data root and contain `projects/` state.
 Use the matching checksum options when checksums were recorded at the source.
 Capture and import retain 64 MiB free on the controller filesystem. Restore
-checks the target filesystem before existing lab data is replaced.
+checks the target filesystem and stages image content before promotion.
 
 ## Shipped Blueprint Boundary
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -162,6 +162,7 @@ hyops lab migrate capture \
   --user <ssh-user> \
   --output ./eve-ng-labs.tar.gz \
   --include-node-state \
+  --guest-quiesced \
   --include-images
 ```
 
@@ -169,8 +170,11 @@ OpenSSH uses its configured agent or keys and prompts for the account password
 in an interactive terminal when required. HybridOps does not store that
 password. Capture assesses all requested streams before transferring data.
 
-Capture refuses to proceed while EVE-NG QEMU nodes or the GNS3 server are
-running. Use `--become` when the SSH account has passwordless sudo access.
+Before EVE-NG node-state capture, shut down each stateful guest inside its
+operating system and pass `--guest-quiesced`. Stopping a node in EVE-NG does
+not establish a clean guest shutdown. Capture also refuses to proceed while
+EVE-NG QEMU nodes or the GNS3 server are running. Use `--become` when the SSH
+account has passwordless sudo access.
 For EVE-NG, `--include-images` creates a separate archive containing only the
 base images referenced by the captured labs. For GNS3, it includes the image
 library in the primary archive. Capture uses `pigz -1` when available and

--- a/blueprints/gcp/containerlab@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/containerlab@v1/ARCHITECTURE.md
@@ -119,6 +119,10 @@ On fresh compute, HybridOps:
 8. performs one native Containerlab deployment
 9. runs the independent health check
 
+A verified existing-lab migration import publishes the same latest pointer,
+checksum and metadata contract. The rebuild path therefore restores an
+imported source tree without a separate deployment mode.
+
 ## Recovery modes
 
 `rebuild` keeps the source tree and native configuration-save output produced by the topology. Automatic configuration reuse follows the topology's existing startup-config references.

--- a/blueprints/gcp/containerlab@v1/README.md
+++ b/blueprints/gcp/containerlab@v1/README.md
@@ -26,5 +26,6 @@ Container images remain native references in the topology. The blueprint can ver
 ## Documentation
 
 - [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-containerlab/)
+- [Existing lab migration](../../../README.md#existing-lab-migration)
 - [Lifecycle and ownership](ARCHITECTURE.md)
 - [Acceptance record](VALIDATION.md)

--- a/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
@@ -116,6 +116,12 @@ Existing lab definitions and base images are protected independently. Replacemen
 
 The restore path reconstructs the surrounding execution environment while returning EVE-NG definitions and selected QEMU state to EVE-NG rather than translating them into another lab format.
 
+Archive verification establishes the integrity and layout of the retained
+state. It does not establish that every guest appliance can boot the same
+writable disk state on a different hypervisor target. Restored nodes must pass
+their own boot and service checks before the migration is accepted. HybridOps
+does not rewrite captured QCOW2 state to repair an appliance during restore.
+
 ## Compute lifetime and cost boundary
 
 Access closure and compute release are separate lifecycle events. Ending a browser, console or SSH session leaves the execution host unchanged; the host becomes eligible for release when the selected continuity state has been preserved and verified.

--- a/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
@@ -85,7 +85,7 @@ Live management addresses are session state. Durable role, platform, grouping an
 
 The blueprint configures `platform/linux/eve-ng-lab-archive` before destructive lifecycle actions.
 
-The primary archive retains EVE-NG lab definitions from `/opt/unetlab/labs` after EVE-NG refreshes saved device configurations in those definitions. The node-state companion path captures stopped QEMU overlays when node-state preservation is selected. The lifecycle stops running QEMU nodes before overlay capture, validates the overlays and records a separate SHA-256 for the companion archive.
+The primary archive retains EVE-NG lab definitions from `/opt/unetlab/labs` after EVE-NG refreshes saved device configurations in those definitions. The node-state companion path captures stopped QEMU overlays when node-state preservation is selected. The operator shuts down stateful guests inside their operating systems and stops the EVE-NG nodes. HybridOps records the per-run acknowledgement, rejects running QEMU processes, validates the overlays and records a separate SHA-256 for the companion archive.
 
 ```text
 lab definitions and saved configurations --+

--- a/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
@@ -101,7 +101,7 @@ stopped QEMU overlays, when selected -------+--> controller-side retained set
                                                compute release
 ```
 
-Vendor or base images remain separately managed. Restored overlays are paired with the matching installed base images. This keeps the retained continuity set focused on lab-owned mutable state.
+Base images remain separately managed during routine preservation. A verified migration intake can carry only the bases referenced by the imported labs. Restored overlays are paired with those installed bases.
 
 ## Restore path
 
@@ -112,7 +112,7 @@ existing EVE-NG lab. Intake checks its lab definitions, archive paths, image
 references and optional QEMU overlay layout, then binds the retained copy to
 this blueprint. The source host remains unchanged.
 
-Existing lab content is protected by default. Replacement requires the explicit overwrite option.
+Existing lab definitions and base images are protected independently. Replacement requires `--overwrite-labs` or `--overwrite-images` for the relevant content.
 
 The restore path reconstructs the surrounding execution environment while returning EVE-NG definitions and selected QEMU state to EVE-NG rather than translating them into another lab format.
 

--- a/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/eve-ng@v1/ARCHITECTURE.md
@@ -107,6 +107,11 @@ Vendor or base images remain separately managed. Restored overlays are paired wi
 
 `--restore-labs` selects the latest verified archive state recorded for the environment. The runtime verifies the primary archive checksum and, when present, the node-state companion checksum before invoking the archive module in restore mode.
 
+A verified migration bundle can provide the initial archive state for an
+existing EVE-NG lab. Intake checks its lab definitions, archive paths, image
+references and optional QEMU overlay layout, then binds the retained copy to
+this blueprint. The source host remains unchanged.
+
 Existing lab content is protected by default. Replacement requires the explicit overwrite option.
 
 The restore path reconstructs the surrounding execution environment while returning EVE-NG definitions and selected QEMU state to EVE-NG rather than translating them into another lab format.

--- a/blueprints/gcp/eve-ng@v1/README.md
+++ b/blueprints/gcp/eve-ng@v1/README.md
@@ -25,5 +25,6 @@ EVE-NG credentials and authorised IOL licence content belong in the encrypted en
 ## Documentation
 
 - [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
+- [Existing lab migration](../../../README.md#existing-lab-migration)
 - [Lifecycle and ownership](ARCHITECTURE.md)
 - [Proxmox blueprint](../../onprem/eve-ng@v1/blueprint.yml)

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -58,7 +58,8 @@ archive_before_destroy:
     # Refresh supported saved device configurations before archiving the lab.
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
-    # Node-state export requires per-run --guest-quiesced or --quiesce-script.
+    # Configure reusable shutdown with `hyops blueprint quiescence edit`.
+    # Use --guest-quiesced only after a manual clean shutdown.
     eveng_lab_archive_include_node_state: true
 
 steps:

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -9,6 +9,7 @@ metadata:
   description: "Provision a single nested-virtualization-capable GCP VM and configure EVE-NG over IAP."
   outcome: "A private EVE-NG host exists in GCP and is configured for governed training and network simulation use."
   ready_message: "EVE-NG network emulation lab ready"
+  credential_secret: "EVENG_ADMIN_PASSWORD"
 
 policy:
   fail_fast: true

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -58,7 +58,7 @@ archive_before_destroy:
     # Refresh supported saved device configurations before archiving the lab.
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
-    # Node-state export requires a per-run --guest-quiesced acknowledgement.
+    # Node-state export requires per-run --guest-quiesced or --quiesce-script.
     eveng_lab_archive_include_node_state: true
 
 steps:

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -59,7 +59,7 @@ archive_before_destroy:
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
     eveng_lab_archive_include_node_state: true
-    eveng_lab_archive_stop_running_nodes: true
+    eveng_lab_archive_stop_running_nodes: false
 
 steps:
   - id: gcp_eve_ng_network

--- a/blueprints/gcp/eve-ng@v1/blueprint.yml
+++ b/blueprints/gcp/eve-ng@v1/blueprint.yml
@@ -58,8 +58,8 @@ archive_before_destroy:
     # Refresh supported saved device configurations before archiving the lab.
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
+    # Node-state export requires a per-run --guest-quiesced acknowledgement.
     eveng_lab_archive_include_node_state: true
-    eveng_lab_archive_stop_running_nodes: false
 
 steps:
   - id: gcp_eve_ng_network

--- a/blueprints/gcp/gns3@v1/ARCHITECTURE.md
+++ b/blueprints/gcp/gns3@v1/ARCHITECTURE.md
@@ -106,6 +106,11 @@ Base images are independently managed by default and can be reconstructed from t
 
 `--restore-labs` selects the latest verified archive state recorded for the environment. The runtime verifies the recorded checksum before invoking the GNS3 archive module in restore mode.
 
+A verified migration bundle can provide the initial project state for an
+existing GNS3 installation. Intake checks the archive root, project
+definitions, image references and checksum, then binds the retained copy to
+this blueprint. The source host remains unchanged.
+
 The restore operation stops the GNS3 service, applies the retained project and controller state, restores ownership, starts the service and waits for the API to return. The normal blueprint health path then verifies the reconstructed lab environment.
 
 ## Compute lifetime and cost boundary

--- a/blueprints/gcp/gns3@v1/README.md
+++ b/blueprints/gcp/gns3@v1/README.md
@@ -26,5 +26,6 @@ The GNS3 server password and authorised IOU licence content belong in the encryp
 ## Documentation
 
 - [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-gns3/)
+- [Existing lab migration](../../../README.md#existing-lab-migration)
 - [Lifecycle and ownership](ARCHITECTURE.md)
 - [Proxmox blueprint](../../onprem/gns3@v1/blueprint.yml)

--- a/blueprints/onprem/eve-ng@v1/README.md
+++ b/blueprints/onprem/eve-ng@v1/README.md
@@ -25,4 +25,5 @@ The target bridge must provide VM connectivity. EVE-NG credentials and authorise
 ## Documentation
 
 - [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-eve-ng/)
+- [Existing lab migration](../../../README.md#existing-lab-migration)
 - [GCP blueprint](../../gcp/eve-ng@v1/blueprint.yml)

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -9,6 +9,7 @@ metadata:
   description: "Build a Jammy template image (if needed), provision a standalone EVE-NG VM on the Proxmox uplink, then configure EVE-NG."
   outcome: "EVE-NG is installed and reachable."
   ready_message: "EVE-NG network emulation lab ready"
+  credential_secret: "EVENG_ADMIN_PASSWORD"
 
 policy:
   fail_fast: true

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -61,7 +61,7 @@ archive_before_destroy:
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
     eveng_lab_archive_include_node_state: true
-    eveng_lab_archive_stop_running_nodes: true
+    eveng_lab_archive_stop_running_nodes: false
 
 steps:
   - id: template_image_jammy

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -60,7 +60,8 @@ archive_before_destroy:
     # Refresh supported saved device configurations before archiving the lab.
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
-    # Node-state export requires per-run --guest-quiesced or --quiesce-script.
+    # Configure reusable shutdown with `hyops blueprint quiescence edit`.
+    # Use --guest-quiesced only after a manual clean shutdown.
     eveng_lab_archive_include_node_state: true
 
 steps:

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -60,8 +60,8 @@ archive_before_destroy:
     # Refresh supported saved device configurations before archiving the lab.
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
+    # Node-state export requires a per-run --guest-quiesced acknowledgement.
     eveng_lab_archive_include_node_state: true
-    eveng_lab_archive_stop_running_nodes: false
 
 steps:
   - id: template_image_jammy

--- a/blueprints/onprem/eve-ng@v1/blueprint.yml
+++ b/blueprints/onprem/eve-ng@v1/blueprint.yml
@@ -60,7 +60,7 @@ archive_before_destroy:
     # Refresh supported saved device configurations before archiving the lab.
     # Save intended device changes to startup configuration first.
     eveng_lab_archive_capture_device_configs: true
-    # Node-state export requires a per-run --guest-quiesced acknowledgement.
+    # Node-state export requires per-run --guest-quiesced or --quiesce-script.
     eveng_lab_archive_include_node_state: true
 
 steps:

--- a/blueprints/onprem/gns3@v1/README.md
+++ b/blueprints/onprem/gns3@v1/README.md
@@ -26,4 +26,5 @@ The target bridge must provide VM connectivity. The GNS3 server password and aut
 ## Documentation
 
 - [Operator runbook](https://docs.hybridops.tech/ops/runbooks/platform/blueprints/hyops-blueprint-gns3/)
+- [Existing lab migration](../../../README.md#existing-lab-migration)
 - [GCP blueprint](../../gcp/gns3@v1/blueprint.yml)

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -3879,11 +3879,16 @@ def _verified_lab_archive(
             state_instance=lifecycle["state_instance"],
         )
     except FileNotFoundError:
-        return None
+        state = {}
     outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
     contract = _lab_archive_contract(lifecycle)
-    archive_path = Path(str(outputs.get(contract["path_output"]) or "")).expanduser()
+    archive_value = str(outputs.get(contract["path_output"]) or "").strip()
     expected = str(outputs.get(contract["sha256_output"]) or "").strip().lower()
+    if not archive_value and not expected:
+        from hyops.lab.migration import load_migration_archive
+
+        return load_migration_archive(paths=paths, payload=payload)
+    archive_path = Path(archive_value).expanduser()
     if not archive_path.is_file() or not re.fullmatch(r"[0-9a-f]{64}", expected):
         return None
 

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -4654,6 +4654,11 @@ def _confirm_archive_destroy(env_name: str) -> bool | None:
 
 def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
     archive = payload["archive_before_destroy"]
+    archive_inputs = dict(archive.get("inputs") or {})
+    if _archive_requires_guest_quiescence(payload):
+        archive_inputs["eveng_lab_archive_guest_quiesced"] = bool(
+            getattr(ns, "guest_quiesced", False)
+        )
     archive_step = {
         "id": "archive_before_destroy",
         "module_ref": archive["module_ref"],
@@ -4661,7 +4666,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         "action": "deploy",
         "phase": "operations",
         "with_deps": False,
-        "inputs": archive.get("inputs") or {},
+        "inputs": archive_inputs,
     }
     print("preparing saved lab state; guests must already be shut down")
     print("this may take several minutes, depending on lab size")

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -46,6 +46,7 @@ from hyops.runtime.preflight_decision import (
     new_preflight_decision,
     validate_preflight_bypass,
 )
+from hyops.runtime.proc import observe_stream_output
 from hyops.runtime.progress import ProgressDisplay, verbose_enabled
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.source_roots import resolve_blueprints_root
@@ -3912,6 +3913,60 @@ def _select_lab_restore_mode(
     return ("restore" if confirmed else "skip"), archive
 
 
+_ANSIBLE_TASK_LINE = re.compile(
+    r"^TASK \[(?:[^:\]]+ : )?(?P<task>.+?)\]\s*\*+\s*$"
+)
+
+
+def _lab_restore_phase(line: str) -> str:
+    match = _ANSIBLE_TASK_LINE.match(str(line or "").strip())
+    if match is None:
+        return ""
+    task = " ".join(match.group("task").split())
+    lowered = task.lower()
+
+    if "image" in lowered:
+        if "capacity" in lowered:
+            return "checking image capacity"
+        if "stage" in lowered:
+            return "staging images"
+        if "transaction" in lowered or "permissions" in lowered:
+            return "installing images"
+        if any(
+            term in lowered
+            for term in ("inspect", "verify", "list", "reject", "measure")
+        ):
+            return "verifying image archive"
+    if "node-state" in lowered or "node state" in lowered or "qemu overlay" in lowered:
+        if "capacity" in lowered:
+            return "checking node-state capacity"
+        if "repair" in lowered:
+            return "repairing node state"
+        if "validate" in lowered or "inspect" in lowered:
+            return "verifying node state"
+        if "restore" in lowered:
+            return "restoring node state"
+    if "saved configuration" in lowered:
+        return "applying saved configurations"
+    if "capacity" in lowered:
+        return "checking lab capacity"
+    if "restore" in lowered and ("lab archive" in lowered or "lab state" in lowered):
+        return "restoring lab definitions"
+    if "archive" in lowered and any(
+        term in lowered for term in ("extract", "restore", "stage")
+    ):
+        return "restoring lab data"
+    if "archive" in lowered and any(
+        term in lowered for term in ("inspect", "verify", "list", "reject", "measure")
+    ):
+        return "verifying lab archive"
+    if "ownership" in lowered or "permissions" in lowered:
+        return "applying permissions"
+    if "publish" in lowered or "restart" in lowered:
+        return "finalising"
+    return ""
+
+
 def _run_lab_restore(
     ns,
     payload: dict[str, Any],
@@ -3993,8 +4048,17 @@ def _run_lab_restore(
     previous_child = os.environ.get("HYOPS_PROGRESS_CHILD")
     if not os.getenv("HYOPS_VERBOSE"):
         os.environ["HYOPS_PROGRESS_CHILD"] = "1"
+
+    def update_restore_progress(stream: str, line: str) -> None:
+        if stream != "stdout":
+            return
+        phase = _lab_restore_phase(line)
+        if phase:
+            progress.update(restore_step["id"], f"Lab restore: {phase}")
+
     try:
-        rc = int(run_step_module_command(restore_step, payload, ns, paths))
+        with observe_stream_output(update_restore_progress):
+            rc = int(run_step_module_command(restore_step, payload, ns, paths))
     except KeyboardInterrupt:
         rc = CANCELLED
     finally:

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -94,6 +94,17 @@ from .planner import compute_preflight, run_step_module_command
 from .schema import load_blueprint, resolve_blueprint_file, validate_blueprint
 
 
+_QUIESCENCE_DRAFT_MARKER = "HYOPS_QUIESCENCE_ACTION_NOT_CONFIGURED"
+_QUIESCENCE_TEMPLATE = """#!/bin/sh
+set -eu
+
+# Shut down stateful guests and stop their EVE-NG nodes before returning.
+# Replace the line below with the actions required by this environment.
+echo 'HYOPS_QUIESCENCE_ACTION_NOT_CONFIGURED' >&2
+exit 64
+"""
+
+
 def _runtime_overlay_for_ref(ns, blueprint_ref: str) -> str:
     if not blueprint_ref:
         return ""
@@ -768,6 +779,42 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
     )
     e.set_defaults(_handler=run_edit)
 
+    quiescence = ssp.add_parser(
+        "quiescence",
+        help="Manage the environment guest-quiescence action.",
+    )
+    quiescence_commands = quiescence.add_subparsers(
+        dest="quiescence_cmd",
+        required=True,
+    )
+
+    def add_quiescence_args(sub: argparse.ArgumentParser) -> None:
+        add_common_args(sub)
+        sub.add_argument("--root", default=None, help="Override runtime root.")
+        sub.add_argument("--env", default=None, help="Runtime environment namespace.")
+
+    quiescence_status = quiescence_commands.add_parser(
+        "status",
+        help="Show the environment guest-quiescence action.",
+    )
+    add_quiescence_args(quiescence_status)
+    quiescence_status.set_defaults(_handler=run_quiescence)
+
+    quiescence_edit = quiescence_commands.add_parser(
+        "edit",
+        help="Create or edit the environment guest-quiescence action.",
+    )
+    add_quiescence_args(quiescence_edit)
+    quiescence_edit.add_argument(
+        "--editor",
+        default="",
+        help=(
+            "Editor command to use. Defaults to HYOPS_EDITOR, VISUAL, "
+            "EDITOR, then common editors."
+        ),
+    )
+    quiescence_edit.set_defaults(_handler=run_quiescence)
+
     q = ssp.add_parser("validate", help="Validate a blueprint manifest.")
     add_common_args(q)
     q.add_argument("--root", default=None, help="Override runtime root for overlay selection.")
@@ -1153,16 +1200,16 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         "--quiesce-script",
         default="",
         help=(
-            "Run a local POSIX shell script on the EVE-NG host before "
-            "node-state capture."
+            "Override the environment EVE-NG guest-quiescence action for "
+            "this operation."
         ),
     )
     d.add_argument(
         "--quiesce-timeout",
         type=int,
-        default=300,
+        default=None,
         metavar="SECONDS",
-        help="Maximum time for EVE-NG guest quiescence and QEMU shutdown.",
+        help="Override the environment guest-quiescence timeout.",
     )
     d.set_defaults(_handler=run_destroy)
 
@@ -1698,6 +1745,161 @@ def run_edit(ns) -> int:
         return 0
     except Exception as exc:
         print(f"ERR: blueprint edit failed: {exc}")
+        return OPERATOR_ERROR
+
+
+def _quiescence_action_path(paths, payload: dict[str, Any]) -> Path:
+    material = automation_session_paths(
+        paths=paths,
+        blueprint_ref=str(payload.get("blueprint_ref") or "blueprint"),
+        env_name=str(Path(paths.root).name),
+    )
+    return Path(material["config_dir"]) / "quiesce.sh"
+
+
+def _quiescence_edit_command(ns, payload: dict[str, Any]) -> str:
+    command = ["hyops", "blueprint", "quiescence", "edit"]
+    runtime_root = str(getattr(ns, "root", "") or "").strip()
+    env_name = str(getattr(ns, "env", "") or "").strip()
+    if runtime_root:
+        command.extend(["--root", runtime_root])
+    elif env_name:
+        command.extend(["--env", env_name])
+    blueprint_ref = str(
+        payload.get("blueprint_ref") or getattr(ns, "ref", "") or ""
+    ).strip()
+    if blueprint_ref:
+        command.extend(["--ref", blueprint_ref])
+    return shlex.join(command)
+
+
+def _validate_quiescence_action(path: Path) -> tuple[Path, str]:
+    unresolved = path.expanduser()
+    if unresolved.is_symlink():
+        raise ValueError("quiescence action must not be a symbolic link")
+    resolved = unresolved.resolve()
+    if not resolved.is_file():
+        raise ValueError(f"quiescence action is not a regular file: {resolved}")
+    size = resolved.stat().st_size
+    if size == 0:
+        raise ValueError("quiescence action is empty")
+    if size > 1024 * 1024:
+        raise ValueError("quiescence action exceeds the 1 MiB limit")
+    content = resolved.read_bytes()
+    if b"\x00" in content:
+        raise ValueError("quiescence action contains a NUL byte")
+    if _QUIESCENCE_DRAFT_MARKER.encode("utf-8") in content:
+        raise ValueError("quiescence action is not configured")
+    return resolved, hashlib.sha256(content).hexdigest()
+
+
+def _quiescence_context(ns) -> tuple[Any, dict[str, Any], Path]:
+    require_runtime_selection(
+        getattr(ns, "root", None),
+        getattr(ns, "env", None),
+        command_label="hyops blueprint quiescence",
+    )
+    paths = resolve_runtime_paths(getattr(ns, "root", None), getattr(ns, "env", None))
+    ensure_layout(paths)
+    require_runtime_writable(paths.root)
+    _enforce_runtime_blueprint_file_scope(
+        ns,
+        paths,
+        command_label="hyops blueprint quiescence",
+    )
+    payload = _resolve_and_validate(ns)
+    if not _archive_requires_guest_quiescence(payload):
+        raise ValueError(
+            "blueprint does not declare EVE-NG node-state preservation"
+        )
+    return paths, payload, _quiescence_action_path(paths, payload)
+
+
+def run_quiescence(ns) -> int:
+    try:
+        _paths, payload, action_path = _quiescence_context(ns)
+        action = str(getattr(ns, "quiescence_cmd", "") or "")
+        if action == "status":
+            if not action_path.exists() and not action_path.is_symlink():
+                status = {
+                    "blueprint_ref": payload["blueprint_ref"],
+                    "status": "unconfigured",
+                    "path": str(action_path),
+                }
+            else:
+                resolved, checksum = _validate_quiescence_action(action_path)
+                status = {
+                    "blueprint_ref": payload["blueprint_ref"],
+                    "status": "configured",
+                    "path": str(resolved),
+                    "sha256": checksum,
+                }
+            if bool(getattr(ns, "json", False)):
+                print(json.dumps(status, indent=2, sort_keys=True))
+            else:
+                print(
+                    f"blueprint={status['blueprint_ref']} "
+                    f"quiescence={status['status']}"
+                )
+                print(f"path={status['path']}")
+                if status.get("sha256"):
+                    print(f"sha256={status['sha256']}")
+            return 0
+        if action != "edit":
+            raise ValueError(f"unsupported quiescence command: {action}")
+
+        if action_path.is_symlink():
+            raise ValueError("quiescence action must not be a symbolic link")
+        action_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        action_path.parent.chmod(0o700)
+        draft_path = action_path.with_suffix(".sh.draft")
+        if draft_path.is_symlink() or (
+            draft_path.exists() and not draft_path.is_file()
+        ):
+            raise ValueError(f"quiescence draft is not a regular file: {draft_path}")
+        content = (
+            action_path.read_text(encoding="utf-8")
+            if action_path.is_file() and not action_path.is_symlink()
+            else _QUIESCENCE_TEMPLATE
+        )
+        draft_path.write_text(content, encoding="utf-8")
+        draft_path.chmod(0o600)
+
+        editor_argv = _editor_argv(ns)
+        editor_argv.append(str(draft_path))
+        print(f"Opening guest-quiescence action for edit: {draft_path}")
+        result = subprocess.run(editor_argv, check=False)
+        if result.returncode != 0:
+            raise ValueError(f"editor returned {result.returncode}")
+
+        draft_content = draft_path.read_text(encoding="utf-8")
+        if _QUIESCENCE_DRAFT_MARKER in draft_content:
+            raise ValueError(
+                f"quiescence action is not configured; draft retained at {draft_path}"
+            )
+        shell = shutil.which("sh")
+        if not shell:
+            raise ValueError("sh is required to validate the quiescence action")
+        syntax = subprocess.run(
+            [shell, "-n", str(draft_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        if syntax.returncode != 0:
+            detail = (syntax.stderr or "").strip()
+            raise ValueError(detail or "quiescence action has invalid shell syntax")
+        _validate_quiescence_action(draft_path)
+        draft_path.replace(action_path)
+        action_path.chmod(0o600)
+        resolved, checksum = _validate_quiescence_action(action_path)
+        print(f"blueprint={payload['blueprint_ref']} quiescence=configured")
+        print(f"path={resolved}")
+        print(f"sha256={checksum}")
+        return 0
+    except Exception as exc:
+        print(f"ERR: blueprint quiescence failed: {exc}")
         return OPERATOR_ERROR
 
 
@@ -4655,6 +4857,7 @@ def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> 
             or bool(getattr(ns, "skip_archive", False))
             or bool(getattr(ns, "guest_quiesced", False))
             or bool(str(getattr(ns, "quiesce_script", "") or "").strip())
+            or getattr(ns, "quiesce_timeout", None) is not None
         ):
             raise ValueError("this blueprint does not declare a lab archive lifecycle")
         return "none"
@@ -4664,7 +4867,7 @@ def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> 
     if bool(getattr(ns, "skip_archive", False)):
         if bool(getattr(ns, "guest_quiesced", False)) or bool(
             str(getattr(ns, "quiesce_script", "") or "").strip()
-        ):
+        ) or getattr(ns, "quiesce_timeout", None) is not None:
             raise ValueError(
                 "guest quiescence options require --archive-before-destroy"
             )
@@ -4702,46 +4905,70 @@ def _archive_requires_guest_quiescence(payload: dict[str, Any]) -> bool:
     return bool(inputs.get("eveng_lab_archive_include_node_state", False))
 
 
-def _confirm_guest_quiescence(ns, payload: dict[str, Any]) -> bool | None:
+def _confirm_guest_quiescence(ns, payload: dict[str, Any], paths) -> bool | None:
     quiesce_script = str(getattr(ns, "quiesce_script", "") or "").strip()
+    timeout_override = getattr(ns, "quiesce_timeout", None)
     if not _archive_requires_guest_quiescence(payload):
-        if bool(getattr(ns, "guest_quiesced", False)) or quiesce_script:
+        if (
+            bool(getattr(ns, "guest_quiesced", False))
+            or quiesce_script
+            or timeout_override is not None
+        ):
             raise ValueError(
                 "guest quiescence options are valid only for EVE-NG node-state archives"
             )
         return True
+    archive = payload.get("archive_before_destroy") or {}
+    archive_inputs = archive.get("inputs") or {}
+    timeout_s = int(
+        timeout_override
+        if timeout_override is not None
+        else archive_inputs.get("eveng_lab_archive_quiesce_timeout_s", 300)
+    )
+    if not 1 <= timeout_s <= 3600:
+        raise ValueError("quiescence timeout must be between 1 and 3600 seconds")
+    setattr(ns, "quiesce_timeout", timeout_s)
+
     if quiesce_script:
-        path = Path(quiesce_script).expanduser()
-        if path.is_symlink():
-            raise ValueError("quiescence script must not be a symbolic link")
-        resolved = path.resolve()
-        if not resolved.is_file():
-            raise ValueError(f"quiescence script is not a regular file: {resolved}")
-        size = resolved.stat().st_size
-        if size == 0:
-            raise ValueError("quiescence script is empty")
-        if size > 1024 * 1024:
-            raise ValueError("quiescence script exceeds the 1 MiB limit")
-        timeout_s = int(getattr(ns, "quiesce_timeout", 300))
-        if not 1 <= timeout_s <= 3600:
-            raise ValueError(
-                "quiescence timeout must be between 1 and 3600 seconds"
-            )
+        resolved, _checksum = _validate_quiescence_action(Path(quiesce_script))
         setattr(ns, "quiesce_script", str(resolved))
+        setattr(ns, "_quiescence_source", "command-override")
         return True
     if bool(getattr(ns, "guest_quiesced", False)):
+        if timeout_override is not None:
+            raise ValueError(
+                "--quiesce-timeout requires a configured or explicit quiescence action"
+            )
+        setattr(ns, "_quiescence_source", "operator-attestation")
         return True
+
+    environment_action = _quiescence_action_path(paths, payload)
+    if environment_action.exists() or environment_action.is_symlink():
+        resolved, _checksum = _validate_quiescence_action(environment_action)
+        setattr(ns, "quiesce_script", str(resolved))
+        setattr(ns, "_quiescence_source", "environment")
+        return True
+
+    if timeout_override is not None:
+        raise ValueError(
+            "--quiesce-timeout requires a configured or explicit quiescence action"
+        )
     if bool(getattr(ns, "yes", False)) or not (
         sys.stdin.isatty() and sys.stdout.isatty()
     ):
         raise ValueError(
-            "EVE-NG node-state archive requires --guest-quiesced after shutting "
-            "down each stateful guest inside its operating system"
+            "EVE-NG node-state archive requires a configured guest-quiescence "
+            "action. Configure it once with: "
+            f"{_quiescence_edit_command(ns, payload)}. "
+            "Use --guest-quiesced only after a manual clean shutdown."
         )
-    return _prompt_yes_no(
+    confirmed = _prompt_yes_no(
         "Confirm stateful guests were shut down inside their operating systems "
         "[y/N]: "
     )
+    if confirmed is True:
+        setattr(ns, "_quiescence_source", "operator-attestation")
+    return confirmed
 
 
 def _confirm_archive_destroy(env_name: str) -> bool | None:
@@ -4768,7 +4995,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
             getattr(ns, "quiesce_script", "") or ""
         ).strip()
         archive_inputs["eveng_lab_archive_quiesce_timeout_s"] = int(
-            getattr(ns, "quiesce_timeout", 300)
+            getattr(ns, "quiesce_timeout", None) or 300
         )
     archive_step = {
         "id": "archive_before_destroy",
@@ -4780,7 +5007,12 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         "inputs": archive_inputs,
     }
     if str(getattr(ns, "quiesce_script", "") or "").strip():
-        print("preparing saved lab state; running guest quiescence action")
+        source = str(getattr(ns, "_quiescence_source", "") or "")
+        qualifier = "configured " if source == "environment" else ""
+        print(
+            "preparing saved lab state; running "
+            f"{qualifier}guest quiescence action"
+        )
     else:
         print("preparing saved lab state; guests must already be shut down")
     print("this may take several minutes, depending on lab size")
@@ -5010,6 +5242,10 @@ def _run_destroy_unlocked(ns) -> int:
                             else None
                         )
                     ),
+                    "quiescence_source": str(
+                        getattr(ns, "_quiescence_source", "") or ""
+                    )
+                    or None,
                     "lifecycle": lifecycle,
                     "steps": steps or [],
                 },
@@ -5090,7 +5326,7 @@ def _run_destroy_unlocked(ns) -> int:
 
     if archive_mode == "archive":
         try:
-            guest_quiesced = _confirm_guest_quiescence(ns, payload)
+            guest_quiesced = _confirm_guest_quiescence(ns, payload, paths)
         except ValueError as exc:
             print(f"ERR: {exc}")
             record_destroy_outcome(

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -3867,7 +3867,7 @@ def _lab_archive_contract(lifecycle: dict[str, Any]) -> dict[str, Any]:
 def _verified_lab_archive(
     payload: dict[str, Any],
     paths,
-) -> tuple[Path, str, Path | None, str] | None:
+) -> tuple[Path, str, Path | None, str, Path | None, str] | None:
     lifecycle = payload.get("archive_before_destroy")
     if not isinstance(lifecycle, dict) or not lifecycle:
         return None
@@ -3913,7 +3913,7 @@ def _verified_lab_archive(
         )
         node_state_metadata_present = bool(candidate_value or candidate_checksum)
         if not (node_state_declared or node_state_metadata_present):
-            return archive_path.resolve(), expected, None, ""
+            return archive_path.resolve(), expected, None, "", None, ""
         candidate = Path(candidate_value).expanduser()
         if not candidate.is_file() or not re.fullmatch(
             r"[0-9a-f]{64}", candidate_checksum
@@ -3929,7 +3929,7 @@ def _verified_lab_archive(
             )
         node_archive = candidate.resolve()
         node_checksum = candidate_checksum
-    return archive_path.resolve(), expected, node_archive, node_checksum
+    return archive_path.resolve(), expected, node_archive, node_checksum, None, ""
 
 
 def _automatic_lab_restore_eligible(payload: dict[str, Any], paths) -> bool:
@@ -3952,7 +3952,10 @@ def _select_lab_restore_mode(
     paths,
     *,
     automatic_restore_eligible: bool = True,
-) -> tuple[str, tuple[Path, str, Path | None, str] | None]:
+) -> tuple[
+    str,
+    tuple[Path, str, Path | None, str, Path | None, str] | None,
+]:
     lifecycle = payload.get("archive_before_destroy")
     requested = bool(getattr(ns, "restore_labs", False))
     skipped = bool(getattr(ns, "skip_lab_restore", False))
@@ -3982,6 +3985,8 @@ def _select_lab_restore_mode(
     print(f"lab archive available: {archive[0]}")
     if archive[2] is not None:
         print(f"stopped node state available: {archive[2]}")
+    if archive[4] is not None:
+        print(f"referenced base images available: {archive[4]}")
     confirmed = _prompt_yes_no("Restore archived labs? [y/N]: ")
     if confirmed is None:
         return "skip", archive
@@ -3992,12 +3997,19 @@ def _run_lab_restore(
     ns,
     payload: dict[str, Any],
     paths,
-    archive: tuple[Path, str, Path | None, str],
+    archive: tuple[Path, str, Path | None, str, Path | None, str],
 ) -> int:
     lifecycle = payload["archive_before_destroy"]
     contract = _lab_archive_contract(lifecycle)
     prefix = contract["prefix"]
-    archive_path, checksum, node_archive_path, node_checksum = archive
+    (
+        archive_path,
+        checksum,
+        node_archive_path,
+        node_checksum,
+        image_archive_path,
+        image_checksum,
+    ) = archive
     restore_inputs = dict(lifecycle.get("inputs") or {})
     restore_inputs.update(
         {
@@ -4024,6 +4036,14 @@ def _run_lab_restore(
                 f"{prefix}_restore_node_state": True,
                 f"{prefix}_node_state_path": str(node_archive_path),
                 f"{prefix}_node_state_expected_sha256": node_checksum,
+            }
+        )
+    if image_archive_path is not None:
+        restore_inputs.update(
+            {
+                f"{prefix}_restore_images": True,
+                f"{prefix}_images_path": str(image_archive_path),
+                f"{prefix}_images_expected_sha256": image_checksum,
             }
         )
     restore_step = {

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1140,13 +1140,29 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Destroy without exporting declared lab data.",
     )
-    d.add_argument(
+    quiescence = d.add_mutually_exclusive_group()
+    quiescence.add_argument(
         "--guest-quiesced",
         action="store_true",
         help=(
             "Confirm stateful EVE-NG guests were shut down inside the guest "
             "before node-state capture."
         ),
+    )
+    quiescence.add_argument(
+        "--quiesce-script",
+        default="",
+        help=(
+            "Run a local POSIX shell script on the EVE-NG host before "
+            "node-state capture."
+        ),
+    )
+    d.add_argument(
+        "--quiesce-timeout",
+        type=int,
+        default=300,
+        metavar="SECONDS",
+        help="Maximum time for EVE-NG guest quiescence and QEMU shutdown.",
     )
     d.set_defaults(_handler=run_destroy)
 
@@ -4638,6 +4654,7 @@ def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> 
             bool(getattr(ns, "archive_before_destroy", False))
             or bool(getattr(ns, "skip_archive", False))
             or bool(getattr(ns, "guest_quiesced", False))
+            or bool(str(getattr(ns, "quiesce_script", "") or "").strip())
         ):
             raise ValueError("this blueprint does not declare a lab archive lifecycle")
         return "none"
@@ -4645,8 +4662,12 @@ def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> 
     if bool(getattr(ns, "archive_before_destroy", False)):
         return "archive"
     if bool(getattr(ns, "skip_archive", False)):
-        if bool(getattr(ns, "guest_quiesced", False)):
-            raise ValueError("--guest-quiesced requires --archive-before-destroy")
+        if bool(getattr(ns, "guest_quiesced", False)) or bool(
+            str(getattr(ns, "quiesce_script", "") or "").strip()
+        ):
+            raise ValueError(
+                "guest quiescence options require --archive-before-destroy"
+            )
         return "skip"
 
     if bool(getattr(ns, "yes", False)) or not (sys.stdin.isatty() and sys.stdout.isatty()):
@@ -4682,11 +4703,31 @@ def _archive_requires_guest_quiescence(payload: dict[str, Any]) -> bool:
 
 
 def _confirm_guest_quiescence(ns, payload: dict[str, Any]) -> bool | None:
+    quiesce_script = str(getattr(ns, "quiesce_script", "") or "").strip()
     if not _archive_requires_guest_quiescence(payload):
-        if bool(getattr(ns, "guest_quiesced", False)):
+        if bool(getattr(ns, "guest_quiesced", False)) or quiesce_script:
             raise ValueError(
-                "--guest-quiesced is valid only for EVE-NG node-state archives"
+                "guest quiescence options are valid only for EVE-NG node-state archives"
             )
+        return True
+    if quiesce_script:
+        path = Path(quiesce_script).expanduser()
+        if path.is_symlink():
+            raise ValueError("quiescence script must not be a symbolic link")
+        resolved = path.resolve()
+        if not resolved.is_file():
+            raise ValueError(f"quiescence script is not a regular file: {resolved}")
+        size = resolved.stat().st_size
+        if size == 0:
+            raise ValueError("quiescence script is empty")
+        if size > 1024 * 1024:
+            raise ValueError("quiescence script exceeds the 1 MiB limit")
+        timeout_s = int(getattr(ns, "quiesce_timeout", 300))
+        if not 1 <= timeout_s <= 3600:
+            raise ValueError(
+                "quiescence timeout must be between 1 and 3600 seconds"
+            )
+        setattr(ns, "quiesce_script", str(resolved))
         return True
     if bool(getattr(ns, "guest_quiesced", False)):
         return True
@@ -4723,6 +4764,12 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         archive_inputs["eveng_lab_archive_guest_quiesced"] = bool(
             getattr(ns, "guest_quiesced", False)
         )
+        archive_inputs["eveng_lab_archive_quiesce_script_path"] = str(
+            getattr(ns, "quiesce_script", "") or ""
+        ).strip()
+        archive_inputs["eveng_lab_archive_quiesce_timeout_s"] = int(
+            getattr(ns, "quiesce_timeout", 300)
+        )
     archive_step = {
         "id": "archive_before_destroy",
         "module_ref": archive["module_ref"],
@@ -4732,7 +4779,10 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         "with_deps": False,
         "inputs": archive_inputs,
     }
-    print("preparing saved lab state; guests must already be shut down")
+    if str(getattr(ns, "quiesce_script", "") or "").strip():
+        print("preparing saved lab state; running guest quiescence action")
+    else:
+        print("preparing saved lab state; guests must already be shut down")
     print("this may take several minutes, depending on lab size")
     progress = ProgressDisplay(
         enabled=bool(
@@ -4951,6 +5001,15 @@ def _run_destroy_unlocked(ns) -> int:
                     "guest_quiesced": bool(
                         getattr(ns, "guest_quiesced", False)
                     ),
+                    "quiescence_method": (
+                        "operator-script"
+                        if str(getattr(ns, "quiesce_script", "") or "").strip()
+                        else (
+                            "operator-attestation"
+                            if bool(getattr(ns, "guest_quiesced", False))
+                            else None
+                        )
+                    ),
                     "lifecycle": lifecycle,
                     "steps": steps or [],
                 },
@@ -5052,7 +5111,8 @@ def _run_destroy_unlocked(ns) -> int:
             _print_destroy_lifecycle_summary(lifecycle)
             print_destroy_record()
             return CANCELLED
-        setattr(ns, "guest_quiesced", True)
+        if not str(getattr(ns, "quiesce_script", "") or "").strip():
+            setattr(ns, "guest_quiesced", True)
 
     if not bool(getattr(ns, "yes", False)) and not json_mode:
         if payload.get("archive_before_destroy"):

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -94,6 +94,7 @@ from .planner import compute_preflight, run_step_module_command
 from .schema import load_blueprint, resolve_blueprint_file, validate_blueprint
 
 
+_PROJECT_SUPPORT_URL = "https://github.com/sponsors/hybridops-tech"
 _QUIESCENCE_DRAFT_MARKER = "HYOPS_QUIESCENCE_ACTION_NOT_CONFIGURED"
 _QUIESCENCE_TEMPLATE = """#!/bin/sh
 set -eu
@@ -259,6 +260,43 @@ def _cancelled_deploy_actions(ns, payload: dict[str, Any]) -> dict[str, str]:
         "resume": shlex.join(["hyops", "blueprint", "deploy", *selection, *selector, "--execute"]),
         "destroy": shlex.join(["hyops", "blueprint", "destroy", *selection, *selector, "--execute"]),
     }
+
+
+def _successful_deploy_actions(ns, payload: dict[str, Any]) -> dict[str, str]:
+    env_name = str(getattr(ns, "env", "") or "").strip()
+    if env_name:
+        selection = ["--env", env_name]
+    else:
+        selection = ["--root", str(getattr(ns, "root", "") or "")]
+
+    blueprint_file = str(getattr(ns, "file", "") or "").strip()
+    if blueprint_file:
+        selector = ["--file", blueprint_file]
+    else:
+        selector = ["--ref", str(payload["blueprint_ref"])]
+
+    actions: dict[str, str] = {}
+    if payload.get("access"):
+        actions["access"] = shlex.join(
+            ["hyops", "blueprint", "access", *selection, *selector]
+        )
+
+    credential_secret = str(
+        (payload.get("metadata") or {}).get("credential_secret") or ""
+    ).strip()
+    if credential_secret:
+        actions["credentials"] = shlex.join(
+            [
+                "hyops",
+                "secrets",
+                "show",
+                *selection,
+                "--raw",
+                credential_secret,
+            ]
+        )
+    actions["support"] = _PROJECT_SUPPORT_URL
+    return actions
 
 
 def _failed_deploy_has_resources(payload: dict[str, Any], paths) -> bool:
@@ -4812,6 +4850,8 @@ def run_deploy(ns) -> int:
         output["iol_license_repairs"] = repair_results
     if cancelled:
         output["next_actions"] = _cancelled_deploy_actions(ns, payload)
+    elif not required_failures:
+        output["next_actions"] = _successful_deploy_actions(ns, payload)
     elif required_failures and _failed_deploy_has_resources(payload, paths):
         output["next_actions"] = {"destroy": _cancelled_deploy_actions(ns, payload)["destroy"]}
 
@@ -4835,7 +4875,19 @@ def run_deploy(ns) -> int:
             print(f"required_failures: {', '.join(required_failures)}")
         if optional_failures:
             print(f"optional_failures: {', '.join(optional_failures)}")
-        if cancelled:
+        if final_status == "ok":
+            actions = output["next_actions"]
+            operator_actions = [
+                (label, actions[label])
+                for label in ("access", "credentials")
+                if label in actions
+            ]
+            if operator_actions:
+                print("next:")
+                for label, command in operator_actions:
+                    print(f"  {label}: {command}")
+            print(f"support: {actions['support']}")
+        elif cancelled:
             print("deployment cancelled; completed resources were retained.")
             print("resume:")
             print(f"  {output['next_actions']['resume']}")

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -1139,6 +1139,14 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Destroy without exporting declared lab data.",
     )
+    d.add_argument(
+        "--guest-quiesced",
+        action="store_true",
+        help=(
+            "Confirm stateful EVE-NG guests were shut down inside the guest "
+            "before node-state capture."
+        ),
+    )
     d.set_defaults(_handler=run_destroy)
 
     b = ssp.add_parser(
@@ -4562,13 +4570,19 @@ def run_deploy(ns) -> int:
 def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> str:
     archive = payload.get("archive_before_destroy")
     if not isinstance(archive, dict) or not archive:
-        if bool(getattr(ns, "archive_before_destroy", False)) or bool(getattr(ns, "skip_archive", False)):
+        if (
+            bool(getattr(ns, "archive_before_destroy", False))
+            or bool(getattr(ns, "skip_archive", False))
+            or bool(getattr(ns, "guest_quiesced", False))
+        ):
             raise ValueError("this blueprint does not declare a lab archive lifecycle")
         return "none"
 
     if bool(getattr(ns, "archive_before_destroy", False)):
         return "archive"
     if bool(getattr(ns, "skip_archive", False)):
+        if bool(getattr(ns, "guest_quiesced", False)):
+            raise ValueError("--guest-quiesced requires --archive-before-destroy")
         return "skip"
 
     if bool(getattr(ns, "yes", False)) or not (sys.stdin.isatty() and sys.stdout.isatty()):
@@ -4591,6 +4605,38 @@ def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> 
         if selected is not None:
             return selected
         print("invalid choice; enter exactly 1, 2, or 3")
+
+
+def _archive_requires_guest_quiescence(payload: dict[str, Any]) -> bool:
+    archive = payload.get("archive_before_destroy")
+    if not isinstance(archive, dict):
+        return False
+    inputs = archive.get("inputs")
+    if not isinstance(inputs, dict):
+        return False
+    return bool(inputs.get("eveng_lab_archive_include_node_state", False))
+
+
+def _confirm_guest_quiescence(ns, payload: dict[str, Any]) -> bool | None:
+    if not _archive_requires_guest_quiescence(payload):
+        if bool(getattr(ns, "guest_quiesced", False)):
+            raise ValueError(
+                "--guest-quiesced is valid only for EVE-NG node-state archives"
+            )
+        return True
+    if bool(getattr(ns, "guest_quiesced", False)):
+        return True
+    if bool(getattr(ns, "yes", False)) or not (
+        sys.stdin.isatty() and sys.stdout.isatty()
+    ):
+        raise ValueError(
+            "EVE-NG node-state archive requires --guest-quiesced after shutting "
+            "down each stateful guest inside its operating system"
+        )
+    return _prompt_yes_no(
+        "Confirm stateful guests were shut down inside their operating systems "
+        "[y/N]: "
+    )
 
 
 def _confirm_archive_destroy(env_name: str) -> bool | None:
@@ -4617,7 +4663,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         "with_deps": False,
         "inputs": archive.get("inputs") or {},
     }
-    print("preparing saved lab state; active nodes will be stopped")
+    print("preparing saved lab state; guests must already be shut down")
     print("this may take several minutes, depending on lab size")
     progress = ProgressDisplay(
         enabled=bool(
@@ -4654,7 +4700,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
     )
     if int(rc) == CANCELLED:
         print("Archive interrupted. Resources were retained.")
-        print("Some lab nodes may have been stopped. Check the lab before continuing.")
+        print("Check lab state before continuing.")
         return CANCELLED
     if rc != 0:
         print("ERR: lab export failed; no resources were destroyed")
@@ -4833,6 +4879,9 @@ def _run_destroy_unlocked(ns) -> int:
                     "env": env_name,
                     "run_id": run_id,
                     "status": status,
+                    "guest_quiesced": bool(
+                        getattr(ns, "guest_quiesced", False)
+                    ),
                     "lifecycle": lifecycle,
                     "steps": steps or [],
                 },
@@ -4910,6 +4959,31 @@ def _run_destroy_unlocked(ns) -> int:
         _print_destroy_lifecycle_summary(lifecycle)
         print_destroy_record()
         return 0
+
+    if archive_mode == "archive":
+        try:
+            guest_quiesced = _confirm_guest_quiescence(ns, payload)
+        except ValueError as exc:
+            print(f"ERR: {exc}")
+            record_destroy_outcome(
+                "blocked",
+                archive="not-started",
+                resources="retained",
+            )
+            print_destroy_record()
+            return OPERATOR_ERROR
+        if guest_quiesced is not True:
+            print("destroy cancelled")
+            print("environment retained")
+            lifecycle = record_destroy_outcome(
+                "cancelled",
+                archive="not-started",
+                resources="retained",
+            )
+            _print_destroy_lifecycle_summary(lifecycle)
+            print_destroy_record()
+            return CANCELLED
+        setattr(ns, "guest_quiesced", True)
 
     if not bool(getattr(ns, "yes", False)) and not json_mode:
         if payload.get("archive_before_destroy"):

--- a/hyops/blueprint/command.py
+++ b/hyops/blueprint/command.py
@@ -106,9 +106,7 @@ def _runtime_overlay_for_ref(ns, blueprint_ref: str) -> str:
     try:
         candidate.relative_to(overlay_root)
     except ValueError as exc:
-        raise ValueError(
-            f"initialized blueprint resolves outside {overlay_root}: {unresolved}"
-        ) from exc
+        raise ValueError(f"initialized blueprint resolves outside {overlay_root}: {unresolved}") from exc
 
     if unresolved.is_symlink() and not candidate.exists():
         raise FileNotFoundError(f"initialized blueprint link is broken: {unresolved}")
@@ -208,8 +206,7 @@ def _blueprint_file_for_edit(ns) -> Path:
     overlay = _runtime_overlay_for_ref(ns, str(getattr(ns, "ref", "")).strip())
     if not overlay:
         raise FileNotFoundError(
-            f"initialized blueprint not found for {getattr(ns, 'ref', None)}; "
-            "run `hyops blueprint init` first."
+            f"initialized blueprint not found for {getattr(ns, 'ref', None)}; run `hyops blueprint init` first."
         )
 
     return Path(overlay)
@@ -229,8 +226,8 @@ def _emit(payload: dict[str, Any], *, json_mode: bool) -> None:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return
 
-    print(f"blueprint={payload.get('blueprint_ref','')} mode={payload.get('mode','')} status=ok")
-    print(f"path={payload.get('path','')}")
+    print(f"blueprint={payload.get('blueprint_ref', '')} mode={payload.get('mode', '')} status=ok")
+    print(f"path={payload.get('path', '')}")
 
 
 def _cancelled_deploy_actions(ns, payload: dict[str, Any]) -> dict[str, str]:
@@ -247,12 +244,8 @@ def _cancelled_deploy_actions(ns, payload: dict[str, Any]) -> dict[str, str]:
         selector = ["--ref", str(payload["blueprint_ref"])]
 
     return {
-        "resume": shlex.join(
-            ["hyops", "blueprint", "deploy", *selection, *selector, "--execute"]
-        ),
-        "destroy": shlex.join(
-            ["hyops", "blueprint", "destroy", *selection, *selector, "--execute"]
-        ),
+        "resume": shlex.join(["hyops", "blueprint", "deploy", *selection, *selector, "--execute"]),
+        "destroy": shlex.join(["hyops", "blueprint", "destroy", *selection, *selector, "--execute"]),
     }
 
 
@@ -411,9 +404,7 @@ def _step_presentation(
             items_label = str(presentation.get("items_label") or "includes").strip()
             inline_items = f"  {items_label}: {', '.join(item_values)}"
             if len(item_values) > 4 or len(inline_items) > 100:
-                item_line = "\n".join(
-                    [f"  {items_label}:", *(f"    - {item}" for item in item_values)]
-                )
+                item_line = "\n".join([f"  {items_label}:", *(f"    - {item}" for item in item_values)])
             else:
                 item_line = inline_items
 
@@ -526,9 +517,7 @@ def _emit_plan(payload: dict[str, Any], *, json_mode: bool) -> None:
         )
         return
 
-    print(
-        f"blueprint={payload['blueprint_ref']} mode={payload['mode']} plan_steps={len(payload['order'])}"
-    )
+    print(f"blueprint={payload['blueprint_ref']} mode={payload['mode']} plan_steps={len(payload['order'])}")
     print("order:")
     for step_id in payload["order"]:
         step = next(s for s in payload["steps"] if s["id"] == step_id)
@@ -688,8 +677,7 @@ def _confirm_deploy_if_needed(ns, payload: dict[str, Any], paths) -> int:
         print(f"  - {_step_display_label(step)} (state={item['state_status']})")
         if verbose_enabled():
             print(
-                f"    id={item['id']} action={item['action']} "
-                f"module={item['module_ref']} ref={item['state_ref']}"
+                f"    id={item['id']} action={item['action']} module={item['module_ref']} ref={item['state_ref']}"
             )
 
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
@@ -735,7 +723,11 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         help="Copy a shipped blueprint into the selected runtime config for operator editing.",
     )
     add_common_args(i)
-    i.add_argument("--root", default=None, help="Override runtime root for blueprint overlay output.")
+    i.add_argument(
+        "--root",
+        default=None,
+        help="Override runtime root for blueprint overlay output.",
+    )
     i.add_argument("--env", default=None, help="Runtime environment namespace (e.g. dev, shared).")
     i.add_argument(
         "--dest-name",
@@ -756,8 +748,7 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         "--editor",
         default="",
         help=(
-            "Editor command to use when --edit is set. "
-            "Defaults to HYOPS_EDITOR, VISUAL, EDITOR, then common editors."
+            "Editor command to use when --edit is set. Defaults to HYOPS_EDITOR, VISUAL, EDITOR, then common editors."
         ),
     )
     i.set_defaults(_handler=run_init)
@@ -772,10 +763,7 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
     e.add_argument(
         "--editor",
         default="",
-        help=(
-            "Editor command to use. Defaults to HYOPS_EDITOR, VISUAL, EDITOR, "
-            "then common editors."
-        ),
+        help=("Editor command to use. Defaults to HYOPS_EDITOR, VISUAL, EDITOR, then common editors."),
     )
     e.set_defaults(_handler=run_edit)
 
@@ -815,9 +803,7 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         default=0,
         help="Local port (default: choose an available port).",
     )
-    a.add_argument(
-        "--no-browser", action="store_true", help="Do not open the default browser."
-    )
+    a.add_argument("--no-browser", action="store_true", help="Do not open the default browser.")
     a.add_argument(
         "--native-consoles",
         action="store_true",
@@ -922,10 +908,7 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
     device_edit.add_argument(
         "--editor",
         default="",
-        help=(
-            "Editor command to use. Defaults to HYOPS_EDITOR, VISUAL, EDITOR, "
-            "then common editors."
-        ),
+        help=("Editor command to use. Defaults to HYOPS_EDITOR, VISUAL, EDITOR, then common editors."),
     )
     device_edit.set_defaults(_handler=run_device)
 
@@ -1036,7 +1019,11 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         default="modules",
         help="Module root directory for step execution (default: modules from cwd or HYOPS_CORE_ROOT).",
     )
-    t.add_argument("--out-dir", default=None, help="Override evidence root for executed module steps.")
+    t.add_argument(
+        "--out-dir",
+        default=None,
+        help="Override evidence root for executed module steps.",
+    )
     t.add_argument(
         "--deps-inputs-dir",
         default=None,
@@ -1077,6 +1064,11 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         "--overwrite-labs",
         action="store_true",
         help="Allow --restore-labs to replace existing lab definitions.",
+    )
+    t.add_argument(
+        "--overwrite-images",
+        action="store_true",
+        help="Allow --restore-labs to replace referenced base images.",
     )
     t.add_argument(
         "--repair-iol-license",
@@ -1126,7 +1118,11 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         default="modules",
         help="Module root directory for step execution (default: modules from cwd or HYOPS_CORE_ROOT).",
     )
-    d.add_argument("--out-dir", default=None, help="Override evidence root for executed module steps.")
+    d.add_argument(
+        "--out-dir",
+        default=None,
+        help="Override evidence root for executed module steps.",
+    )
     d.add_argument(
         "--yes",
         action="store_true",
@@ -1162,9 +1158,7 @@ def add_blueprint_subparser(sp: argparse._SubParsersAction) -> None:
         default="modules",
         help="Module root directory for step execution.",
     )
-    b.add_argument(
-        "--out-dir", default=None, help="Override run-record root for module steps."
-    )
+    b.add_argument("--out-dir", default=None, help="Override run-record root for module steps.")
     b.add_argument(
         "--deps-inputs-dir",
         default=None,
@@ -1204,9 +1198,7 @@ def run_validate(ns) -> int:
 
 
 def _resolve_device_blueprint(ns, paths) -> dict[str, Any]:
-    if str(getattr(ns, "ref", "") or "").strip() or str(
-        getattr(ns, "file", "") or ""
-    ).strip():
+    if str(getattr(ns, "ref", "") or "").strip() or str(getattr(ns, "file", "") or "").strip():
         return _resolve_and_validate(ns)
 
     candidates: list[dict[str, Any]] = []
@@ -1220,9 +1212,7 @@ def _resolve_device_blueprint(ns, paths) -> dict[str, Any]:
         if isinstance(access.get("automation"), dict) and access["automation"]:
             candidates.append(payload)
     if not candidates:
-        raise ValueError(
-            "no initialized automation blueprint was found; pass --ref or run blueprint init"
-        )
+        raise ValueError("no initialized automation blueprint was found; pass --ref or run blueprint init")
     if len(candidates) > 1:
         refs = ", ".join(str(item.get("blueprint_ref") or "") for item in candidates)
         raise ValueError(f"multiple automation blueprints are initialized ({refs}); pass --ref")
@@ -1254,9 +1244,7 @@ def _device_context(ns) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, 
     automation, material = _device_material(ns)
     target_file = material["target_file"]
     if not target_file.is_file():
-        raise ValueError(
-            "device targets are unavailable; run blueprint access with --automation"
-        )
+        raise ValueError("device targets are unavailable; run blueprint access with --automation")
     targets = load_automation_targets(target_file, automation["management_cidr"])
     return automation, material, targets
 
@@ -1307,21 +1295,14 @@ def _device_web_requests(
         raise ValueError("device web accepts target names or --all, not both")
     if use_all:
         selected = [
-            (str(target["host"]), target)
-            for target in targets
-            if isinstance(target.get("web"), dict)
+            (str(target["host"]), target) for target in targets if isinstance(target.get("web"), dict)
         ]
         if not selected:
-            raise ValueError(
-                "no targets declare web access; run device edit and add a web mapping"
-            )
+            raise ValueError("no targets declare web access; run device edit and add a web mapping")
     else:
         if not target_tokens:
             raise ValueError("device web requires at least one target or --all")
-        selected = [
-            _resolve_device_target(token, automation, targets)
-            for token in target_tokens
-        ]
+        selected = [_resolve_device_target(token, automation, targets) for token in target_tokens]
 
     scheme_override = str(getattr(ns, "scheme", None) or "").strip().lower()
     if scheme_override and scheme_override not in {"http", "https"}:
@@ -1344,12 +1325,8 @@ def _device_web_requests(
         declared = target.get("web") if target else None
         web = declared if isinstance(declared, dict) else {}
         scheme = scheme_override or str(web.get("scheme") or "https")
-        remote_port = port_override or int(
-            web.get("port") or (443 if scheme == "https" else 80)
-        )
-        path = str(
-            path_override if path_override is not None else web.get("path") or "/"
-        )
+        remote_port = port_override or int(web.get("port") or (443 if scheme == "https" else 80))
+        path = str(path_override if path_override is not None else web.get("path") or "/")
         requests.append(
             {
                 "address": address,
@@ -1389,10 +1366,7 @@ def _run_device_web(
                 "-o",
                 "ExitOnForwardFailure=yes",
                 "-L",
-                (
-                    f"127.0.0.1:{local_port}:{request['address']}:"
-                    f"{request['remote_port']}"
-                ),
+                (f"127.0.0.1:{local_port}:{request['address']}:{request['remote_port']}"),
                 gateway_alias,
             ]
             proc = subprocess.Popen(
@@ -1407,12 +1381,9 @@ def _run_device_web(
             except Exception:
                 _stop_process(proc)
                 raise
-            local_url = (
-                f"{request['scheme']}://127.0.0.1:{local_port}{request['path']}"
-            )
+            local_url = f"{request['scheme']}://127.0.0.1:{local_port}{request['path']}"
             target_url = (
-                f"{request['scheme']}://{request['address']}:"
-                f"{request['remote_port']}{request['path']}"
+                f"{request['scheme']}://{request['address']}:{request['remote_port']}{request['path']}"
             )
             sessions.append(
                 {
@@ -1431,10 +1402,7 @@ def _run_device_web(
         else:
             print(f"device web access: {len(sessions)} targets")
             for session in sessions:
-                print(
-                    f"- {session['label']}  local={session['local_url']}  "
-                    f"target={session['target_url']}"
-                )
+                print(f"- {session['label']}  local={session['local_url']}  target={session['target_url']}")
         print("press Ctrl-C to close access")
 
         open_all = bool(getattr(ns, "open_all", False))
@@ -1453,9 +1421,7 @@ def _run_device_web(
                     continue
                 detail = (proc.stderr.read() if proc.stderr else "").strip()
                 raise ValueError(
-                    detail
-                    or f"device web tunnel for {session['label']} exited with "
-                    f"rc={return_code}"
+                    detail or f"device web tunnel for {session['label']} exited with rc={return_code}"
                 )
             time.sleep(0.25)
     except KeyboardInterrupt:
@@ -1477,13 +1443,9 @@ def _device_process_environment(material: dict[str, Any]) -> dict[str, str]:
     }
     for label, path in required.items():
         if not path.is_file():
-            raise ValueError(
-                f"{label} is unavailable; run blueprint access with --automation"
-            )
+            raise ValueError(f"{label} is unavailable; run blueprint access with --automation")
     try:
-        session = yaml.safe_load(
-            Path(material["session_file"]).read_text(encoding="utf-8")
-        ) or {}
+        session = yaml.safe_load(Path(material["session_file"]).read_text(encoding="utf-8")) or {}
     except (OSError, yaml.YAMLError) as exc:
         raise ValueError("device session metadata is invalid") from exc
     proxy = str(session.get("socks_proxy") or "").strip()
@@ -1518,10 +1480,7 @@ def run_device(ns) -> int:
             automation, material = _device_material(ns)
             target_file = Path(material["target_file"])
             if not target_file.is_file():
-                raise ValueError(
-                    "device targets are unavailable; run blueprint access with "
-                    "--automation"
-                )
+                raise ValueError("device targets are unavailable; run blueprint access with --automation")
             editor_argv = _editor_argv(ns)
             editor_argv.append(str(target_file))
             print(f"Opening device targets for edit: {target_file}")
@@ -1537,8 +1496,7 @@ def run_device(ns) -> int:
                 print(json.dumps({"targets": targets}, indent=2, sort_keys=True))
             elif not targets:
                 print(
-                    "no devices discovered; connect a management interface to "
-                    f"{automation['management_network_label']}"
+                    f"no devices discovered; connect a management interface to {automation['management_network_label']}"
                 )
             else:
                 for target in targets:
@@ -1560,8 +1518,7 @@ def run_device(ns) -> int:
         ssh_config = Path(material["ssh_config"])
         if not ssh_config.is_file():
             raise ValueError(
-                "private access is not active; run blueprint access with --automation "
-                "and keep it open"
+                "private access is not active; run blueprint access with --automation and keep it open"
             )
         ssh = shutil.which("ssh")
         if not ssh:
@@ -1612,10 +1569,7 @@ def run_device(ns) -> int:
                 check=False,
             )
             if result.returncode == 255:
-                print(
-                    f"ERR: device SSH failed for {target['name']} as "
-                    f"{target['user']}."
-                )
+                print(f"ERR: device SSH failed for {target['name']} as {target['user']}.")
                 print(f"device targets: {material['target_file']}")
                 print(f"edit: {_device_edit_command(ns)}")
             return int(result.returncode)
@@ -1678,8 +1632,7 @@ def run_init(ns) -> int:
         dest_path = (dest_dir / dest_name).resolve()
         if dest_path.exists() and not bool(getattr(ns, "force", False)):
             raise FileExistsError(
-                f"initialized blueprint already exists: {dest_path} "
-                "(use --force to overwrite)"
+                f"initialized blueprint already exists: {dest_path} (use --force to overwrite)"
             )
         shutil.copy2(Path(payload["path"]), dest_path)
         dest_path.chmod(0o600)
@@ -1770,10 +1723,7 @@ def run_preflight(ns) -> int:
             f"preflight_status={status} steps={len(step_results)}"
         )
         for item in step_results:
-            print(
-                f"  - {item['id']}: {item['status']} "
-                f"{item['action']} {item['module_ref']}"
-            )
+            print(f"  - {item['id']}: {item['status']} {item['action']} {item['module_ref']}")
             if item["status"] == "blocked":
                 detail = _step_failure_detail(item)
                 if detail:
@@ -1806,9 +1756,7 @@ def _available_local_port(requested: int) -> int:
         return int(sock.getsockname()[1])
 
 
-def _wait_for_local_port(
-    port: int, proc: subprocess.Popen, timeout_s: float = 15.0
-) -> None:
+def _wait_for_local_port(port: int, proc: subprocess.Popen, timeout_s: float = 15.0) -> None:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         if proc.poll() is not None:
@@ -1849,9 +1797,7 @@ def _require_local_ports_available(ports: list[int]) -> None:
                 raise
             sockets.append(sock)
     except OSError as exc:
-        raise ValueError(
-            f"local port {port} is unavailable on localhost: {exc}"
-        ) from exc
+        raise ValueError(f"local port {port} is unavailable on localhost: {exc}") from exc
     finally:
         for sock in sockets:
             sock.close()
@@ -1881,8 +1827,7 @@ def _discover_eve_qemu_console_ports(
     )
     if probe.returncode != 0:
         raise ValueError(
-            "failed to discover native EVE-NG consoles: "
-            + _ssh_access_error(probe.stderr, known_hosts_file)
+            "failed to discover native EVE-NG consoles: " + _ssh_access_error(probe.stderr, known_hosts_file)
         )
     return _parse_eve_qemu_console_ports(probe.stdout)
 
@@ -1951,8 +1896,7 @@ def _runtime_access_secret(paths, env_name: str, env_key: str) -> str:
     value = str(values.get(env_key) or "").strip()
     if not value:
         raise ValueError(
-            f"native console credential {env_key} is missing; run: "
-            f"hyops secrets ensure --env {env_name} {env_key}"
+            f"native console credential {env_key} is missing; run: hyops secrets ensure --env {env_name} {env_key}"
         )
     return value
 
@@ -2055,8 +1999,7 @@ def _gns3_console_refresher(
             failed.discard(port)
             scheme = "spice" if console_type.startswith("spice") else console_type
             print(
-                f"native console available: {name} "
-                f"({console_type}) {scheme}://127.0.0.1:{port}",
+                f"native console available: {name} ({console_type}) {scheme}://127.0.0.1:{port}",
                 flush=True,
             )
 
@@ -2196,10 +2139,7 @@ def _print_cost_estimate(
     if not estimate.available:
         print("estimated fixed cost: unavailable")
         return
-    print(
-        "estimated fixed cost: "
-        f"{format_money(estimate.hourly, estimate.currency)}/hour"
-    )
+    print(f"estimated fixed cost: {format_money(estimate.hourly, estimate.currency)}/hour")
     state_seconds = _state_age_seconds(state.get("updated_at"))
     if state_seconds:
         print(
@@ -2252,11 +2192,7 @@ def _gcp_cost_estimate_with_progress(
         "cloud-cost",
         "Cloud cost estimate",
         "ok" if estimate.available else "skipped",
-        plain=(
-            "cloud cost estimate: ready"
-            if estimate.available
-            else "cloud cost estimate: unavailable"
-        ),
+        plain=("cloud cost estimate: ready" if estimate.available else "cloud cost estimate: unavailable"),
     )
     return estimate
 
@@ -2345,35 +2281,23 @@ def _destroy_lifecycle_snapshot(
     resolved_estimate = estimate
     if resolved_estimate is None:
         resolved_estimate = _gcp_blueprint_cost_estimate(payload, paths)
-    estimate_available = bool(
-        isinstance(resolved_estimate, CostEstimate) and resolved_estimate.available
-    )
+    estimate_available = bool(isinstance(resolved_estimate, CostEstimate) and resolved_estimate.available)
     return {
         "provider": "gcp",
-        "resource_generation_started_at": (
-            started.isoformat().replace("+00:00", "Z") if started else None
-        ),
+        "resource_generation_started_at": (started.isoformat().replace("+00:00", "Z") if started else None),
         "observed_at": observed.isoformat().replace("+00:00", "Z"),
         "duration_seconds": duration_seconds,
         "estimate": {
             "available": estimate_available,
-            "currency": (
-                resolved_estimate.currency if estimate_available else "USD"
-            ),
-            "fixed_hourly": (
-                str(resolved_estimate.hourly) if estimate_available else None
-            ),
+            "currency": (resolved_estimate.currency if estimate_available else "USD"),
+            "fixed_hourly": (str(resolved_estimate.hourly) if estimate_available else None),
             "fixed_total": (
                 str(resolved_estimate.amount_for_seconds(duration_seconds))
                 if estimate_available and duration_seconds is not None
                 else None
             ),
-            "basis": (
-                resolved_estimate.basis if estimate_available else "unavailable"
-            ),
-            "classification": (
-                "public list-price estimate; not a GCP invoice or billing total"
-            ),
+            "basis": (resolved_estimate.basis if estimate_available else "unavailable"),
+            "classification": ("public list-price estimate; not a GCP invoice or billing total"),
         },
     }
 
@@ -2392,9 +2316,7 @@ def _complete_destroy_lifecycle(
     estimate = dict(lifecycle["estimate"])
     if resources == "released":
         estimate["ongoing_hourly"] = "0.00"
-        lifecycle["released_at"] = datetime.now(timezone.utc).isoformat().replace(
-            "+00:00", "Z"
-        )
+        lifecycle["released_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     elif resources == "retained" and estimate["available"]:
         estimate["ongoing_hourly"] = estimate["fixed_hourly"]
     else:
@@ -2427,18 +2349,12 @@ def _print_destroy_lifecycle_summary(lifecycle: dict[str, Any] | None) -> None:
     if fixed_total is None:
         print(f"{cost_label}: unavailable")
     else:
-        print(
-            f"{cost_label}: "
-            f"{format_money(Decimal(str(fixed_total)), currency)}"
-        )
+        print(f"{cost_label}: {format_money(Decimal(str(fixed_total)), currency)}")
     ongoing = estimate.get("ongoing_hourly")
     if ongoing is None:
         print("estimated ongoing rate: unverified")
     else:
-        print(
-            "estimated ongoing rate: "
-            f"{format_money(Decimal(str(ongoing)), currency)}/hour"
-        )
+        print(f"estimated ongoing rate: {format_money(Decimal(str(ongoing)), currency)}/hour")
     if estimate.get("basis") and estimate["basis"] != "unavailable":
         print(f"pricing basis: {estimate['basis']}")
     print("estimate only; not a GCP invoice or billing total")
@@ -2468,15 +2384,12 @@ def _offer_access_close_destroy(
         else:
             print("billing: unable to verify")
         print(
-            "trial, credit and spend details: "
-            f"https://console.cloud.google.com/billing?project={project_id}"
+            f"trial, credit and spend details: https://console.cloud.google.com/billing?project={project_id}"
         )
     print(f"resource state age: {_state_age(state.get('updated_at'))}")
     if cost_estimate is not None:
         access_seconds = (
-            max(0, int(time.monotonic() - access_started_at))
-            if access_started_at is not None
-            else None
+            max(0, int(time.monotonic() - access_started_at)) if access_started_at is not None else None
         )
         _print_cost_estimate(
             cost_estimate,
@@ -2486,8 +2399,7 @@ def _offer_access_close_destroy(
     print("billable resources may remain active after access closes")
 
     destroy_command = (
-        f"hyops blueprint destroy --env {env_name} "
-        f"--ref {payload.get('blueprint_ref', '')} --execute"
+        f"hyops blueprint destroy --env {env_name} --ref {payload.get('blueprint_ref', '')} --execute"
     )
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         print(f"destroy when finished: {destroy_command}")
@@ -2520,8 +2432,7 @@ def _expire_access_session(
                 raise ValueError("access-session authority record changed before expiry")
             if str(current.get("status") or "") != "active":
                 raise ValueError(
-                    f"access-session expiry is not authorised in state "
-                    f"{current.get('status', 'unknown')}"
+                    f"access-session expiry is not authorised in state {current.get('status', 'unknown')}"
                 )
             access = payload.get("access")
             state_ref = str((access if isinstance(access, dict) else {}).get("state_ref") or "")
@@ -2548,9 +2459,7 @@ def _expire_access_session(
             destroy_ns = argparse.Namespace(**vars(ns))
             destroy_ns.execute = True
             destroy_ns.yes = True
-            destroy_ns.archive_before_destroy = bool(
-                payload.get("archive_before_destroy")
-            )
+            destroy_ns.archive_before_destroy = bool(payload.get("archive_before_destroy"))
             destroy_ns.skip_archive = False
             destroy_ns._cost_estimate = cost_estimate
             destroy_ns._lifecycle_lock_held = True
@@ -2640,10 +2549,7 @@ def _print_session(output: dict[str, Any]) -> None:
     outcome = output.get("outcome")
     if isinstance(outcome, dict) and outcome:
         if "resources_released" in outcome:
-            print(
-                "resources_released="
-                f"{'yes' if bool(outcome['resources_released']) else 'no'}"
-            )
+            print(f"resources_released={'yes' if bool(outcome['resources_released']) else 'no'}")
         if outcome.get("reason"):
             print(f"reason={outcome['reason']}")
     print(f"run record: {output.get('run_record', '')}")
@@ -2740,9 +2646,12 @@ def _ssh_access_trust_options(
     host_key_alias: str = "",
 ) -> list[str]:
     options = [
-        "-o", "StrictHostKeyChecking=accept-new",
-        "-o", f"UserKnownHostsFile={known_hosts_file}",
-        "-o", "LogLevel=ERROR",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        f"UserKnownHostsFile={known_hosts_file}",
+        "-o",
+        "LogLevel=ERROR",
     ]
     if host_key_alias:
         options.extend(["-o", f"HostKeyAlias={host_key_alias}"])
@@ -2751,10 +2660,7 @@ def _ssh_access_trust_options(
 
 def _ssh_access_error(stderr: str, known_hosts_file: Path) -> str:
     detail = str(stderr or "").strip()
-    if (
-        "REMOTE HOST IDENTIFICATION HAS CHANGED" in detail
-        or "Host key verification failed" in detail
-    ):
+    if "REMOTE HOST IDENTIFICATION HAS CHANGED" in detail or "Host key verification failed" in detail:
         return (
             "SSH host identity changed unexpectedly for the current VM state; access was stopped. "
             f"Review the deployed VM and its scoped trust record: {known_hosts_file}. "
@@ -2808,8 +2714,7 @@ def _read_automation_leases(
     if not lease_file:
         return ""
     remote_command = (
-        f"cat -- {shlex.quote(lease_file)} 2>/dev/null || "
-        f"sudo -n cat -- {shlex.quote(lease_file)}"
+        f"cat -- {shlex.quote(lease_file)} 2>/dev/null || sudo -n cat -- {shlex.quote(lease_file)}"
     )
     result = subprocess.run(
         [*ssh_base, ssh_target, remote_command],
@@ -2834,15 +2739,11 @@ def _prepare_automation_access(
     ssh_target: str,
     reserved_ports: list[int] | None = None,
 ) -> tuple[int, dict[str, Any]]:
-    requested_port = int(getattr(ns, "socks_port", 0) or 0) or int(
-        automation.get("local_socks_port") or 0
-    )
+    requested_port = int(getattr(ns, "socks_port", 0) or 0) or int(automation.get("local_socks_port") or 0)
     socks_port = _available_local_port(requested_port)
     reserved = set(reserved_ports or [])
     if socks_port in reserved and requested_port:
-        raise ValueError(
-            f"device proxy port {socks_port} is already used by this access session"
-        )
+        raise ValueError(f"device proxy port {socks_port} is already used by this access session")
     while socks_port in reserved:
         socks_port = _available_local_port(0)
     _require_local_ports_available([socks_port])
@@ -2910,11 +2811,7 @@ def _print_automation_access(
     *,
     route_requested: bool = False,
 ) -> None:
-    print(
-        "automation network: "
-        f"{automation['management_network_label']} "
-        f"({automation['management_cidr']})"
-    )
+    print(f"automation network: {automation['management_network_label']} ({automation['management_cidr']})")
     if automation.get("discovery_mode") == "containerlab-inspect":
         print("device discovery: reading Containerlab runtime state")
     else:
@@ -2943,8 +2840,7 @@ def _print_lab_route_ready(automation: dict[str, Any]) -> None:
     print(f"local route: {automation['management_cidr']} through the lab host")
     if is_windows_wsl():
         print(
-            "route scope: HybridOps Linux environment; Windows applications "
-            "use the generated proxy or SSH config"
+            "route scope: HybridOps Linux environment; Windows applications use the generated proxy or SSH config"
         )
 
 
@@ -2956,14 +2852,11 @@ def _start_lab_route(
 ) -> tuple[subprocess.Popen, dict[str, Any]]:
     if not sys.platform.startswith("linux"):
         raise ValueError(
-            "--route-lab currently requires Linux; use --automation for "
-            "portable SSH and API access"
+            "--route-lab currently requires Linux; use --automation for portable SSH and API access"
         )
     conflicts = local_route_conflicts(automation["management_cidr"])
     if conflicts:
-        raise ValueError(
-            "management subnet conflicts with a local route: " + conflicts[0]
-        )
+        raise ValueError("management subnet conflicts with a local route: " + conflicts[0])
     ip_command = shutil.which("ip")
     if not ip_command:
         raise ValueError("--route-lab requires the ip command")
@@ -2971,9 +2864,7 @@ def _start_lab_route(
         raise ValueError("--route-lab requires Linux TUN support at /dev/net/tun")
     plan = linux_tunnel_plan(scope)
     if Path(f"/sys/class/net/{plan['interface']}").exists():
-        raise ValueError(
-            f"local tunnel interface is already in use: {plan['interface']}"
-        )
+        raise ValueError(f"local tunnel interface is already in use: {plan['interface']}")
     privilege: list[str] = []
     if os.geteuid() != 0:
         sudo = shutil.which("sudo")
@@ -3060,9 +2951,7 @@ def _start_lab_route(
             check=False,
         )
         if gateway_probe.returncode != 0:
-            raise ValueError(
-                "private management gateway did not respond through the lab route"
-            )
+            raise ValueError("private management gateway did not respond through the lab route")
         plan["privilege"] = privilege
         plan["ip_command"] = ip_command
         return route_proc, plan
@@ -3124,9 +3013,7 @@ def _session_options(ns, payload: dict[str, Any]) -> tuple[int, str]:
     if minutes == 0 and action:
         raise ValueError("--on-expiry requires --session-minutes")
     if minutes > 0 and not action:
-        raise ValueError(
-            "--session-minutes requires --on-expiry protected-release"
-        )
+        raise ValueError("--session-minutes requires --on-expiry protected-release")
     if minutes == 0:
         return 0, ""
     if str(payload.get("blueprint_ref") or "") not in {
@@ -3135,8 +3022,7 @@ def _session_options(ns, payload: dict[str, Any]) -> tuple[int, str]:
         "gcp/containerlab@v1",
     }:
         raise ValueError(
-            "time-bounded access is supported for the GCP EVE-NG, GNS3, "
-            "and Containerlab blueprints"
+            "time-bounded access is supported for the GCP EVE-NG, GNS3, and Containerlab blueprints"
         )
     return minutes * 60, action
 
@@ -3151,10 +3037,7 @@ def _access_resource_generation(
     identities: dict[str, dict[str, str]] = {}
     for name, raw in sorted(vms.items()):
         vm = raw if isinstance(raw, dict) else {}
-        identities[str(name)] = {
-            key: str(vm.get(key) or "")
-            for key in ("vm_id", "vm_name", "zone")
-        }
+        identities[str(name)] = {key: str(vm.get(key) or "") for key in ("vm_id", "vm_name", "zone")}
     material = {
         "blueprint_ref": str(payload.get("blueprint_ref") or ""),
         "state_ref": str(access.get("state_ref") or ""),
@@ -3167,11 +3050,7 @@ def _access_resource_generation(
 
 
 def _session_warning_seconds(duration_seconds: int) -> tuple[int, ...]:
-    return tuple(
-        threshold
-        for threshold in (1800, 600, 300, 60)
-        if threshold < duration_seconds
-    )
+    return tuple(threshold for threshold in (1800, 600, 300, 60) if threshold < duration_seconds)
 
 
 def _wait_for_managed_access(
@@ -3319,9 +3198,7 @@ def run_access(ns) -> int:
                 raise ValueError(f"VM state does not contain a usable IPv4 address: {state_ref}")
             if access_type == "direct-http":
                 if automation:
-                    raise ValueError(
-                        "device automation access requires an SSH-forward access path"
-                    )
+                    raise ValueError("device automation access requires an SSH-forward access path")
                 url = f"http://{host}:{remote_port}{path}"
                 print("opening direct EVE-NG access")
                 print(f"URL: {url}")
@@ -3341,10 +3218,13 @@ def run_access(ns) -> int:
             known_hosts_file = _access_known_hosts_file(paths, state_ref, state)
             ssh_base = [
                 ssh,
-                "-o", "BatchMode=yes",
-                "-o", "IdentitiesOnly=yes",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "IdentitiesOnly=yes",
                 *_ssh_access_trust_options(known_hosts_file),
-                "-i", str(ssh_key),
+                "-i",
+                str(ssh_key),
             ]
             identity_check = subprocess.run(
                 [*ssh_base, ssh_target, "true"],
@@ -3356,9 +3236,7 @@ def run_access(ns) -> int:
                 check=False,
             )
             if identity_check.returncode != 0:
-                raise ValueError(
-                    _ssh_access_error(identity_check.stderr, known_hosts_file)
-                )
+                raise ValueError(_ssh_access_error(identity_check.stderr, known_hosts_file))
             native_console_mode = _native_console_mode(
                 access,
                 bool(getattr(ns, "native_consoles", False)),
@@ -3373,9 +3251,7 @@ def run_access(ns) -> int:
                 if console_ports:
                     _require_local_ports_available(console_ports)
 
-            requested_port = int(getattr(ns, "local_port", 0) or 0) or int(
-                access.get("local_port") or 0
-            )
+            requested_port = int(getattr(ns, "local_port", 0) or 0) or int(access.get("local_port") or 0)
             port = _available_local_port(requested_port)
             if requested_port:
                 _require_local_ports_available([port])
@@ -3407,9 +3283,7 @@ def run_access(ns) -> int:
             if automation:
                 argv.extend(["-D", f"127.0.0.1:{socks_port}"])
             for console_port in console_ports:
-                argv.extend(
-                    ["-L", f"127.0.0.1:{console_port}:127.0.0.1:{console_port}"]
-                )
+                argv.extend(["-L", f"127.0.0.1:{console_port}:127.0.0.1:{console_port}"])
             argv.append(ssh_target)
 
             if access_type == "ssh-tcp-forward":
@@ -3502,9 +3376,7 @@ def run_access(ns) -> int:
                         native_console_stop()
                     _stop_process(proc)
                     raise
-            if access_type != "ssh-tcp-forward" and not bool(
-                getattr(ns, "no_browser", False)
-            ):
+            if access_type != "ssh-tcp-forward" and not bool(getattr(ns, "no_browser", False)):
                 open_operator_url(url)
             print("press Ctrl-C to close access")
             try:
@@ -3585,8 +3457,15 @@ def run_access(ns) -> int:
                 iap_port = _available_local_port(0)
             print("preparing private GCP IAP access", flush=True)
             iap_argv = [
-                gcloud, "compute", "start-iap-tunnel", instance, "22",
-                "--project", project, "--zone", zone,
+                gcloud,
+                "compute",
+                "start-iap-tunnel",
+                instance,
+                "22",
+                "--project",
+                project,
+                "--zone",
+                zone,
                 f"--local-host-port=127.0.0.1:{iap_port}",
                 "--verbosity=error",
             ]
@@ -3595,14 +3474,18 @@ def run_access(ns) -> int:
             known_hosts_file = _access_known_hosts_file(paths, state_ref, state)
             ssh_base = [
                 ssh,
-                "-o", "BatchMode=yes",
-                "-o", "IdentitiesOnly=yes",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "IdentitiesOnly=yes",
                 *_ssh_access_trust_options(
                     known_hosts_file,
                     host_key_alias=f"hyops-{known_hosts_file.stem}",
                 ),
-                "-i", ssh_key,
-                "-p", str(iap_port),
+                "-i",
+                ssh_key,
+                "-p",
+                str(iap_port),
             ]
             ssh_target = f"{ssh_user}@127.0.0.1"
             if native_console_mode == "eve-ng-qemu":
@@ -3641,20 +3524,23 @@ def run_access(ns) -> int:
             if automation:
                 argv.extend(["-D", f"127.0.0.1:{socks_port}"])
             for console_port in console_ports:
-                argv.extend(
-                    ["-L", f"127.0.0.1:{console_port}:127.0.0.1:{console_port}"]
-                )
+                argv.extend(["-L", f"127.0.0.1:{console_port}:127.0.0.1:{console_port}"])
             argv.append(ssh_target)
         else:
             if automation:
-                raise ValueError(
-                    "device automation access requires an SSH-forward access path"
-                )
+                raise ValueError("device automation access requires an SSH-forward access path")
             if bool(getattr(ns, "native_consoles", False)):
                 raise ValueError("native consoles require an SSH-forward access declaration")
             argv = [
-                gcloud, "compute", "start-iap-tunnel", instance, str(remote_port),
-                "--project", project, "--zone", zone,
+                gcloud,
+                "compute",
+                "start-iap-tunnel",
+                instance,
+                str(remote_port),
+                "--project",
+                project,
+                "--zone",
+                zone,
                 f"--local-host-port=127.0.0.1:{port}",
             ]
         open_browser = bool(access.get("open_browser", True))
@@ -3671,7 +3557,9 @@ def run_access(ns) -> int:
                 route_requested=bool(getattr(ns, "route_lab", False)),
             )
         validated, enabled, _detail = diagnose_project_billing(project)
-        print(f"billing: {'enabled' if enabled else 'disabled'}" if validated else "billing: unable to verify")
+        print(
+            f"billing: {'enabled' if enabled else 'disabled'}" if validated else "billing: unable to verify"
+        )
         _print_cost_estimate(cost_estimate, state=state)
         if bool(getattr(ns, "native_consoles", False)):
             _print_native_console_client_guidance(native_console_mode)
@@ -3847,19 +3735,18 @@ def _lab_archive_contract(lifecycle: dict[str, Any]) -> dict[str, Any]:
     prefix = str(lifecycle.get("contract_prefix") or "eveng_lab_archive").strip()
     return {
         "prefix": prefix,
-        "contents_label": str(
-            lifecycle.get("contents_label") or "lab definitions"
-        ).strip(),
+        "contents_label": str(lifecycle.get("contents_label") or "lab definitions").strip(),
         "node_state": bool(lifecycle.get("node_state", True)),
-        "restore_overwrite_default": bool(
-            lifecycle.get("restore_overwrite_default", False)
-        ),
+        "restore_overwrite_default": bool(lifecycle.get("restore_overwrite_default", False)),
         "path_output": f"{prefix}_path",
         "previous_path_output": f"{prefix}_previous_path",
         "sha256_output": f"{prefix}_sha256",
         "node_included_output": f"{prefix}_node_state_included",
         "node_path_output": f"{prefix}_node_state_archive_path",
         "node_sha256_output": f"{prefix}_node_state_sha256",
+        "images_included_output": f"{prefix}_images_included",
+        "images_path_output": f"{prefix}_images_archive_path",
+        "images_sha256_output": f"{prefix}_images_sha256",
         "device_configs_captured_output": f"{prefix}_device_configs_captured",
     }
 
@@ -3902,34 +3789,53 @@ def _verified_lab_archive(
     node_archive: Path | None = None
     node_checksum = ""
     if contract["node_state"]:
-        candidate_value = str(
-            outputs.get(contract["node_path_output"]) or ""
-        ).strip()
-        candidate_checksum = str(
-            outputs.get(contract["node_sha256_output"]) or ""
-        ).strip().lower()
-        node_state_declared = bool(
-            outputs.get(contract["node_included_output"], False)
-        )
+        candidate_value = str(outputs.get(contract["node_path_output"]) or "").strip()
+        candidate_checksum = str(outputs.get(contract["node_sha256_output"]) or "").strip().lower()
+        node_state_declared = bool(outputs.get(contract["node_included_output"], False))
         node_state_metadata_present = bool(candidate_value or candidate_checksum)
-        if not (node_state_declared or node_state_metadata_present):
-            return archive_path.resolve(), expected, None, "", None, ""
+        if node_state_declared or node_state_metadata_present:
+            candidate = Path(candidate_value).expanduser()
+            if not candidate.is_file() or not re.fullmatch(r"[0-9a-f]{64}", candidate_checksum):
+                raise ValueError("node-state archive is missing or unverifiable")
+            node_digest = hashlib.sha256()
+            with candidate.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    node_digest.update(chunk)
+            if node_digest.hexdigest() != candidate_checksum:
+                raise ValueError(f"node-state archive checksum verification failed: {candidate}")
+            node_archive = candidate.resolve()
+            node_checksum = candidate_checksum
+    image_archive: Path | None = None
+    image_checksum = ""
+    candidate_value = str(outputs.get(contract["images_path_output"]) or "").strip()
+    candidate_checksum = str(outputs.get(contract["images_sha256_output"]) or "").strip().lower()
+    images_declared = bool(outputs.get(contract["images_included_output"], False))
+    if images_declared or candidate_value or candidate_checksum:
         candidate = Path(candidate_value).expanduser()
-        if not candidate.is_file() or not re.fullmatch(
-            r"[0-9a-f]{64}", candidate_checksum
-        ):
-            raise ValueError("node-state archive is missing or unverifiable")
-        node_digest = hashlib.sha256()
+        if not candidate.is_file() or not re.fullmatch(r"[0-9a-f]{64}", candidate_checksum):
+            raise ValueError("image archive is missing or unverifiable")
+        image_digest = hashlib.sha256()
         with candidate.open("rb") as handle:
             for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                node_digest.update(chunk)
-        if node_digest.hexdigest() != candidate_checksum:
-            raise ValueError(
-                f"node-state archive checksum verification failed: {candidate}"
-            )
-        node_archive = candidate.resolve()
-        node_checksum = candidate_checksum
-    return archive_path.resolve(), expected, node_archive, node_checksum, None, ""
+                image_digest.update(chunk)
+        if image_digest.hexdigest() != candidate_checksum:
+            raise ValueError(f"image archive checksum verification failed: {candidate}")
+        image_archive = candidate.resolve()
+        image_checksum = candidate_checksum
+    else:
+        from hyops.lab.migration import load_migration_images
+
+        migrated_images = load_migration_images(paths=paths, payload=payload)
+        if migrated_images is not None:
+            image_archive, image_checksum = migrated_images
+    return (
+        archive_path.resolve(),
+        expected,
+        node_archive,
+        node_checksum,
+        image_archive,
+        image_checksum,
+    )
 
 
 def _automatic_lab_restore_eligible(payload: dict[str, Any], paths) -> bool:
@@ -3960,9 +3866,12 @@ def _select_lab_restore_mode(
     requested = bool(getattr(ns, "restore_labs", False))
     skipped = bool(getattr(ns, "skip_lab_restore", False))
     overwrite = bool(getattr(ns, "overwrite_labs", False))
+    overwrite_images = bool(getattr(ns, "overwrite_images", False))
 
     if overwrite and not requested:
         raise ValueError("--overwrite-labs requires --restore-labs")
+    if overwrite_images and not requested:
+        raise ValueError("--overwrite-images requires --restore-labs")
     if (requested or skipped) and not isinstance(lifecycle, dict):
         raise ValueError("this blueprint does not declare a lab archive lifecycle")
 
@@ -3971,6 +3880,8 @@ def _select_lab_restore_mode(
         if requested:
             raise ValueError("no verified lab archive is available for this environment")
         return "none", None
+    if overwrite_images and archive[4] is None:
+        raise ValueError("--overwrite-images requires a verified image archive")
     if requested:
         return "restore", archive
     if skipped:
@@ -4042,6 +3953,7 @@ def _run_lab_restore(
         restore_inputs.update(
             {
                 f"{prefix}_restore_images": True,
+                f"{prefix}_overwrite_images": bool(getattr(ns, "overwrite_images", False)),
                 f"{prefix}_images_path": str(image_archive_path),
                 f"{prefix}_images_expected_sha256": image_checksum,
             }
@@ -4082,9 +3994,7 @@ def _run_lab_restore(
             os.environ.pop("HYOPS_PROGRESS_CHILD", None)
         else:
             os.environ["HYOPS_PROGRESS_CHILD"] = previous_child
-    restore_status = "cancelled" if rc == CANCELLED else (
-        "ok" if rc == 0 else "failed"
-    )
+    restore_status = "cancelled" if rc == CANCELLED else ("ok" if rc == 0 else "failed")
     progress.finish(
         restore_step["id"],
         "Lab restore",
@@ -4175,11 +4085,7 @@ def run_deploy(ns) -> int:
         preflight_decision = complete_preflight_decision(
             preflight_decision,
             passed=not preflight_required,
-            detail=(
-                ""
-                if not preflight_required
-                else f"required_failures={','.join(preflight_required)}"
-            ),
+            detail=("" if not preflight_required else f"required_failures={','.join(preflight_required)}"),
         )
         preflight_summary = {
             "status": preflight_status,
@@ -4253,12 +4159,7 @@ def run_deploy(ns) -> int:
     iol_repair_used = False
     repair_results: list[dict[str, Any]] = []
     progress = ProgressDisplay(
-        enabled=bool(
-            sys.stdout
-            and sys.stdout.isatty()
-            and not json_mode
-            and not os.getenv("HYOPS_VERBOSE")
-        ),
+        enabled=bool(sys.stdout and sys.stdout.isatty() and not json_mode and not os.getenv("HYOPS_VERBOSE")),
         show_elapsed=False,
     )
 
@@ -4334,12 +4235,10 @@ def run_deploy(ns) -> int:
                     detail = "state-ok"
                     if skip_detail:
                         detail = f"state-ok ({skip_detail})"
-                    presentation_label, presentation_detail, skip_item_line = (
-                        _step_presentation(
-                            step,
-                            state_dir=paths.state_dir,
-                            progress_after=progress_after,
-                        )
+                    presentation_label, presentation_detail, skip_item_line = _step_presentation(
+                        step,
+                        state_dir=paths.state_dir,
+                        progress_after=progress_after,
                     )
                     result = dict(base)
                     result.update({"status": "skipped", "reason": detail, "rc": 0})
@@ -4405,10 +4304,7 @@ def run_deploy(ns) -> int:
         progress.start(
             step_id,
             running_label,
-            plain=(
-                f"step={step_id} status=running action={step['action']} "
-                f"module={step['module_ref']}"
-            ),
+            plain=(f"step={step_id} status=running action={step['action']} module={step['module_ref']}"),
         )
         previous_child = os.environ.get("HYOPS_PROGRESS_CHILD")
         failure_state_before = _step_failure_state(step, paths)
@@ -4439,8 +4335,7 @@ def run_deploy(ns) -> int:
             and mismatch is not None
             and bool(getattr(ns, "repair_iol_license", False))
             and not iol_repair_used
-            and str(step.get("module_ref") or "").strip().lower()
-            == IOL_IMAGES_MODULE_REF
+            and str(step.get("module_ref") or "").strip().lower() == IOL_IMAGES_MODULE_REF
             and str(step.get("action") or "").strip().lower() in {"apply", "deploy"}
         ):
             iol_repair_used = True
@@ -4576,11 +4471,7 @@ def run_deploy(ns) -> int:
             step_results.append(
                 {
                     "id": "restore_archived_labs",
-                    "module_ref": str(
-                        (payload.get("archive_before_destroy") or {}).get(
-                            "module_ref", ""
-                        )
-                    ),
+                    "module_ref": str((payload.get("archive_before_destroy") or {}).get("module_ref", "")),
                     "action": "deploy",
                     "phase": "operations",
                     "optional": False,
@@ -4632,16 +4523,12 @@ def run_deploy(ns) -> int:
     if cancelled:
         output["next_actions"] = _cancelled_deploy_actions(ns, payload)
     elif required_failures and _failed_deploy_has_resources(payload, paths):
-        output["next_actions"] = {
-            "destroy": _cancelled_deploy_actions(ns, payload)["destroy"]
-        }
+        output["next_actions"] = {"destroy": _cancelled_deploy_actions(ns, payload)["destroy"]}
 
     if json_mode:
         print(json.dumps(output, indent=2, sort_keys=True))
     else:
-        ready_message = str(
-            (payload.get("metadata") or {}).get("ready_message") or ""
-        ).strip()
+        ready_message = str((payload.get("metadata") or {}).get("ready_message") or "").strip()
         if final_status == "ok" and ready_message and progress.enabled:
             print()
             progress.finish(
@@ -4675,9 +4562,7 @@ def run_deploy(ns) -> int:
 def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> str:
     archive = payload.get("archive_before_destroy")
     if not isinstance(archive, dict) or not archive:
-        if bool(getattr(ns, "archive_before_destroy", False)) or bool(
-            getattr(ns, "skip_archive", False)
-        ):
+        if bool(getattr(ns, "archive_before_destroy", False)) or bool(getattr(ns, "skip_archive", False)):
             raise ValueError("this blueprint does not declare a lab archive lifecycle")
         return "none"
 
@@ -4686,12 +4571,9 @@ def _select_archive_destroy_mode(ns, payload: dict[str, Any], env_name: str) -> 
     if bool(getattr(ns, "skip_archive", False)):
         return "skip"
 
-    if bool(getattr(ns, "yes", False)) or not (
-        sys.stdin.isatty() and sys.stdout.isatty()
-    ):
+    if bool(getattr(ns, "yes", False)) or not (sys.stdin.isatty() and sys.stdout.isatty()):
         raise ValueError(
-            "this blueprint protects lab data; select --archive-before-destroy "
-            "or --skip-archive"
+            "this blueprint protects lab data; select --archive-before-destroy or --skip-archive"
         )
 
     print("lab data:")
@@ -4763,9 +4645,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
             os.environ.pop("HYOPS_PROGRESS_CHILD", None)
         else:
             os.environ["HYOPS_PROGRESS_CHILD"] = previous_child
-    archive_status = "cancelled" if int(rc) == CANCELLED else (
-        "ok" if rc == 0 else "failed"
-    )
+    archive_status = "cancelled" if int(rc) == CANCELLED else ("ok" if rc == 0 else "failed")
     progress.finish(
         archive_step["id"],
         "Lab archive",
@@ -4788,9 +4668,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
         )
         outputs = state.get("outputs") if isinstance(state.get("outputs"), dict) else {}
         contract = _lab_archive_contract(archive)
-        archive_path = Path(
-            str(outputs.get(contract["path_output"]) or "")
-        ).expanduser()
+        archive_path = Path(str(outputs.get(contract["path_output"]) or "")).expanduser()
         expected = str(outputs.get(contract["sha256_output"]) or "").strip().lower()
         if not archive_path.is_file() or not expected:
             raise ValueError("lab export did not publish a verifiable archive")
@@ -4808,27 +4686,17 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
     archive_contents = [contract["contents_label"]]
     if bool(outputs.get(contract["device_configs_captured_output"], False)):
         archive_contents.append("saved device configurations")
-    previous_archive_path = Path(
-        str(outputs.get(contract["previous_path_output"]) or "")
-    ).expanduser()
+    previous_archive_path = Path(str(outputs.get(contract["previous_path_output"]) or "")).expanduser()
     if previous_archive_path.is_file():
         archive_contents.append("previous generation retained")
     verbose = bool(os.getenv("HYOPS_VERBOSE"))
     if verbose:
         print(f"lab archive: {archive_path}")
         print(f"sha256: {actual}")
-    if contract["node_state"] and bool(
-        outputs.get(contract["node_included_output"], False)
-    ):
-        node_archive_path = Path(
-            str(outputs.get(contract["node_path_output"]) or "")
-        ).expanduser()
-        node_expected = str(
-            outputs.get(contract["node_sha256_output"]) or ""
-        ).strip().lower()
-        if not node_archive_path.is_file() or not re.fullmatch(
-            r"[0-9a-f]{64}", node_expected
-        ):
+    if contract["node_state"] and bool(outputs.get(contract["node_included_output"], False)):
+        node_archive_path = Path(str(outputs.get(contract["node_path_output"]) or "")).expanduser()
+        node_expected = str(outputs.get(contract["node_sha256_output"]) or "").strip().lower()
+        if not node_archive_path.is_file() or not re.fullmatch(r"[0-9a-f]{64}", node_expected):
             print("ERR: node-state archive is missing; no resources were destroyed")
             return OPERATOR_ERROR
         node_digest = hashlib.sha256()
@@ -4837,10 +4705,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
                 node_digest.update(chunk)
         node_actual = node_digest.hexdigest()
         if node_actual != node_expected:
-            print(
-                "ERR: node-state archive checksum verification failed; "
-                "no resources were destroyed"
-            )
+            print("ERR: node-state archive checksum verification failed; no resources were destroyed")
             return OPERATOR_ERROR
         archive_contents.append("stopped node state")
         if verbose:
@@ -4853,9 +4718,7 @@ def _run_archive_before_destroy(ns, payload: dict[str, Any], paths) -> int:
 
 
 def run_destroy(ns) -> int:
-    if not bool(getattr(ns, "execute", False)) or bool(
-        getattr(ns, "_lifecycle_lock_held", False)
-    ):
+    if not bool(getattr(ns, "execute", False)) or bool(getattr(ns, "_lifecycle_lock_held", False)):
         return _run_destroy_unlocked(ns)
     try:
         require_runtime_selection(
@@ -4913,10 +4776,7 @@ def _run_destroy_unlocked(ns) -> int:
                 action = "retain" if bool(step.get("retain_on_destroy", False)) else "destroy"
                 print(f"  - {_step_display_label(step)}: {action}")
                 if os.getenv("HYOPS_VERBOSE"):
-                    print(
-                        f"    id={step_id} module={step['module_ref']} "
-                        f"ref={step_state_ref(step)}"
-                    )
+                    print(f"    id={step_id} module={step['module_ref']} ref={step_state_ref(step)}")
         return 0
 
     json_mode = bool(getattr(ns, "json", False))
@@ -4939,10 +4799,7 @@ def _run_destroy_unlocked(ns) -> int:
         return OPERATOR_ERROR
 
     by_id = {step["id"]: step for step in payload["steps"]}
-    env_name = (
-        str(getattr(ns, "env", None) or getattr(paths.root, "name", "") or "").strip()
-        or "default"
-    )
+    env_name = str(getattr(ns, "env", None) or getattr(paths.root, "name", "") or "").strip() or "default"
     lifecycle_snapshot = _destroy_lifecycle_snapshot(
         payload,
         paths,
@@ -4999,17 +4856,10 @@ def _run_destroy_unlocked(ns) -> int:
             step = by_id[step_id]
             state_ref = step_state_ref(step)
             status = module_state_status(paths.state_dir, state_ref) or "missing"
-            preview_status = (
-                "pending"
-                if _destroy_gate_required(step, by_id, paths)
-                else status
-            )
+            preview_status = "pending" if _destroy_gate_required(step, by_id, paths) else status
             print(f"  - {_destroy_preview_label(step, preview_status)}")
             if os.getenv("HYOPS_VERBOSE"):
-                print(
-                    f"    id={step_id} module={step['module_ref']} "
-                    f"state={status} ref={state_ref}"
-                )
+                print(f"    id={step_id} module={step['module_ref']} state={status} ref={state_ref}")
         cost_estimate = getattr(ns, "_cost_estimate", None)
         if cost_estimate is None and lifecycle_snapshot is not None:
             estimate_payload = lifecycle_snapshot["estimate"]
@@ -5125,12 +4975,7 @@ def _run_destroy_unlocked(ns) -> int:
     optional_failures: list[str] = []
     cancelled = False
     progress = ProgressDisplay(
-        enabled=bool(
-            sys.stdout
-            and sys.stdout.isatty()
-            and not json_mode
-            and not os.getenv("HYOPS_VERBOSE")
-        ),
+        enabled=bool(sys.stdout and sys.stdout.isatty() and not json_mode and not os.getenv("HYOPS_VERBOSE")),
         show_elapsed=False,
     )
     deferred_by_parent: dict[str, list[tuple[dict[str, Any], dict[str, Any]]]] = {}
@@ -5166,9 +5011,7 @@ def _run_destroy_unlocked(ns) -> int:
                 {
                     "module_ref": child_ref,
                     "status": "destroyed",
-                    "updated_at": datetime.now(timezone.utc).strftime(
-                        "%Y-%m-%dT%H:%M:%SZ"
-                    ),
+                    "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "outputs": {},
                     "output_count": 0,
                     "destroyed_by_blueprint_step": parent_id,
@@ -5237,20 +5080,14 @@ def _run_destroy_unlocked(ns) -> int:
                 step_id,
                 step_id,
                 "retained",
-                plain=(
-                    f"step={step_id} status=retained reason=retain_on_destroy "
-                    f"progress={progress_after}%"
-                ),
+                plain=(f"step={step_id} status=retained reason=retain_on_destroy progress={progress_after}%"),
                 detail=f"retain_on_destroy, {completed_detail}",
             )
             continue
 
         state_status = module_state_status(paths.state_dir, state_ref)
         destroy_gate_required = _destroy_gate_required(step, by_id, paths)
-        if (
-            not destroy_gate_required
-            and (not state_status or state_status in {"destroyed", "absent"})
-        ):
+        if not destroy_gate_required and (not state_status or state_status in {"destroyed", "absent"}):
             reason = "no-state" if not state_status else f"state-{state_status}"
             result = dict(base)
             result.update({"status": "skipped", "reason": reason, "rc": 0})
@@ -5282,10 +5119,7 @@ def _run_destroy_unlocked(ns) -> int:
                 step_id,
                 step_id,
                 "deferred",
-                plain=(
-                    f"step={step_id} status=deferred "
-                    f"reason=destroy-subsumed-by-{destroy_parent}"
-                ),
+                plain=(f"step={step_id} status=deferred reason=destroy-subsumed-by-{destroy_parent}"),
                 detail=f"awaiting {destroy_parent}, {completed_detail}",
             )
             continue
@@ -5303,10 +5137,7 @@ def _run_destroy_unlocked(ns) -> int:
         progress.start(
             step_id,
             running_label,
-            plain=(
-                f"step={step_id} status=running action=destroy "
-                f"module={step['module_ref']}"
-            ),
+            plain=(f"step={step_id} status=running action=destroy module={step['module_ref']}"),
         )
         previous_child = os.environ.get("HYOPS_PROGRESS_CHILD")
         failure_state_before = _step_failure_state(destroy_step, paths)
@@ -5463,9 +5294,7 @@ def _run_destroy_unlocked(ns) -> int:
 
 
 def run_rebuild(ns) -> int:
-    if not bool(getattr(ns, "execute", False)) or bool(
-        getattr(ns, "_lifecycle_lock_held", False)
-    ):
+    if not bool(getattr(ns, "execute", False)) or bool(getattr(ns, "_lifecycle_lock_held", False)):
         return _run_rebuild_unlocked(ns)
     try:
         require_runtime_selection(
@@ -5498,8 +5327,7 @@ def _run_rebuild_unlocked(ns) -> int:
 
     destroy_order = list(reversed(payload["order"]))
     print(
-        f"blueprint={payload['blueprint_ref']} mode={payload['mode']} "
-        f"rebuild_steps={len(payload['order'])}"
+        f"blueprint={payload['blueprint_ref']} mode={payload['mode']} rebuild_steps={len(payload['order'])}"
     )
     if not bool(getattr(ns, "execute", False)) or verbose_enabled():
         print("destroy_order:")
@@ -5542,9 +5370,7 @@ def _run_rebuild_unlocked(ns) -> int:
             getattr(ns, "env", None),
             command_label="hyops blueprint rebuild",
         )
-        paths = resolve_runtime_paths(
-            getattr(ns, "root", None), getattr(ns, "env", None)
-        )
+        paths = resolve_runtime_paths(getattr(ns, "root", None), getattr(ns, "env", None))
         ensure_layout(paths)
     except Exception as exc:
         print(f"ERR: blueprint rebuild failed: {exc}")
@@ -5552,10 +5378,7 @@ def _run_rebuild_unlocked(ns) -> int:
 
     env_name = str(getattr(ns, "env", None) or paths.root.name).strip()
     if not bool(getattr(ns, "yes", False)):
-        print(
-            "WARN: blueprint rebuild will destroy and recreate owned resources "
-            f"in env={env_name}."
-        )
+        print(f"WARN: blueprint rebuild will destroy and recreate owned resources in env={env_name}.")
         if not (sys.stdin.isatty() and sys.stdout.isatty()):
             print("ERR: non-interactive rebuild requires --yes")
             return OPERATOR_ERROR
@@ -5573,9 +5396,7 @@ def _run_rebuild_unlocked(ns) -> int:
     record_file = record_dir / "rebuild.json"
     record_writer = EvidenceWriter(record_dir)
 
-    def write_record(
-        status: str, destroy_rc: int | None, deploy_rc: int | None
-    ) -> None:
+    def write_record(status: str, destroy_rc: int | None, deploy_rc: int | None) -> None:
         record_writer.write_json(
             record_file.name,
             {

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -638,6 +638,32 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("node state: no QEMU overlays found", stdout.getvalue())
 
+    def test_archive_execution_injects_guest_quiescence(self):
+        payload = {
+            "archive_before_destroy": {
+                "module_ref": "platform/linux/eve-ng-lab-archive",
+                "state_instance": "lab_archive",
+                "inputs": {
+                    "eveng_lab_archive_include_node_state": True,
+                    "eveng_lab_archive_stop_running_nodes": True,
+                },
+            }
+        }
+        ns = _namespace()
+        ns.guest_quiesced = True
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+
+        with patch(
+            "hyops.blueprint.command.run_step_module_command",
+            return_value=CANCELLED,
+        ) as command:
+            rc = _run_archive_before_destroy(ns, payload, paths)
+
+        self.assertEqual(rc, CANCELLED)
+        inputs = command.call_args.args[0]["inputs"]
+        self.assertTrue(inputs["eveng_lab_archive_guest_quiesced"])
+        self.assertTrue(inputs["eveng_lab_archive_stop_running_nodes"])
+
     def test_failed_archive_stops_before_resource_destroy(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))
         payload = _payload()

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -106,6 +106,23 @@ class ResumableBlueprintDestroyTest(TestCase):
 
         self.assertTrue(confirmed)
 
+    def test_quiescence_script_satisfies_automatic_destroy_gate(self):
+        ns = _namespace()
+        payload = {
+            "archive_before_destroy": {
+                "inputs": {"eveng_lab_archive_include_node_state": True}
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            script = Path(tmp) / "quiesce.sh"
+            script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            ns.quiesce_script = str(script)
+
+            confirmed = _confirm_guest_quiescence(ns, payload)
+
+        self.assertTrue(confirmed)
+        self.assertEqual(ns.quiesce_script, str(script.resolve()))
+
     def test_standalone_destroy_resolves_cost_from_access_state(self):
         payload = {
             "blueprint_ref": "gcp/eve-ng@v1",
@@ -663,6 +680,34 @@ class ResumableBlueprintDestroyTest(TestCase):
         inputs = command.call_args.args[0]["inputs"]
         self.assertTrue(inputs["eveng_lab_archive_guest_quiesced"])
         self.assertTrue(inputs["eveng_lab_archive_stop_running_nodes"])
+
+    def test_archive_execution_injects_quiescence_script(self):
+        payload = {
+            "archive_before_destroy": {
+                "module_ref": "platform/linux/eve-ng-lab-archive",
+                "state_instance": "lab_archive",
+                "inputs": {"eveng_lab_archive_include_node_state": True},
+            }
+        }
+        ns = _namespace()
+        ns.quiesce_script = "/tmp/quiesce.sh"
+        ns.quiesce_timeout = 120
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+
+        with patch(
+            "hyops.blueprint.command.run_step_module_command",
+            return_value=CANCELLED,
+        ) as command:
+            rc = _run_archive_before_destroy(ns, payload, paths)
+
+        self.assertEqual(rc, CANCELLED)
+        inputs = command.call_args.args[0]["inputs"]
+        self.assertFalse(inputs["eveng_lab_archive_guest_quiesced"])
+        self.assertEqual(
+            inputs["eveng_lab_archive_quiesce_script_path"],
+            "/tmp/quiesce.sh",
+        )
+        self.assertEqual(inputs["eveng_lab_archive_quiesce_timeout_s"], 120)
 
     def test_failed_archive_stops_before_resource_destroy(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -12,8 +12,10 @@ from hyops.blueprint.command import (
     _confirm_guest_quiescence,
     _destroyed_blueprint_cost_cleared,
     _gcp_blueprint_cost_estimate,
+    _quiescence_action_path,
     _run_archive_before_destroy,
     _select_archive_destroy_mode,
+    run_quiescence,
     run_destroy,
 )
 from hyops.runtime.cost import CostEstimate
@@ -54,6 +56,8 @@ def _namespace():
         archive_before_destroy=False,
         skip_archive=False,
         guest_quiesced=False,
+        quiesce_script="",
+        quiesce_timeout=None,
     )
 
 
@@ -85,8 +89,13 @@ class ResumableBlueprintDestroyTest(TestCase):
             }
         }
 
-        with self.assertRaisesRegex(ValueError, "requires --guest-quiesced"):
-            _confirm_guest_quiescence(ns, payload)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = SimpleNamespace(
+                root=Path(tmp),
+                config_dir=Path(tmp) / "config",
+            )
+            with self.assertRaisesRegex(ValueError, "requires a configured"):
+                _confirm_guest_quiescence(ns, payload, paths)
 
     def test_interactive_node_state_archive_records_quiescence(self):
         ns = _namespace()
@@ -97,14 +106,20 @@ class ResumableBlueprintDestroyTest(TestCase):
             }
         }
 
-        with (
-            patch("hyops.blueprint.command.sys.stdin.isatty", return_value=True),
-            patch("hyops.blueprint.command.sys.stdout.isatty", return_value=True),
-            patch("hyops.blueprint.command.input", return_value="y"),
-        ):
-            confirmed = _confirm_guest_quiescence(ns, payload)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = SimpleNamespace(
+                root=Path(tmp),
+                config_dir=Path(tmp) / "config",
+            )
+            with (
+                patch("hyops.blueprint.command.sys.stdin.isatty", return_value=True),
+                patch("hyops.blueprint.command.sys.stdout.isatty", return_value=True),
+                patch("hyops.blueprint.command.input", return_value="y"),
+            ):
+                confirmed = _confirm_guest_quiescence(ns, payload, paths)
 
         self.assertTrue(confirmed)
+        self.assertEqual(ns._quiescence_source, "operator-attestation")
 
     def test_quiescence_script_satisfies_automatic_destroy_gate(self):
         ns = _namespace()
@@ -117,11 +132,102 @@ class ResumableBlueprintDestroyTest(TestCase):
             script = Path(tmp) / "quiesce.sh"
             script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             ns.quiesce_script = str(script)
+            paths = SimpleNamespace(
+                root=Path(tmp),
+                config_dir=Path(tmp) / "config",
+            )
 
-            confirmed = _confirm_guest_quiescence(ns, payload)
+            confirmed = _confirm_guest_quiescence(ns, payload, paths)
 
         self.assertTrue(confirmed)
         self.assertEqual(ns.quiesce_script, str(script.resolve()))
+        self.assertEqual(ns._quiescence_source, "command-override")
+
+    def test_environment_quiescence_action_is_resolved_automatically(self):
+        ns = _namespace()
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "archive_before_destroy": {
+                "inputs": {"eveng_lab_archive_include_node_state": True}
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = SimpleNamespace(
+                root=Path(tmp),
+                config_dir=Path(tmp) / "config",
+            )
+            action = _quiescence_action_path(paths, payload)
+            action.parent.mkdir(parents=True)
+            action.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+            confirmed = _confirm_guest_quiescence(ns, payload, paths)
+
+        self.assertTrue(confirmed)
+        self.assertEqual(ns.quiesce_script, str(action.resolve()))
+        self.assertEqual(ns._quiescence_source, "environment")
+
+    def test_quiescence_edit_activates_valid_environment_action(self):
+        ns = _namespace()
+        ns.quiescence_cmd = "edit"
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "archive_before_destroy": {
+                "inputs": {"eveng_lab_archive_include_node_state": True}
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = SimpleNamespace(root=root, config_dir=root / "config")
+            action = _quiescence_action_path(paths, payload)
+            editor = root / "editor.sh"
+            editor.write_text(
+                "#!/bin/sh\nprintf '#!/bin/sh\\nset -eu\\nexit 0\\n' > \"$1\"\n",
+                encoding="utf-8",
+            )
+            editor.chmod(0o700)
+            ns.editor = str(editor)
+
+            with patch(
+                "hyops.blueprint.command._quiescence_context",
+                return_value=(paths, payload, action),
+            ):
+                rc = run_quiescence(ns)
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(action.is_file())
+            self.assertEqual(action.stat().st_mode & 0o777, 0o600)
+            self.assertNotIn(
+                "NOT_CONFIGURED",
+                action.read_text(encoding="utf-8"),
+            )
+
+    def test_quiescence_edit_rejects_unchanged_template(self):
+        ns = _namespace()
+        ns.quiescence_cmd = "edit"
+        payload = {
+            "blueprint_ref": "gcp/eve-ng@v1",
+            "archive_before_destroy": {
+                "inputs": {"eveng_lab_archive_include_node_state": True}
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = SimpleNamespace(root=root, config_dir=root / "config")
+            action = _quiescence_action_path(paths, payload)
+            editor = root / "editor.sh"
+            editor.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            editor.chmod(0o700)
+            ns.editor = str(editor)
+
+            with patch(
+                "hyops.blueprint.command._quiescence_context",
+                return_value=(paths, payload, action),
+            ):
+                rc = run_quiescence(ns)
+
+            self.assertNotEqual(rc, 0)
+            self.assertFalse(action.exists())
+            self.assertTrue(action.with_suffix(".sh.draft").is_file())
 
     def test_standalone_destroy_resolves_cost_from_access_state(self):
         payload = {

--- a/hyops/blueprint/tests/test_destroy.py
+++ b/hyops/blueprint/tests/test_destroy.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from hyops.blueprint.command import (
     _confirm_archive_destroy,
+    _confirm_guest_quiescence,
     _destroyed_blueprint_cost_cleared,
     _gcp_blueprint_cost_estimate,
     _run_archive_before_destroy,
@@ -52,6 +53,7 @@ def _namespace():
         file=None,
         archive_before_destroy=False,
         skip_archive=False,
+        guest_quiesced=False,
     )
 
 
@@ -74,6 +76,35 @@ class ResumableBlueprintDestroyTest(TestCase):
             confirmed = _confirm_archive_destroy("test")
 
         self.assertIsNone(confirmed)
+
+    def test_node_state_archive_requires_quiescence_for_automatic_destroy(self):
+        ns = _namespace()
+        payload = {
+            "archive_before_destroy": {
+                "inputs": {"eveng_lab_archive_include_node_state": True}
+            }
+        }
+
+        with self.assertRaisesRegex(ValueError, "requires --guest-quiesced"):
+            _confirm_guest_quiescence(ns, payload)
+
+    def test_interactive_node_state_archive_records_quiescence(self):
+        ns = _namespace()
+        ns.yes = False
+        payload = {
+            "archive_before_destroy": {
+                "inputs": {"eveng_lab_archive_include_node_state": True}
+            }
+        }
+
+        with (
+            patch("hyops.blueprint.command.sys.stdin.isatty", return_value=True),
+            patch("hyops.blueprint.command.sys.stdout.isatty", return_value=True),
+            patch("hyops.blueprint.command.input", return_value="y"),
+        ):
+            confirmed = _confirm_guest_quiescence(ns, payload)
+
+        self.assertTrue(confirmed)
 
     def test_standalone_destroy_resolves_cost_from_access_state(self):
         payload = {
@@ -634,7 +665,7 @@ class ResumableBlueprintDestroyTest(TestCase):
         command.assert_called_once()
         self.assertEqual(command.call_args.args[0]["id"], "archive_before_destroy")
 
-    def test_interrupted_archive_reports_retained_resources_and_stopped_nodes(self):
+    def test_interrupted_archive_reports_retained_resources(self):
         payload = {
             "archive_before_destroy": {
                 "module_ref": "platform/test/archive",
@@ -657,10 +688,7 @@ class ResumableBlueprintDestroyTest(TestCase):
         self.assertEqual(rc, CANCELLED)
         output = stdout.getvalue()
         self.assertIn("Archive interrupted. Resources were retained.", output)
-        self.assertIn(
-            "Some lab nodes may have been stopped. Check the lab before continuing.",
-            output,
-        )
+        self.assertIn("Check lab state before continuing.", output)
 
     def test_cancelled_archive_stops_before_resource_destroy(self):
         paths = SimpleNamespace(state_dir="/tmp/state", root=SimpleNamespace(name="test"))

--- a/hyops/blueprint/tests/test_gcp_eve_ng.py
+++ b/hyops/blueprint/tests/test_gcp_eve_ng.py
@@ -25,6 +25,10 @@ class GcpEveNgBlueprintTest(TestCase):
             validated["metadata"]["ready_message"],
             "EVE-NG network emulation lab ready",
         )
+        self.assertEqual(
+            validated["metadata"]["credential_secret"],
+            "EVENG_ADMIN_PASSWORD",
+        )
         archive = validated["archive_before_destroy"]
         self.assertTrue(archive["inputs"]["load_vault_env"])
         self.assertEqual(

--- a/hyops/blueprint/tests/test_preflight_bypass.py
+++ b/hyops/blueprint/tests/test_preflight_bypass.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
-from hyops.blueprint.command import run_deploy
+from hyops.blueprint.command import _successful_deploy_actions, run_deploy
 from hyops.runtime.exitcodes import OPERATOR_ERROR
 from hyops.runtime.paths import RuntimePaths
 from hyops.runner.command import _remote_blueprint_command
@@ -64,6 +64,29 @@ def _namespace(
 
 
 class BlueprintPreflightBypassTest(TestCase):
+    def test_successful_deploy_actions_include_access_credentials_and_support(self) -> None:
+        payload = _payload()
+        payload["access"] = {"type": "gcp-iap-ssh-forward"}
+        payload["metadata"] = {"credential_secret": "EVENG_ADMIN_PASSWORD"}
+        ns = _namespace(Path("/tmp/runtime"), reason="test")
+        ns.root = None
+        ns.env = "demo-lab"
+
+        actions = _successful_deploy_actions(ns, payload)
+
+        self.assertEqual(
+            actions["access"],
+            "hyops blueprint access --env demo-lab --ref test/lab@v1",
+        )
+        self.assertEqual(
+            actions["credentials"],
+            "hyops secrets show --env demo-lab --raw EVENG_ADMIN_PASSWORD",
+        )
+        self.assertEqual(
+            actions["support"],
+            "https://github.com/sponsors/hybridops-tech",
+        )
+
     def test_mutating_blueprint_bypass_requires_reason(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -38,7 +38,7 @@ def _payload():
                 "eveng_lab_archive_action": "export",
                 "eveng_lab_archive_capture_device_configs": True,
                 "eveng_lab_archive_include_node_state": True,
-                "eveng_lab_archive_stop_running_nodes": True,
+                "eveng_lab_archive_stop_running_nodes": False,
             },
         }
     }

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -123,12 +123,34 @@ class BlueprintLabRestoreTest(TestCase):
         with patch(
             "hyops.blueprint.command.read_module_state",
             side_effect=FileNotFoundError,
+        ), patch(
+            "hyops.lab.migration.load_migration_archive",
+            return_value=None,
         ), self.assertRaisesRegex(ValueError, "no verified lab archive"):
             _select_lab_restore_mode(
                 _namespace(restore_labs=True),
                 _payload(),
                 paths,
             )
+
+    def test_explicit_restore_accepts_staged_migration_archive(self):
+        imported = (Path("/tmp/imported.tar.gz"), "d" * 64, None, "")
+        paths = SimpleNamespace(state_dir=Path("/tmp/state"))
+        with patch(
+            "hyops.blueprint.command.read_module_state",
+            side_effect=FileNotFoundError,
+        ), patch(
+            "hyops.lab.migration.load_migration_archive",
+            return_value=imported,
+        ):
+            mode, selected = _select_lab_restore_mode(
+                _namespace(restore_labs=True),
+                _payload(),
+                paths,
+            )
+
+        self.assertEqual(mode, "restore")
+        self.assertEqual(selected, imported)
 
     def test_checksum_mismatch_stops_restore(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -20,6 +20,7 @@ def _namespace(**overrides):
         "restore_labs": False,
         "skip_lab_restore": False,
         "overwrite_labs": False,
+        "overwrite_images": False,
         "yes": True,
         "json": False,
     }
@@ -78,10 +79,13 @@ class BlueprintLabRestoreTest(TestCase):
                     "eveng_lab_archive_sha256": checksum,
                 }
             }
-            with patch(
-                "hyops.blueprint.command.read_module_state",
-                return_value=state,
-            ), patch("builtins.input") as prompt:
+            with (
+                patch(
+                    "hyops.blueprint.command.read_module_state",
+                    return_value=state,
+                ),
+                patch("builtins.input") as prompt,
+            ):
                 mode, selected = _select_lab_restore_mode(
                     _namespace(yes=False),
                     _payload(),
@@ -123,13 +127,17 @@ class BlueprintLabRestoreTest(TestCase):
 
     def test_explicit_restore_requires_an_archive(self):
         paths = SimpleNamespace(state_dir=Path("/tmp/state"))
-        with patch(
-            "hyops.blueprint.command.read_module_state",
-            side_effect=FileNotFoundError,
-        ), patch(
-            "hyops.lab.migration.load_migration_archive",
-            return_value=None,
-        ), self.assertRaisesRegex(ValueError, "no verified lab archive"):
+        with (
+            patch(
+                "hyops.blueprint.command.read_module_state",
+                side_effect=FileNotFoundError,
+            ),
+            patch(
+                "hyops.lab.migration.load_migration_archive",
+                return_value=None,
+            ),
+            self.assertRaisesRegex(ValueError, "no verified lab archive"),
+        ):
             _select_lab_restore_mode(
                 _namespace(restore_labs=True),
                 _payload(),
@@ -146,12 +154,15 @@ class BlueprintLabRestoreTest(TestCase):
             "",
         )
         paths = SimpleNamespace(state_dir=Path("/tmp/state"))
-        with patch(
-            "hyops.blueprint.command.read_module_state",
-            side_effect=FileNotFoundError,
-        ), patch(
-            "hyops.lab.migration.load_migration_archive",
-            return_value=imported,
+        with (
+            patch(
+                "hyops.blueprint.command.read_module_state",
+                side_effect=FileNotFoundError,
+            ),
+            patch(
+                "hyops.lab.migration.load_migration_archive",
+                return_value=imported,
+            ),
         ):
             mode, selected = _select_lab_restore_mode(
                 _namespace(restore_labs=True),
@@ -173,10 +184,13 @@ class BlueprintLabRestoreTest(TestCase):
                     "eveng_lab_archive_sha256": "a" * 64,
                 }
             }
-            with patch(
-                "hyops.blueprint.command.read_module_state",
-                return_value=state,
-            ), self.assertRaisesRegex(ValueError, "checksum verification failed"):
+            with (
+                patch(
+                    "hyops.blueprint.command.read_module_state",
+                    return_value=state,
+                ),
+                self.assertRaisesRegex(ValueError, "checksum verification failed"),
+            ):
                 _select_lab_restore_mode(
                     _namespace(restore_labs=True),
                     _payload(),
@@ -216,9 +230,7 @@ class BlueprintLabRestoreTest(TestCase):
             "b" * 64,
         )
         self.assertFalse(step["inputs"]["eveng_lab_archive_overwrite"])
-        self.assertFalse(
-            step["inputs"]["eveng_lab_archive_capture_device_configs"]
-        )
+        self.assertFalse(step["inputs"]["eveng_lab_archive_capture_device_configs"])
         self.assertFalse(step["inputs"]["eveng_lab_archive_include_node_state"])
         self.assertFalse(step["inputs"]["eveng_lab_archive_stop_running_nodes"])
 
@@ -330,6 +342,74 @@ class BlueprintLabRestoreTest(TestCase):
             ),
         )
 
+    def test_restore_retains_migrated_images_after_a_later_lab_export(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "latest-labs.tar.gz"
+            archive.write_bytes(b"latest portable labs")
+            checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+            image_archive = Path(tmp) / "imported-images.tar.gz"
+            image_archive.write_bytes(b"referenced bases")
+            image_checksum = hashlib.sha256(image_archive.read_bytes()).hexdigest()
+            paths = SimpleNamespace(state_dir=Path(tmp) / "state")
+            payload = _payload() | {"blueprint_ref": "gcp/eve-ng@v1"}
+            state = {
+                "outputs": {
+                    "eveng_lab_archive_path": str(archive),
+                    "eveng_lab_archive_sha256": checksum,
+                }
+            }
+            with (
+                patch(
+                    "hyops.blueprint.command.read_module_state",
+                    return_value=state,
+                ),
+                patch(
+                    "hyops.lab.migration.load_migration_images",
+                    return_value=(image_archive.resolve(), image_checksum),
+                ) as migrated_images,
+            ):
+                mode, selected = _select_lab_restore_mode(
+                    _namespace(restore_labs=True),
+                    payload,
+                    paths,
+                )
+
+        self.assertEqual(mode, "restore")
+        self.assertEqual(selected[0], archive.resolve())
+        self.assertEqual(selected[4:], (image_archive.resolve(), image_checksum))
+        migrated_images.assert_called_once()
+
+    def test_restore_uses_image_metadata_published_by_prior_restore(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "labs.tar.gz"
+            archive.write_bytes(b"portable labs")
+            checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+            image_archive = Path(tmp) / "images.tar.gz"
+            image_archive.write_bytes(b"referenced bases")
+            image_checksum = hashlib.sha256(image_archive.read_bytes()).hexdigest()
+            paths = SimpleNamespace(state_dir=Path(tmp) / "state")
+            state = {
+                "outputs": {
+                    "eveng_lab_archive_path": str(archive),
+                    "eveng_lab_archive_sha256": checksum,
+                    "eveng_lab_archive_images_included": True,
+                    "eveng_lab_archive_images_archive_path": str(image_archive),
+                    "eveng_lab_archive_images_sha256": image_checksum,
+                }
+            }
+            with patch(
+                "hyops.blueprint.command.read_module_state",
+                return_value=state,
+            ):
+                mode, selected = _select_lab_restore_mode(
+                    _namespace(restore_labs=True),
+                    _payload(),
+                    paths,
+                )
+
+        self.assertEqual(mode, "restore")
+        self.assertEqual(selected[4:], (image_archive.resolve(), image_checksum))
+
     def test_restore_includes_verified_referenced_images(self):
         archive = (
             Path("/tmp/labs.tar.gz"),
@@ -361,6 +441,36 @@ class BlueprintLabRestoreTest(TestCase):
             inputs["eveng_lab_archive_images_expected_sha256"],
             "e" * 64,
         )
+        self.assertFalse(inputs["eveng_lab_archive_overwrite_images"])
+
+    def test_image_overwrite_is_separate_from_lab_overwrite(self):
+        archive = (
+            Path("/tmp/labs.tar.gz"),
+            "b" * 64,
+            None,
+            "",
+            Path("/tmp/labs.images.tar.gz"),
+            "e" * 64,
+        )
+        with patch(
+            "hyops.blueprint.command.run_step_module_command",
+            return_value=0,
+        ) as command:
+            rc = _run_lab_restore(
+                _namespace(
+                    restore_labs=True,
+                    overwrite_labs=False,
+                    overwrite_images=True,
+                ),
+                _payload(),
+                SimpleNamespace(),
+                archive,
+            )
+
+        self.assertEqual(rc, 0)
+        inputs = command.call_args.args[0]["inputs"]
+        self.assertFalse(inputs["eveng_lab_archive_overwrite"])
+        self.assertTrue(inputs["eveng_lab_archive_overwrite_images"])
 
     def test_gns3_restore_uses_declared_archive_contract(self):
         payload = {

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -58,9 +58,9 @@ class BlueprintLabRestoreTest(TestCase):
         self.assertEqual(
             _lab_restore_phase(
                 "TASK [hybridops.helper.eveng_lab_archive : "
-                "Repair leaked clusters in restored EVE-NG QEMU overlays] ***"
+                "Inspect restored EVE-NG QEMU overlays] ***"
             ),
-            "repairing node state",
+            "verifying node state",
         )
         self.assertEqual(
             _lab_restore_phase(

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -8,8 +8,10 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
+from hyops.runtime import proc
 from hyops.blueprint.command import (
     _automatic_lab_restore_eligible,
+    _lab_restore_phase,
     _run_lab_restore,
     _select_lab_restore_mode,
 )
@@ -45,6 +47,36 @@ def _payload():
 
 
 class BlueprintLabRestoreTest(TestCase):
+    def test_restore_phase_maps_long_running_tasks(self):
+        self.assertEqual(
+            _lab_restore_phase(
+                "TASK [hybridops.helper.eveng_lab_archive : "
+                "Stage referenced EVE-NG images] *****"
+            ),
+            "staging images",
+        )
+        self.assertEqual(
+            _lab_restore_phase(
+                "TASK [hybridops.helper.eveng_lab_archive : "
+                "Repair leaked clusters in restored EVE-NG QEMU overlays] ***"
+            ),
+            "repairing node state",
+        )
+        self.assertEqual(
+            _lab_restore_phase(
+                "TASK [hybridops.app.gns3_lab_archive : Restore GNS3 lab state] ***"
+            ),
+            "restoring lab definitions",
+        )
+        self.assertEqual(
+            _lab_restore_phase(
+                "TASK [hybridops.app.containerlab_recovery : "
+                "Extract recovery archive] ***"
+            ),
+            "restoring lab data",
+        )
+        self.assertEqual(_lab_restore_phase("ok: [eve-ng-01]"), "")
+
     def test_existing_target_does_not_require_automatic_restore(self):
         paths = SimpleNamespace(state_dir=Path("/tmp/state"))
 
@@ -268,6 +300,44 @@ class BlueprintLabRestoreTest(TestCase):
 
         self.assertEqual(rc, 0)
         self.assertFalse(progress_class.call_args.kwargs["show_elapsed"])
+
+    def test_restore_reports_the_current_ansible_phase(self):
+        archive = (
+            Path("/tmp/labs.tar.gz"),
+            "b" * 64,
+            None,
+            "",
+            None,
+            "",
+        )
+
+        def run_restore(*_args):
+            proc._notify_stream_observers(
+                "stdout",
+                "TASK [hybridops.helper.eveng_lab_archive : "
+                "Stage referenced EVE-NG images] *****\n",
+            )
+            return 0
+
+        with (
+            patch(
+                "hyops.blueprint.command.run_step_module_command",
+                side_effect=run_restore,
+            ),
+            patch("hyops.blueprint.command.ProgressDisplay") as progress_class,
+        ):
+            rc = _run_lab_restore(
+                _namespace(restore_labs=True),
+                _payload(),
+                SimpleNamespace(),
+                archive,
+            )
+
+        self.assertEqual(rc, 0)
+        progress_class.return_value.update.assert_called_with(
+            "restore_archived_labs",
+            "Lab restore: staging images",
+        )
 
     def test_restore_includes_verified_node_state(self):
         archive = (

--- a/hyops/blueprint/tests/test_restore.py
+++ b/hyops/blueprint/tests/test_restore.py
@@ -116,7 +116,10 @@ class BlueprintLabRestoreTest(TestCase):
                 )
 
         self.assertEqual(mode, "restore")
-        self.assertEqual(selected, (archive.resolve(), checksum, None, ""))
+        self.assertEqual(
+            selected,
+            (archive.resolve(), checksum, None, "", None, ""),
+        )
 
     def test_explicit_restore_requires_an_archive(self):
         paths = SimpleNamespace(state_dir=Path("/tmp/state"))
@@ -134,7 +137,14 @@ class BlueprintLabRestoreTest(TestCase):
             )
 
     def test_explicit_restore_accepts_staged_migration_archive(self):
-        imported = (Path("/tmp/imported.tar.gz"), "d" * 64, None, "")
+        imported = (
+            Path("/tmp/imported.tar.gz"),
+            "d" * 64,
+            None,
+            "",
+            None,
+            "",
+        )
         paths = SimpleNamespace(state_dir=Path("/tmp/state"))
         with patch(
             "hyops.blueprint.command.read_module_state",
@@ -174,7 +184,14 @@ class BlueprintLabRestoreTest(TestCase):
                 )
 
     def test_restore_reuses_target_contract_and_protects_existing_labs(self):
-        archive = (Path("/tmp/labs.tar.gz"), "b" * 64, None, "")
+        archive = (
+            Path("/tmp/labs.tar.gz"),
+            "b" * 64,
+            None,
+            "",
+            None,
+            "",
+        )
         with patch(
             "hyops.blueprint.command.run_step_module_command",
             return_value=0,
@@ -206,7 +223,14 @@ class BlueprintLabRestoreTest(TestCase):
         self.assertFalse(step["inputs"]["eveng_lab_archive_stop_running_nodes"])
 
     def test_restore_hides_nested_progress_and_elapsed_time(self):
-        archive = (Path("/tmp/labs.tar.gz"), "b" * 64, None, "")
+        archive = (
+            Path("/tmp/labs.tar.gz"),
+            "b" * 64,
+            None,
+            "",
+            None,
+            "",
+        )
 
         def run_restore(*_args):
             self.assertEqual(os.environ.get("HYOPS_PROGRESS_CHILD"), "1")
@@ -239,6 +263,8 @@ class BlueprintLabRestoreTest(TestCase):
             "b" * 64,
             Path("/tmp/labs.tar.gz.node-state.tar.gz"),
             "c" * 64,
+            None,
+            "",
         )
         with patch(
             "hyops.blueprint.command.run_step_module_command",
@@ -299,7 +325,41 @@ class BlueprintLabRestoreTest(TestCase):
                 checksum,
                 node_archive.resolve(),
                 node_checksum,
+                None,
+                "",
             ),
+        )
+
+    def test_restore_includes_verified_referenced_images(self):
+        archive = (
+            Path("/tmp/labs.tar.gz"),
+            "b" * 64,
+            None,
+            "",
+            Path("/tmp/labs.images.tar.gz"),
+            "e" * 64,
+        )
+        with patch(
+            "hyops.blueprint.command.run_step_module_command",
+            return_value=0,
+        ) as command:
+            rc = _run_lab_restore(
+                _namespace(restore_labs=True),
+                _payload(),
+                SimpleNamespace(),
+                archive,
+            )
+
+        self.assertEqual(rc, 0)
+        inputs = command.call_args.args[0]["inputs"]
+        self.assertTrue(inputs["eveng_lab_archive_restore_images"])
+        self.assertEqual(
+            inputs["eveng_lab_archive_images_path"],
+            "/tmp/labs.images.tar.gz",
+        )
+        self.assertEqual(
+            inputs["eveng_lab_archive_images_expected_sha256"],
+            "e" * 64,
         )
 
     def test_gns3_restore_uses_declared_archive_contract(self):
@@ -316,7 +376,14 @@ class BlueprintLabRestoreTest(TestCase):
                 },
             }
         }
-        archive = (Path("/tmp/gns3-labs.tar.gz"), "d" * 64, None, "")
+        archive = (
+            Path("/tmp/gns3-labs.tar.gz"),
+            "d" * 64,
+            None,
+            "",
+            None,
+            "",
+        )
         with patch(
             "hyops.blueprint.command.run_step_module_command",
             return_value=0,

--- a/hyops/cli.py
+++ b/hyops/cli.py
@@ -15,6 +15,7 @@ from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
 from hyops.init.command import add_init_subparser
 from hyops.inventory.command import add_inventory_subparser
+from hyops.lab.command import add_lab_subparser
 from hyops.module.command import add_module_subparser
 from hyops.preflight.command import add_preflight_subparser
 from hyops.runner.command import add_runner_subparser
@@ -126,6 +127,7 @@ def build_parser() -> argparse.ArgumentParser:
             print("WARN: blueprint command disabled; missing dependency: PyYAML", file=sys.stderr)
         else:
             raise
+    add_lab_subparser(sp)
     add_terragrunt_subparser(sp)
     add_tfc_subparser(sp)
     add_stacks_subparser(sp)

--- a/hyops/drivers/config/ansible/config.py
+++ b/hyops/drivers/config/ansible/config.py
@@ -86,6 +86,21 @@ def resolve_policy_defaults(profile: dict[str, Any]) -> tuple[int | None, int, b
     return timeout_s, retries, redact
 
 
+def resolve_execution_timeout(
+    inputs: dict[str, Any],
+    *,
+    default: int | None,
+) -> tuple[int | None, str]:
+    raw = inputs.get("execution_timeout_s")
+    if raw is None:
+        return default, ""
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        return default, "inputs.execution_timeout_s must be an integer"
+    if raw < 60 or raw > 86400:
+        return default, "inputs.execution_timeout_s must be between 60 and 86400"
+    return raw, ""
+
+
 def resolve_ansible_cfg(profile: dict[str, Any]) -> dict[str, Any]:
     raw = profile.get("ansible")
     if not isinstance(raw, dict):

--- a/hyops/drivers/config/ansible/connectivity.py
+++ b/hyops/drivers/config/ansible/connectivity.py
@@ -121,6 +121,7 @@ def _classify_ssh_auth_probe_failure(
     gcp_iap_instance: str,
     gcp_iap_project_id: str,
     gcp_iap_zone: str,
+    privilege_user: str = "",
 ) -> str:
     stderr = str(getattr(result, "stderr", "") or "")
     stdout = str(getattr(result, "stdout", "") or "")
@@ -137,8 +138,26 @@ def _classify_ssh_auth_probe_failure(
     if "banner exchange" in combined or "connection timed out" in combined:
         return f"ssh service did not become ready yet (see {label}.* in evidence dir)"
 
+    if privilege_user:
+        sudo_failure = (
+            "sudo:" in combined
+            or "not in the sudoers" in combined
+            or "may not run sudo" in combined
+        )
+        if sudo_failure:
+            return (
+                f"passwordless privilege escalation to {privilege_user} failed "
+                f"(see {label}.* in evidence dir)"
+            )
+
     if "permission denied" in combined or "publickey" in combined or "authentication failed" in combined:
         return f"ssh authentication failed (see {label}.* in evidence dir)"
+
+    if privilege_user:
+        return (
+            f"passwordless privilege escalation to {privilege_user} failed "
+            f"(see {label}.* in evidence dir)"
+        )
 
     return f"ssh auth probe failed (see {label}.* in evidence dir)"
 
@@ -321,6 +340,8 @@ def probe_ssh_auth(
     gcp_iap_instance: str = "",
     gcp_iap_project_id: str = "",
     gcp_iap_zone: str = "",
+    become: bool = False,
+    become_user: str = "root",
 ) -> tuple[bool, str]:
     ssh_bin = shutil.which("ssh")
     if not ssh_bin:
@@ -356,6 +377,18 @@ def probe_ssh_auth(
             f"--zone {shlex.quote(gcp_iap_zone)} --verbosity=warning"
         )
         argv.extend(["-o", f"ProxyCommand={proxy_cmd}"])
+        argv.extend(
+            [
+                "-o",
+                "ControlMaster=no",
+                "-o",
+                "ControlPath=none",
+                "-o",
+                "ServerAliveInterval=15",
+                "-o",
+                "ServerAliveCountMax=2",
+            ]
+        )
     elif proxy_host:
         proxy_cmd_parts = [
             "ssh",
@@ -376,7 +409,14 @@ def probe_ssh_auth(
     if ssh_private_key_file:
         argv.extend(["-i", ssh_private_key_file])
 
-    argv.extend([f"{target_user}@{target_host}", "true"])
+    privilege_user = str(become_user or "root").strip() or "root"
+    remote_command = "true"
+    if become and target_user != privilege_user:
+        remote_command = f"sudo -n -u {shlex.quote(privilege_user)} true"
+    else:
+        privilege_user = ""
+
+    argv.extend([f"{target_user}@{target_host}", remote_command])
 
     attempts = 3 if access_mode == "gcp-iap" else 1
     delay_s = 2
@@ -406,6 +446,7 @@ def probe_ssh_auth(
                 gcp_iap_instance=gcp_iap_instance,
                 gcp_iap_project_id=gcp_iap_project_id,
                 gcp_iap_zone=gcp_iap_zone,
+                privilege_user=privilege_user,
             )
 
         if access_mode != "gcp-iap":
@@ -716,6 +757,9 @@ def connectivity_check(
     if not as_bool(inputs.get("connectivity_check"), default=True):
         return True, ""
 
+    become = as_bool(inputs.get("become"), default=True)
+    become_user = str(inputs.get("become_user") or "root").strip() or "root"
+
     inventory_groups = inputs.get("inventory_groups")
     if isinstance(inventory_groups, dict) and inventory_groups:
         targets: list[tuple[str, str]] = []
@@ -812,6 +856,8 @@ def connectivity_check(
                     gcp_iap_instance=gcp_iap_instance,
                     gcp_iap_project_id=gcp_iap_project_id,
                     gcp_iap_zone=gcp_iap_zone,
+                    become=become,
+                    become_user=become_user,
                 )
                 attempt = 1
                 while not ok and time.time() < deadline:
@@ -835,6 +881,8 @@ def connectivity_check(
                         gcp_iap_instance=gcp_iap_instance,
                         gcp_iap_project_id=gcp_iap_project_id,
                         gcp_iap_zone=gcp_iap_zone,
+                        become=become,
+                        become_user=become_user,
                     )
                 if not ok:
                     if err.startswith("gcp-iap tunnel authorisation failed"):
@@ -843,6 +891,11 @@ def connectivity_check(
                         return False, (
                             "connectivity check failed: target VM is reachable through its transport path, "
                             f"but SSH is not ready yet for {label} (host={host}). {err}"
+                        )
+                    if err.startswith("passwordless privilege escalation"):
+                        return False, (
+                            f"connectivity check failed: {err} for {label} (host={host}). "
+                            f"Confirm target_user={target_user} can run sudo -n as {become_user}."
                         )
                     hint = (
                         "connectivity check failed: target SSH port is reachable, but authentication failed for "
@@ -915,6 +968,8 @@ def connectivity_check(
                 evidence_dir=evidence_dir,
                 redact=redact,
                 label=f"connectivity_ssh_auth.{label}",
+                become=become,
+                become_user=become_user,
             )
             attempt = 1
             while not ok and time.time() < deadline:
@@ -934,8 +989,15 @@ def connectivity_check(
                     evidence_dir=evidence_dir,
                     redact=redact,
                     label=f"connectivity_ssh_auth.{label}.try{attempt}",
+                    become=become,
+                    become_user=become_user,
                 )
             if not ok:
+                if err.startswith("passwordless privilege escalation"):
+                    return False, (
+                        f"connectivity check failed: {err} for {label} (host={host}). "
+                        f"Confirm target_user={target_user} can run sudo -n as {become_user}."
+                    )
                 return False, (
                     "connectivity check failed: target is reachable via proxy, but SSH authentication failed for "
                     f"{label} (host={host}). Confirm target_user={target_user} and key injection. {err}"
@@ -997,6 +1059,8 @@ def connectivity_check(
             redact=redact,
             label="connectivity_ssh_auth",
             access_mode="direct",
+            become=become,
+            become_user=become_user,
         )
         attempt = 1
         while not ok and time.time() < deadline:
@@ -1017,12 +1081,19 @@ def connectivity_check(
                 redact=redact,
                 label=f"connectivity_ssh_auth.try{attempt}",
                 access_mode="direct",
+                become=become,
+                become_user=become_user,
             )
         if not ok:
             if err.startswith("gcp-iap tunnel authorisation failed"):
                 return False, f"connectivity check failed: {err}"
             if err.startswith("ssh service did not become ready yet"):
                 return False, f"connectivity check failed: target VM is reachable through its transport path, but SSH is not ready yet. {err}"
+            if err.startswith("passwordless privilege escalation"):
+                return False, (
+                    f"connectivity check failed: {err}. "
+                    f"Confirm target_user={target_user} can run sudo -n as {become_user}."
+                )
             hint = (
                 "connectivity check failed: target SSH port is reachable, but authentication failed. "
                 f"Confirm target_user={target_user} exists and the SSH key is authorised. {err}"
@@ -1052,6 +1123,8 @@ def connectivity_check(
             gcp_iap_instance=gcp_iap_instance,
             gcp_iap_project_id=gcp_iap_project_id,
             gcp_iap_zone=gcp_iap_zone,
+            become=become,
+            become_user=become_user,
         )
         attempt = 1
         while not ok and time.time() < deadline:
@@ -1075,8 +1148,15 @@ def connectivity_check(
                 gcp_iap_instance=gcp_iap_instance,
                 gcp_iap_project_id=gcp_iap_project_id,
                 gcp_iap_zone=gcp_iap_zone,
+                become=become,
+                become_user=become_user,
             )
         if not ok:
+            if err.startswith("passwordless privilege escalation"):
+                return False, (
+                    f"connectivity check failed: {err}. "
+                    f"Confirm target_user={target_user} can run sudo -n as {become_user}."
+                )
             return False, unreachable_access_hint(
                 inputs=inputs,
                 runtime_root=runtime_root,
@@ -1151,6 +1231,8 @@ def connectivity_check(
         evidence_dir=evidence_dir,
         redact=redact,
         label="connectivity_ssh_auth",
+        become=become,
+        become_user=become_user,
     )
     attempt = 1
     while not ok and time.time() < deadline:
@@ -1170,8 +1252,15 @@ def connectivity_check(
             evidence_dir=evidence_dir,
             redact=redact,
             label=f"connectivity_ssh_auth.try{attempt}",
+            become=become,
+            become_user=become_user,
         )
     if not ok:
+        if err.startswith("passwordless privilege escalation"):
+            return False, (
+                f"connectivity check failed: {err}. "
+                f"Confirm target_user={target_user} can run sudo -n as {become_user}."
+            )
         return False, (
             "connectivity check failed: target is reachable via proxy, but SSH authentication failed. "
             f"Confirm target_user={target_user} and key injection. {err}"

--- a/hyops/drivers/config/ansible/driver.py
+++ b/hyops/drivers/config/ansible/driver.py
@@ -29,6 +29,7 @@ from hyops.runtime.source_roots import discover_core_root
 from .config import (
     load_profile,
     resolve_ansible_cfg,
+    resolve_execution_timeout,
     resolve_policy_defaults,
     resolve_required_credentials,
     resolve_required_env,
@@ -296,6 +297,10 @@ def run(request: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(inputs, dict):
         inputs = {}
 
+    timeout_s, timeout_error = resolve_execution_timeout(inputs, default=timeout_s)
+    if timeout_error:
+        return _fail(ev, result, timeout_error)
+
     proxy_jump_auto_note = apply_proxy_jump_auto(inputs, runtime_root)
     if proxy_jump_auto_note:
         result.setdefault("warnings", []).append(proxy_jump_auto_note)
@@ -520,6 +525,12 @@ def run(request: dict[str, Any]) -> dict[str, Any]:
         retries=retries,
     )
     if run_result.rc != 0:
+        if run_result.rc == 124 and timeout_s is not None:
+            return _fail(
+                ev,
+                result,
+                f"{err_msg}: timed out after {timeout_s} seconds",
+            )
         hint = ansible_error_hint(
             command_name=command_name,
             module_ref=module_ref,

--- a/hyops/drivers/config/ansible/inventory.py
+++ b/hyops/drivers/config/ansible/inventory.py
@@ -81,6 +81,8 @@ def _build_gcp_iap_common_args(
         f"-o ProxyCommand=\"{proxy_cmd}\" "
         "-o ConnectTimeout=30 "
         "-o ConnectionAttempts=3 "
+        "-o ServerAliveInterval=15 "
+        "-o ServerAliveCountMax=2 "
         "-o StrictHostKeyChecking=no "
         "-o UserKnownHostsFile=/dev/null"
     )
@@ -187,6 +189,10 @@ def _write_inventory_groups(path: Path, inputs: dict[str, Any], inventory_groups
     )
     if ssh_private_key_file:
         lines.append(f"ansible_ssh_private_key_file={ssh_private_key_file}")
+    if access_mode == "gcp-iap":
+        # A multiplexed master can retain a closed IAP subprocess after an
+        # interrupted run. Give each Ansible connection its own tunnel.
+        lines.append("ansible_ssh_args='-o ControlMaster=no -o ControlPath=none'")
     lines.append(f"ansible_become={'true' if become else 'false'}")
     # Do not force ansible_become_user=root: it prevents roles/tasks from
     # switching to service users (e.g. postgres) when required.
@@ -243,6 +249,7 @@ def write_inventory(path: Path, inputs: dict[str, Any]) -> str:
         )
         parts[1] = f"ansible_host={instance_name}"
         parts.append(f"ansible_ssh_common_args='{common_args}'")
+        parts.append("ansible_ssh_args='-o ControlMaster=no -o ControlPath=none'")
     elif proxy_host:
         proxy_user = str(inputs.get("ssh_proxy_jump_user") or "").strip() or "root"
         proxy_port = as_int(inputs.get("ssh_proxy_jump_port"), default=22)

--- a/hyops/drivers/config/ansible/results.py
+++ b/hyops/drivers/config/ansible/results.py
@@ -23,6 +23,20 @@ _GNS3_IOU_HOST_MISMATCH = re.compile(
     r"([A-Za-z0-9][A-Za-z0-9_.-]*)",
     re.IGNORECASE,
 )
+_EVE_ARCHIVE_IMAGE_CONFLICT = re.compile(
+    r"EVE-NG image content already exists at\s+([^;\"\r\n]+);\s*"
+    r"use --overwrite-images only when replacement is intended",
+    re.IGNORECASE,
+)
+_EVE_ARCHIVE_LAB_CONFLICT = re.compile(
+    r"EVE-NG lab content already exists at\s+([^\"\r\n]+?)\.\s*Set\s+"
+    r"eveng_lab_archive_overwrite=true only when replacing it is intended",
+    re.IGNORECASE,
+)
+_EVE_ARCHIVE_NODE_STATE_CONFLICT = re.compile(
+    r"EVE-NG node state already exists:\s+([^\"\r\n]+?)\.\s*Enable overwrite only",
+    re.IGNORECASE,
+)
 
 
 def ansible_error_hint(
@@ -129,6 +143,31 @@ def ansible_error_hint(
             "EVE-NG nodes are still running. Stop all active lab nodes in the "
             "EVE-NG UI, then repeat the archive operation. No resources were destroyed."
         )
+
+    if module_ref.strip().lower() == "platform/linux/eve-ng-lab-archive":
+        image_conflict = _EVE_ARCHIVE_IMAGE_CONFLICT.search(tail)
+        if image_conflict:
+            path = image_conflict.group(1).strip()
+            return (
+                f"EVE-NG image content already exists at {path}. "
+                "Rerun with --overwrite-images only when replacement is intended."
+            )
+
+        lab_conflict = _EVE_ARCHIVE_LAB_CONFLICT.search(tail)
+        if lab_conflict:
+            path = lab_conflict.group(1).strip()
+            return (
+                f"EVE-NG lab content already exists at {path}. "
+                "Rerun with --overwrite-labs only when replacement is intended."
+            )
+
+        node_state_conflict = _EVE_ARCHIVE_NODE_STATE_CONFLICT.search(tail)
+        if node_state_conflict:
+            path = node_state_conflict.group(1).strip()
+            return (
+                f"EVE-NG node state already exists at {path}. "
+                "Rerun with --overwrite-labs only when replacement is intended."
+            )
 
     return ""
 

--- a/hyops/lab/__init__.py
+++ b/hyops/lab/__init__.py
@@ -1,0 +1,1 @@
+"""Lab lifecycle commands."""

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -132,7 +132,7 @@ class _CaptureProgress:
 
 class _ImportProgress:
     def __init__(self) -> None:
-        self.display = ProgressDisplay()
+        self.display = ProgressDisplay(show_elapsed=False)
         self._plain_last: dict[str, float] = {}
 
     def __call__(self, event: dict[str, Any]) -> None:

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -34,6 +34,11 @@ def _add_archive_args(parser: argparse.ArgumentParser) -> None:
         help="Optional EVE-NG QEMU node-state companion archive.",
     )
     parser.add_argument(
+        "--images",
+        default="",
+        help="Optional EVE-NG referenced-image companion archive.",
+    )
+    parser.add_argument(
         "--expected-sha256",
         default="",
         help="Expected SHA-256 for the primary archive.",
@@ -42,6 +47,11 @@ def _add_archive_args(parser: argparse.ArgumentParser) -> None:
         "--node-state-expected-sha256",
         default="",
         help="Expected SHA-256 for the node-state archive.",
+    )
+    parser.add_argument(
+        "--images-expected-sha256",
+        default="",
+        help="Expected SHA-256 for the image archive.",
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON output.")
 
@@ -95,7 +105,15 @@ def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
     capture_parser.add_argument(
         "--include-images",
         action="store_true",
-        help="Include the GNS3 image library.",
+        help=(
+            "Capture referenced EVE-NG base images as a companion archive, "
+            "or include the GNS3 image library."
+        ),
+    )
+    capture_parser.add_argument(
+        "--images-output",
+        default="",
+        help="Optional EVE-NG referenced-image output path.",
     )
     capture_parser.add_argument("--force", action="store_true", help="Replace outputs.")
     capture_parser.add_argument("--json", action="store_true", help="Emit JSON output.")
@@ -146,6 +164,13 @@ def _print_inspection(report: dict[str, Any]) -> None:
         print(f"node_state=present overlays={node_state['overlay_count']}")
     else:
         print("node_state=absent")
+    images = report.get("images")
+    if isinstance(images, dict):
+        print(f"images=present referenced={images['image_count']}")
+    elif report.get("images_included"):
+        print("images=included")
+    else:
+        print("images=absent")
     for warning in report.get("warnings") or []:
         print(f"WARN: {warning}")
 
@@ -163,6 +188,7 @@ def run_capture(ns) -> int:
             include_node_state=ns.include_node_state,
             node_state_output=ns.node_state_output or None,
             include_images=ns.include_images,
+            images_output=ns.images_output or None,
             force=ns.force,
         )
     except (OSError, ValueError) as exc:
@@ -181,8 +207,10 @@ def run_inspect(ns) -> int:
             platform=ns.platform,
             archive=ns.archive,
             node_state=ns.node_state or None,
+            images=ns.images or None,
             expected_sha256=ns.expected_sha256,
             node_state_expected_sha256=ns.node_state_expected_sha256,
+            images_expected_sha256=ns.images_expected_sha256,
         )
     except (OSError, ValueError) as exc:
         print(f"ERR: lab migration inspection failed: {exc}")
@@ -221,8 +249,10 @@ def run_import(ns) -> int:
             platform=ns.platform,
             archive=ns.archive,
             node_state=ns.node_state or None,
+            images=ns.images or None,
             expected_sha256=ns.expected_sha256,
             node_state_expected_sha256=ns.node_state_expected_sha256,
+            images_expected_sha256=ns.images_expected_sha256,
             force=ns.force,
         )
     except (OSError, ValueError) as exc:

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import shlex
+import time
 from typing import Any
 
 from hyops.runtime.exitcodes import OPERATOR_ERROR
@@ -47,10 +48,17 @@ def _concise_rate(value: int | float) -> str:
     return f"{_concise_bytes(value)}/s"
 
 
+def _concise_duration(value: int | float) -> str:
+    seconds = max(0, int(value))
+    minutes, seconds = divmod(seconds, 60)
+    return f"{minutes}m {seconds:02d}s" if minutes else f"{seconds}s"
+
+
 class _CaptureProgress:
     def __init__(self) -> None:
-        self.display = ProgressDisplay()
+        self.display = ProgressDisplay(show_elapsed=False)
         self._plain_last: dict[str, float] = {}
+        self._verification_started = 0.0
 
     def __call__(self, event: dict[str, Any]) -> None:
         phase = str(event.get("phase") or "")
@@ -107,12 +115,16 @@ class _CaptureProgress:
                     f"capture={stage} status={status} bytes={written} "
                     f"elapsed_s={int(elapsed)}"
                 ),
-                detail=f"{_concise_bytes(written)}  {_concise_rate(rate)}",
+                detail=(
+                    f"{_concise_duration(elapsed)}  "
+                    f"{_concise_bytes(written)}  {_concise_rate(rate)}"
+                ),
             )
             self._plain_last.pop(key, None)
             return
 
         if phase == "verification_started":
+            self._verification_started = time.monotonic()
             self.display.start(
                 key,
                 label,
@@ -122,12 +134,19 @@ class _CaptureProgress:
 
         if phase == "verification_finished":
             status = str(event.get("status") or "failed")
+            elapsed = (
+                time.monotonic() - self._verification_started
+                if self._verification_started
+                else 0.0
+            )
             self.display.finish(
                 key,
                 label,
                 status,
                 plain=f"capture=verification status={status}",
+                detail=_concise_duration(elapsed),
             )
+            self._verification_started = 0.0
 
 
 class _ImportProgress:

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -1,0 +1,259 @@
+"""CLI for existing-lab migration intake."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+from typing import Any
+
+from hyops.runtime.exitcodes import OPERATOR_ERROR
+from hyops.runtime.layout import ensure_layout
+from hyops.runtime.paths import resolve_runtime_paths
+from hyops.runtime.root import require_runtime_selection
+from hyops.runtime.storage import format_runtime_storage_error, require_runtime_writable
+
+from .migration import (
+    capture_existing_lab,
+    inspect_migration_archive,
+    stage_migration_archive,
+)
+
+
+def _add_archive_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--platform",
+        required=True,
+        choices=("eve-ng", "gns3"),
+        help="Source lab platform.",
+    )
+    parser.add_argument("--archive", required=True, help="Portable lab archive path.")
+    parser.add_argument(
+        "--node-state",
+        default="",
+        help="Optional EVE-NG QEMU node-state companion archive.",
+    )
+    parser.add_argument(
+        "--expected-sha256",
+        default="",
+        help="Expected SHA-256 for the primary archive.",
+    )
+    parser.add_argument(
+        "--node-state-expected-sha256",
+        default="",
+        help="Expected SHA-256 for the node-state archive.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+
+
+def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
+    parser = sp.add_parser("lab", help="Existing lab migration.")
+    commands = parser.add_subparsers(dest="lab_cmd", required=True)
+    migrate = commands.add_parser(
+        "migrate",
+        help="Capture, inspect or import a same-platform lab archive.",
+    )
+    migration_commands = migrate.add_subparsers(dest="migration_cmd", required=True)
+
+    capture_parser = migration_commands.add_parser(
+        "capture",
+        help="Capture a stopped existing lab through SSH without changing its host.",
+    )
+    capture_parser.add_argument(
+        "--platform",
+        required=True,
+        choices=("eve-ng", "gns3"),
+        help="Source lab platform.",
+    )
+    capture_parser.add_argument("--host", required=True, help="SSH host or alias.")
+    capture_parser.add_argument("--user", default="", help="SSH user.")
+    capture_parser.add_argument("--port", type=int, default=22, help="SSH port.")
+    capture_parser.add_argument(
+        "--identity-file",
+        default="",
+        help="SSH private key path.",
+    )
+    capture_parser.add_argument("--output", required=True, help="Local archive path.")
+    capture_parser.add_argument(
+        "--become",
+        action="store_true",
+        help="Read source data through passwordless sudo.",
+    )
+    capture_parser.add_argument(
+        "--include-node-state",
+        action="store_true",
+        help="Capture stopped EVE-NG QEMU overlays.",
+    )
+    capture_parser.add_argument(
+        "--node-state-output",
+        default="",
+        help="Optional EVE-NG node-state output path.",
+    )
+    capture_parser.add_argument(
+        "--include-images",
+        action="store_true",
+        help="Include the GNS3 image library.",
+    )
+    capture_parser.add_argument("--force", action="store_true", help="Replace outputs.")
+    capture_parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    capture_parser.set_defaults(_handler=run_capture)
+
+    inspect_parser = migration_commands.add_parser(
+        "inspect",
+        help="Validate a migration archive without changing runtime state.",
+    )
+    _add_archive_args(inspect_parser)
+    inspect_parser.set_defaults(_handler=run_inspect)
+
+    import_parser = migration_commands.add_parser(
+        "import",
+        help="Stage a verified archive for restoration by a target blueprint.",
+    )
+    _add_archive_args(import_parser)
+    import_parser.add_argument("--root", default=None, help="Override runtime root.")
+    import_parser.add_argument("--env", default=None, help="Runtime environment namespace.")
+    import_parser.add_argument("--ref", default="", help="Target blueprint reference.")
+    import_parser.add_argument(
+        "--file",
+        default="",
+        help="Explicit runtime blueprint file.",
+    )
+    import_parser.add_argument(
+        "--blueprints-root",
+        default="blueprints",
+        help="Blueprint root directory.",
+    )
+    import_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace a different active migration record.",
+    )
+    import_parser.set_defaults(_handler=run_import)
+
+
+def _print_inspection(report: dict[str, Any]) -> None:
+    archive = report["archive"]
+    print(f"migration platform={report['platform']} status={report['status']}")
+    print(f"archive={archive['path']}")
+    print(f"sha256={archive['sha256']}")
+    print(f"definitions={report['definition_count']} members={archive['member_count']}")
+    print(f"image_references={len(report['image_references'])}")
+    node_state = report.get("node_state")
+    if isinstance(node_state, dict):
+        print(f"node_state=present overlays={node_state['overlay_count']}")
+    else:
+        print("node_state=absent")
+    for warning in report.get("warnings") or []:
+        print(f"WARN: {warning}")
+
+
+def run_capture(ns) -> int:
+    try:
+        report = capture_existing_lab(
+            platform=ns.platform,
+            host=ns.host,
+            output=ns.output,
+            user=ns.user,
+            port=ns.port,
+            identity_file=ns.identity_file or None,
+            become=ns.become,
+            include_node_state=ns.include_node_state,
+            node_state_output=ns.node_state_output or None,
+            include_images=ns.include_images,
+            force=ns.force,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"ERR: lab migration capture failed: {exc}")
+        return OPERATOR_ERROR
+    if ns.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_inspection(report)
+    return 0
+
+
+def run_inspect(ns) -> int:
+    try:
+        report = inspect_migration_archive(
+            platform=ns.platform,
+            archive=ns.archive,
+            node_state=ns.node_state or None,
+            expected_sha256=ns.expected_sha256,
+            node_state_expected_sha256=ns.node_state_expected_sha256,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"ERR: lab migration inspection failed: {exc}")
+        return OPERATOR_ERROR
+    if ns.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_inspection(report)
+    return 0
+
+
+def run_import(ns) -> int:
+    try:
+        require_runtime_selection(
+            ns.root,
+            ns.env,
+            command_label="hyops lab migrate import",
+        )
+        paths = resolve_runtime_paths(ns.root, ns.env)
+        ensure_layout(paths)
+        require_runtime_writable(paths.root)
+        from hyops.blueprint.command import (
+            _enforce_runtime_blueprint_file_scope,
+            _resolve_and_validate,
+        )
+
+        _enforce_runtime_blueprint_file_scope(
+            ns,
+            paths,
+            command_label="lab migration import",
+        )
+        payload = _resolve_and_validate(ns)
+        record = stage_migration_archive(
+            paths=paths,
+            payload=payload,
+            platform=ns.platform,
+            archive=ns.archive,
+            node_state=ns.node_state or None,
+            expected_sha256=ns.expected_sha256,
+            node_state_expected_sha256=ns.node_state_expected_sha256,
+            force=ns.force,
+        )
+    except (OSError, ValueError) as exc:
+        detail = format_runtime_storage_error(exc) if isinstance(exc, OSError) else str(exc)
+        print(f"ERR: lab migration import failed: {detail}")
+        return OPERATOR_ERROR
+
+    if ns.json:
+        print(json.dumps(record, indent=2, sort_keys=True))
+        return 0
+    print(
+        f"migration platform={record['platform']} "
+        f"blueprint={record['blueprint_ref']} status=ready"
+    )
+    print(f"archive={record['archive']['path']}")
+    print(f"sha256={record['archive']['sha256']}")
+    print(f"definitions={record['definition_count']}")
+    for warning in record.get("warnings") or []:
+        print(f"WARN: {warning}")
+    if ns.env:
+        selection = ["--env", ns.env]
+    elif ns.root:
+        selection = ["--root", ns.root]
+    else:
+        selection = []
+    selector = ["--file", ns.file] if ns.file else ["--ref", record["blueprint_ref"]]
+    command = [
+        "hyops",
+        "blueprint",
+        "deploy",
+        *selection,
+        *selector,
+        "--execute",
+        "--restore-labs",
+    ]
+    print(f"restore: {shlex.join(command)}")
+    return 0

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -26,6 +26,7 @@ _CAPTURE_LABELS = {
     "assessment": "Assessing source",
     "lab_definitions": "Lab definitions",
     "gns3_projects": "GNS3 projects",
+    "containerlab_source": "Containerlab source",
     "node_state": "Node state",
     "referenced_images": "Referenced images",
     "verification": "Archive verification",
@@ -127,7 +128,7 @@ def _add_archive_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--platform",
         required=True,
-        choices=("eve-ng", "gns3"),
+        choices=("eve-ng", "gns3", "containerlab"),
         help="Source lab platform.",
     )
     parser.add_argument("--archive", required=True, help="Portable lab archive path.")
@@ -170,12 +171,12 @@ def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
 
     capture_parser = migration_commands.add_parser(
         "capture",
-        help="Capture a stopped existing lab through SSH without changing its host.",
+        help="Capture an existing lab through SSH without changing its source tree.",
     )
     capture_parser.add_argument(
         "--platform",
         required=True,
-        choices=("eve-ng", "gns3"),
+        choices=("eve-ng", "gns3", "containerlab"),
         help="Source lab platform.",
     )
     capture_parser.add_argument("--host", required=True, help="SSH host or alias.")
@@ -190,6 +191,29 @@ def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
         ),
     )
     capture_parser.add_argument("--output", required=True, help="Local archive path.")
+    capture_parser.add_argument(
+        "--source-root",
+        default="",
+        help="Authoritative source directory for Containerlab capture.",
+    )
+    capture_parser.add_argument(
+        "--topology-relpath",
+        default="lab.clab.yml",
+        help="Containerlab topology path relative to --source-root.",
+    )
+    capture_parser.add_argument(
+        "--source-labdir-base",
+        default="",
+        help=(
+            "Optional native labdir base used by the existing Containerlab host. "
+            "Omit it to use Containerlab's default."
+        ),
+    )
+    capture_parser.add_argument(
+        "--target-labdir-base",
+        default="/var/lib/hybridops/containerlab/labdirs",
+        help="Native labdir base declared by the target Containerlab blueprint.",
+    )
     capture_parser.add_argument(
         "--become",
         action="store_true",
@@ -276,6 +300,13 @@ def _print_inspection(report: dict[str, Any]) -> None:
         print("images=included")
     else:
         print("images=absent")
+    containerlab = report.get("containerlab")
+    if isinstance(containerlab, dict):
+        print(f"topology={containerlab['topology_relpath']}")
+        print(
+            "native_config_save="
+            f"{'ok' if containerlab.get('native_config_save_rc') == 0 else 'unavailable'}"
+        )
     for warning in report.get("warnings") or []:
         print(f"WARN: {warning}")
 
@@ -295,6 +326,10 @@ def run_capture(ns) -> int:
             node_state_output=ns.node_state_output or None,
             include_images=ns.include_images,
             images_output=ns.images_output or None,
+            source_root=ns.source_root,
+            topology_relpath=ns.topology_relpath,
+            source_labdir_base=ns.source_labdir_base,
+            target_labdir_base=ns.target_labdir_base,
             force=ns.force,
             progress=progress,
         )

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -65,6 +65,22 @@ class _CaptureProgress:
         if phase == "assessment_started":
             print("assessing source and requested capture streams", flush=True)
             return
+        if phase == "quiescence_started":
+            self.display.start(
+                "lab-migration-quiescence",
+                "Guest quiescence",
+                plain="capture=quiescence status=running",
+            )
+            return
+        if phase == "quiescence_finished":
+            status = str(event.get("status") or "failed")
+            self.display.finish(
+                "lab-migration-quiescence",
+                "Guest quiescence",
+                status,
+                plain=f"capture=quiescence status={status}",
+            )
+            return
         if phase == "assessment_finished":
             print("source assessment:")
             print(f"  lab definitions: {_concise_bytes(event['primary_bytes'])}")
@@ -330,13 +346,29 @@ def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Capture stopped EVE-NG QEMU overlays.",
     )
-    capture_parser.add_argument(
+    quiescence = capture_parser.add_mutually_exclusive_group()
+    quiescence.add_argument(
         "--guest-quiesced",
         action="store_true",
         help=(
             "Confirm EVE-NG guests were shut down inside the guest before "
             "node-state capture."
         ),
+    )
+    quiescence.add_argument(
+        "--quiesce-script",
+        default="",
+        help=(
+            "Run a local POSIX shell script on the EVE-NG host before "
+            "node-state capture."
+        ),
+    )
+    capture_parser.add_argument(
+        "--quiesce-timeout",
+        type=int,
+        default=300,
+        metavar="SECONDS",
+        help="Maximum time for EVE-NG guest quiescence and QEMU shutdown.",
     )
     capture_parser.add_argument(
         "--node-state-output",
@@ -442,6 +474,8 @@ def run_capture(ns) -> int:
             become=ns.become,
             include_node_state=ns.include_node_state,
             guest_quiesced=ns.guest_quiesced,
+            quiesce_script=ns.quiesce_script or None,
+            quiesce_timeout_s=ns.quiesce_timeout,
             node_state_output=ns.node_state_output or None,
             include_images=ns.include_images,
             images_output=ns.images_output or None,

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -10,14 +10,117 @@ from typing import Any
 from hyops.runtime.exitcodes import OPERATOR_ERROR
 from hyops.runtime.layout import ensure_layout
 from hyops.runtime.paths import resolve_runtime_paths
+from hyops.runtime.progress import ProgressDisplay
 from hyops.runtime.root import require_runtime_selection
 from hyops.runtime.storage import format_runtime_storage_error, require_runtime_writable
 
 from .migration import (
+    _format_bytes,
     capture_existing_lab,
     inspect_migration_archive,
     stage_migration_archive,
 )
+
+
+_CAPTURE_LABELS = {
+    "assessment": "Assessing source",
+    "lab_definitions": "Lab definitions",
+    "gns3_projects": "GNS3 projects",
+    "node_state": "Node state",
+    "referenced_images": "Referenced images",
+    "verification": "Archive verification",
+}
+
+
+def _concise_bytes(value: int | float) -> str:
+    return _format_bytes(max(0, int(value))).split(" (", 1)[0]
+
+
+def _concise_rate(value: int | float) -> str:
+    return f"{_concise_bytes(value)}/s"
+
+
+class _CaptureProgress:
+    def __init__(self) -> None:
+        self.display = ProgressDisplay()
+        self._plain_last: dict[str, float] = {}
+
+    def __call__(self, event: dict[str, Any]) -> None:
+        phase = str(event.get("phase") or "")
+        if phase == "assessment_started":
+            print("assessing source and requested capture streams", flush=True)
+            return
+        if phase == "assessment_finished":
+            print("source assessment:")
+            print(f"  lab definitions: {_concise_bytes(event['primary_bytes'])}")
+            if int(event.get("node_state_bytes") or 0) > 0:
+                print(f"  node state: {_concise_bytes(event['node_state_bytes'])}")
+            if int(event.get("image_bytes") or 0) > 0:
+                print(f"  referenced images: {_concise_bytes(event['image_bytes'])}")
+            return
+
+        stage = str(event.get("stage") or "capture")
+        label = _CAPTURE_LABELS.get(stage, stage.replace("_", " ").title())
+        key = f"lab-migration-{stage}"
+        written = int(event.get("bytes_written") or 0)
+        elapsed = float(event.get("elapsed_seconds") or 0.0)
+        rate = float(event.get("bytes_per_second") or 0.0)
+
+        if phase == "stream_started":
+            expected = int(event.get("expected_source_bytes") or 0)
+            source = f"  source {_concise_bytes(expected)}" if expected else ""
+            self.display.start(
+                key,
+                f"{label}{source}",
+                plain=(f"capture={stage} status=running source_bytes={expected}"),
+            )
+            self._plain_last[key] = 0.0
+            return
+
+        if phase == "stream_progress":
+            current = f"{label}  {_concise_bytes(written)}  {_concise_rate(rate)}"
+            self.display.update(key, current)
+            last = self._plain_last.get(key, 0.0)
+            if not self.display.enabled and elapsed - last >= 30.0:
+                print(
+                    f"capture={stage} status=running bytes={written} "
+                    f"rate_bps={int(rate)} elapsed_s={int(elapsed)}",
+                    flush=True,
+                )
+                self._plain_last[key] = elapsed
+            return
+
+        if phase == "stream_finished":
+            status = str(event.get("status") or "failed")
+            self.display.finish(
+                key,
+                label,
+                status,
+                plain=(
+                    f"capture={stage} status={status} bytes={written} "
+                    f"elapsed_s={int(elapsed)}"
+                ),
+                detail=f"{_concise_bytes(written)}  {_concise_rate(rate)}",
+            )
+            self._plain_last.pop(key, None)
+            return
+
+        if phase == "verification_started":
+            self.display.start(
+                key,
+                label,
+                plain="capture=verification status=running",
+            )
+            return
+
+        if phase == "verification_finished":
+            status = str(event.get("status") or "failed")
+            self.display.finish(
+                key,
+                label,
+                status,
+                plain=f"capture=verification status={status}",
+            )
 
 
 def _add_archive_args(parser: argparse.ArgumentParser) -> None:
@@ -132,7 +235,9 @@ def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
     )
     _add_archive_args(import_parser)
     import_parser.add_argument("--root", default=None, help="Override runtime root.")
-    import_parser.add_argument("--env", default=None, help="Runtime environment namespace.")
+    import_parser.add_argument(
+        "--env", default=None, help="Runtime environment namespace."
+    )
     import_parser.add_argument("--ref", default="", help="Target blueprint reference.")
     import_parser.add_argument(
         "--file",
@@ -176,6 +281,7 @@ def _print_inspection(report: dict[str, Any]) -> None:
 
 
 def run_capture(ns) -> int:
+    progress = None if ns.json else _CaptureProgress()
     try:
         report = capture_existing_lab(
             platform=ns.platform,
@@ -190,6 +296,7 @@ def run_capture(ns) -> int:
             include_images=ns.include_images,
             images_output=ns.images_output or None,
             force=ns.force,
+            progress=progress,
         )
     except (OSError, ValueError) as exc:
         print(f"ERR: lab migration capture failed: {exc}")
@@ -256,7 +363,9 @@ def run_import(ns) -> int:
             force=ns.force,
         )
     except (OSError, ValueError) as exc:
-        detail = format_runtime_storage_error(exc) if isinstance(exc, OSError) else str(exc)
+        detail = (
+            format_runtime_storage_error(exc) if isinstance(exc, OSError) else str(exc)
+        )
         print(f"ERR: lab migration import failed: {detail}")
         return OPERATOR_ERROR
 

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -71,7 +71,10 @@ def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
     capture_parser.add_argument(
         "--identity-file",
         default="",
-        help="SSH private key path.",
+        help=(
+            "Optional SSH private key path. Without it, OpenSSH uses its "
+            "configured identities and may prompt for a password."
+        ),
     )
     capture_parser.add_argument("--output", required=True, help="Local archive path.")
     capture_parser.add_argument(

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -331,6 +331,14 @@ def add_lab_subparser(sp: argparse._SubParsersAction) -> None:
         help="Capture stopped EVE-NG QEMU overlays.",
     )
     capture_parser.add_argument(
+        "--guest-quiesced",
+        action="store_true",
+        help=(
+            "Confirm EVE-NG guests were shut down inside the guest before "
+            "node-state capture."
+        ),
+    )
+    capture_parser.add_argument(
         "--node-state-output",
         default="",
         help="Optional EVE-NG node-state output path.",
@@ -396,7 +404,11 @@ def _print_inspection(report: dict[str, Any]) -> None:
     print(f"image_references={len(report['image_references'])}")
     node_state = report.get("node_state")
     if isinstance(node_state, dict):
-        print(f"node_state=present overlays={node_state['overlay_count']}")
+        consistency = str(node_state.get("capture_consistency") or "unrecorded")
+        print(
+            f"node_state=present overlays={node_state['overlay_count']} "
+            f"consistency={consistency}"
+        )
     else:
         print("node_state=absent")
     images = report.get("images")
@@ -429,6 +441,7 @@ def run_capture(ns) -> int:
             identity_file=ns.identity_file or None,
             become=ns.become,
             include_node_state=ns.include_node_state,
+            guest_quiesced=ns.guest_quiesced,
             node_state_output=ns.node_state_output or None,
             include_images=ns.include_images,
             images_output=ns.images_output or None,

--- a/hyops/lab/command.py
+++ b/hyops/lab/command.py
@@ -32,6 +32,12 @@ _CAPTURE_LABELS = {
     "verification": "Archive verification",
 }
 
+_IMPORT_LABELS = {
+    "lab_definitions": "Lab definitions",
+    "node_state": "Node state",
+    "referenced_images": "Referenced images",
+}
+
 
 def _concise_bytes(value: int | float) -> str:
     return _format_bytes(max(0, int(value))).split(" (", 1)[0]
@@ -122,6 +128,87 @@ class _CaptureProgress:
                 status,
                 plain=f"capture=verification status={status}",
             )
+
+
+class _ImportProgress:
+    def __init__(self) -> None:
+        self.display = ProgressDisplay()
+        self._plain_last: dict[str, float] = {}
+
+    def __call__(self, event: dict[str, Any]) -> None:
+        phase = str(event.get("phase") or "")
+        if phase in {"import_verification_started", "import_verification_finished"}:
+            key = "lab-migration-import-verification"
+            label = "Bundle verification"
+            if phase == "import_verification_started":
+                self.display.start(
+                    key,
+                    label,
+                    plain="import=verification status=running",
+                )
+                return
+            status = str(event.get("status") or "failed")
+            self.display.finish(
+                key,
+                label,
+                status,
+                plain=f"import=verification status={status}",
+            )
+            return
+
+        stage = str(event.get("stage") or "archive")
+        label = _IMPORT_LABELS.get(stage, stage.replace("_", " ").title())
+        key = f"lab-migration-import-{stage}"
+        written = int(event.get("bytes_written") or 0)
+        total = int(event.get("total_bytes") or 0)
+        elapsed = float(event.get("elapsed_seconds") or 0.0)
+        rate = float(event.get("bytes_per_second") or 0.0)
+
+        if phase == "stage_started":
+            self.display.start(
+                key,
+                label,
+                plain=f"import={stage} status=running bytes_total={total}",
+            )
+            self._plain_last[key] = 0.0
+            return
+
+        if phase == "stage_progress":
+            current = f"{label}  {_concise_bytes(written)}/{_concise_bytes(total)}"
+            if rate > 0:
+                current += f"  {_concise_rate(rate)}"
+            self.display.update(key, current)
+            last = self._plain_last.get(key, 0.0)
+            if not self.display.enabled and elapsed - last >= 30.0:
+                print(
+                    f"import={stage} status=running bytes={written} "
+                    f"total_bytes={total} rate_bps={int(rate)} "
+                    f"elapsed_s={int(elapsed)}",
+                    flush=True,
+                )
+                self._plain_last[key] = elapsed
+            return
+
+        if phase == "stage_verifying":
+            self.display.update(key, f"Verifying {label.lower()}")
+            if not self.display.enabled:
+                print(f"import={stage} status=verifying", flush=True)
+            return
+
+        if phase == "stage_finished":
+            status = str(event.get("status") or "failed")
+            detail = "already staged" if status == "skipped" else _concise_bytes(written)
+            self.display.finish(
+                key,
+                label,
+                status,
+                plain=(
+                    f"import={stage} status={status} bytes={written} "
+                    f"elapsed_s={int(elapsed)}"
+                ),
+                detail=detail,
+            )
+            self._plain_last.pop(key, None)
 
 
 def _add_archive_args(parser: argparse.ArgumentParser) -> None:
@@ -365,6 +452,7 @@ def run_inspect(ns) -> int:
 
 
 def run_import(ns) -> int:
+    progress = None if ns.json else _ImportProgress()
     try:
         require_runtime_selection(
             ns.root,
@@ -396,6 +484,7 @@ def run_import(ns) -> int:
             node_state_expected_sha256=ns.node_state_expected_sha256,
             images_expected_sha256=ns.images_expected_sha256,
             force=ns.force,
+            progress=progress,
         )
     except (OSError, ValueError) as exc:
         detail = (

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -1,4 +1,4 @@
-"""Verified intake for existing EVE-NG and GNS3 lab archives."""
+"""Verified intake for existing network-lab archives."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from typing import Any, Callable, Iterable
 
 SCHEMA_VERSION = 1
 RECORD_KIND = "hybridops/lab-migration"
-SUPPORTED_PLATFORMS = ("eve-ng", "gns3")
+SUPPORTED_PLATFORMS = ("eve-ng", "gns3", "containerlab")
 CaptureProgress = Callable[[dict[str, Any]], None]
 _MAX_DEFINITION_BYTES = 32 * 1024 * 1024
 _MAX_MEMBERS = 200_000
@@ -156,6 +156,318 @@ command = [
 file_list = b"".join(os.fsencode(path) + b"\0" for path in selected)
 result = subprocess.run(command, input=file_list, stdout=sys.stdout.buffer, check=False)
 raise SystemExit(result.returncode)
+"""
+
+_CONTAINERLAB_CAPTURE_PROGRAM = r"""
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+mode = sys.argv[1]
+source_root = Path(sys.argv[2])
+topology_relpath = sys.argv[3]
+source_labdir_base = sys.argv[4]
+target_labdir_base = sys.argv[5]
+
+
+def fail(message, status=24):
+    print(message, file=sys.stderr)
+    raise SystemExit(status)
+
+
+def safe_relative(value):
+    if (
+        not value
+        or value in {".", ".."}
+        or value.startswith("/")
+        or "\\" in value
+        or ".." in PurePosixPath(value).parts
+        or any(ord(character) < 32 for character in value)
+    ):
+        fail(f"Containerlab topology path is unsafe: {value!r}")
+    return PurePosixPath(value).as_posix()
+
+
+def source_files(root):
+    resolved = root.resolve(strict=True)
+    selected = []
+    for current, directories, files in os.walk(resolved, topdown=True, followlinks=False):
+        current_path = Path(current)
+        relative_current = current_path.relative_to(resolved)
+        kept_directories = []
+        for name in sorted(directories):
+            path = current_path / name
+            relative = relative_current / name
+            if len(relative.parts) == 1 and name.startswith("clab-"):
+                continue
+            if path.is_symlink():
+                fail(f"Containerlab source contains a symbolic link: {relative}")
+            if not path.is_dir():
+                fail(f"Containerlab source contains an unsupported entry: {relative}")
+            kept_directories.append(name)
+        directories[:] = kept_directories
+        for name in sorted(files):
+            path = current_path / name
+            relative = relative_current / name
+            if path.is_symlink():
+                fail(f"Containerlab source contains a symbolic link: {relative}")
+            file_stat = path.stat()
+            if not stat.S_ISREG(file_stat.st_mode):
+                fail(f"Containerlab source contains an unsupported entry: {relative}")
+            selected.append((path, PurePosixPath(relative.as_posix()), file_stat))
+    return selected
+
+
+def image_references(topology, inspection):
+    references = set()
+    try:
+        text = topology.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        text = ""
+    for match in re.finditer(r"(?m)^\s*image:\s*[\"']?([^#\"'\s]+)", text):
+        references.add(match.group(1).strip())
+
+    def walk(value, key=""):
+        if isinstance(value, dict):
+            for child_key, child in value.items():
+                walk(child, str(child_key).lower())
+        elif isinstance(value, list):
+            for child in value:
+                walk(child, key)
+        elif isinstance(value, str) and "image" in key and value.strip():
+            references.add(value.strip())
+
+    if inspection:
+        try:
+            walk(json.loads(inspection))
+        except (json.JSONDecodeError, RecursionError):
+            pass
+    return sorted(references)
+
+
+def add_bytes(handle, name, payload, file_mode=0o640):
+    member = tarfile.TarInfo(name=name)
+    member.size = len(payload)
+    member.mode = file_mode
+    member.uid = 0
+    member.gid = 0
+    member.uname = "root"
+    member.gname = "root"
+    member.mtime = 0
+    handle.addfile(member, io.BytesIO(payload))
+
+
+def add_directory(handle, name, directory_mode=0o750):
+    member = tarfile.TarInfo(name=name.rstrip("/") + "/")
+    member.type = tarfile.DIRTYPE
+    member.mode = directory_mode
+    member.uid = 0
+    member.gid = 0
+    member.uname = "root"
+    member.gname = "root"
+    member.mtime = 0
+    handle.addfile(member)
+
+
+def add_file(handle, source, name, file_stat):
+    member = tarfile.TarInfo(name=name)
+    member.size = file_stat.st_size
+    member.mode = stat.S_IMODE(file_stat.st_mode) & 0o777
+    member.uid = 0
+    member.gid = 0
+    member.uname = "root"
+    member.gname = "root"
+    member.mtime = 0
+    with source.open("rb") as source_handle:
+        handle.addfile(member, source_handle)
+
+
+topology_relpath = safe_relative(topology_relpath)
+try:
+    source_resolved = source_root.resolve(strict=True)
+except FileNotFoundError:
+    fail(f"Containerlab source root was not found: {source_root}", 20)
+if not source_resolved.is_dir():
+    fail(f"Containerlab source root is not a directory: {source_root}", 20)
+if source_resolved in {Path("/"), Path("/var/lib/docker")}:
+    fail(f"Containerlab source root is too broad: {source_resolved}")
+for label, value in (
+    ("source", source_labdir_base),
+    ("target", target_labdir_base),
+):
+    if not value and label == "source":
+        continue
+    if (
+        not value.startswith("/")
+        or "\\" in value
+        or ".." in PurePosixPath(value).parts
+        or any(ord(character) < 32 for character in value)
+    ):
+        fail(f"Containerlab {label} labdir base is invalid: {value!r}")
+
+topology = source_resolved / topology_relpath
+try:
+    topology.resolve(strict=True).relative_to(source_resolved)
+except (FileNotFoundError, ValueError):
+    fail(f"Containerlab topology was not found under the source root: {topology_relpath}", 20)
+if topology.is_symlink() or not topology.is_file():
+    fail(f"Containerlab topology is not a regular file: {topology_relpath}", 20)
+
+files = source_files(source_resolved)
+if mode == "assess":
+    allocated = sum(item[2].st_blocks * 512 for item in files)
+    print(allocated)
+    raise SystemExit(0)
+if mode != "capture":
+    fail("Unsupported Containerlab capture mode")
+
+version_payload = ""
+inspection_payload = ""
+save_rc = 127
+with tempfile.TemporaryDirectory(prefix="hyops-containerlab-") as temporary:
+    saved_configs = Path(temporary) / "startup-configs"
+    saved_configs.mkdir(mode=0o750)
+    containerlab_environment = {
+        **os.environ,
+        "CLAB_VERSION_CHECK": "disable",
+    }
+    if source_labdir_base:
+        containerlab_environment["CLAB_LABDIR_BASE"] = source_labdir_base
+    try:
+        saved = subprocess.run(
+            [
+                "containerlab",
+                "save",
+                "-t",
+                str(topology),
+                "--copy",
+                str(saved_configs),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env=containerlab_environment,
+            timeout=300,
+        )
+        save_rc = saved.returncode
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        save_rc = 127
+
+    try:
+        version = subprocess.run(
+            ["containerlab", "version", "--json"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            text=True,
+            timeout=15,
+        )
+        if version.returncode == 0:
+            version_payload = version.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    try:
+        inspection = subprocess.run(
+            ["containerlab", "inspect", "-t", str(topology), "-f", "json"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env=containerlab_environment,
+            text=True,
+            timeout=60,
+        )
+        if inspection.returncode == 0:
+            inspection_payload = inspection.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    topology_sha256 = hashlib.sha256(topology.read_bytes()).hexdigest()
+    try:
+        version_value = json.loads(version_payload).get("version", "") if version_payload else ""
+    except (AttributeError, json.JSONDecodeError):
+        version_value = ""
+    manifest = {
+        "schema": "hybridops.containerlab.recovery/v1",
+        "mode": "rebuild",
+        "topology_relpath": topology_relpath,
+        "topology_sha256": topology_sha256,
+        "source_root_included": True,
+        "containerlab_version": str(version_value),
+        "image_refs": image_references(topology, inspection_payload),
+        "labdir_base": target_labdir_base,
+        "native_config_save_attempted": True,
+        "native_config_save_rc": save_rc,
+        "native_snapshots_requested": False,
+        "lab_directory_included": False,
+        "additional_paths_count": 0,
+    }
+
+    bundle = "containerlab-migration"
+    source_prefix = f"{bundle}/lab-source"
+    saved_files = source_files(saved_configs)
+    archive_files = {
+        relative.as_posix(): (source, relative, file_stat)
+        for source, relative, file_stat in files
+    }
+    if save_rc == 0:
+        for source, relative, file_stat in saved_files:
+            archive_relative = PurePosixPath("startup-configs") / relative
+            archive_files[archive_relative.as_posix()] = (
+                source,
+                archive_relative,
+                file_stat,
+            )
+    with tarfile.open(
+        fileobj=sys.stdout.buffer,
+        mode="w|gz",
+        compresslevel=1,
+        format=tarfile.PAX_FORMAT,
+    ) as archive:
+        add_directory(archive, bundle)
+        add_directory(archive, source_prefix)
+        directories = set()
+        for _, relative, _ in archive_files.values():
+            for parent in relative.parents:
+                if str(parent) not in {"", "."}:
+                    directories.add(parent.as_posix())
+        for directory in sorted(directories, key=lambda item: (item.count("/"), item)):
+            add_directory(archive, f"{source_prefix}/{directory}")
+        for source, relative, file_stat in sorted(
+            archive_files.values(),
+            key=lambda item: item[1].as_posix(),
+        ):
+            add_file(
+                archive,
+                source,
+                f"{source_prefix}/{relative.as_posix()}",
+                file_stat,
+            )
+        add_bytes(
+            archive,
+            f"{bundle}/hybridops-recovery-manifest.json",
+            (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8"),
+        )
+        if version_payload:
+            add_bytes(
+                archive,
+                f"{bundle}/containerlab-version.json",
+                (version_payload + "\n").encode("utf-8"),
+            )
+        if inspection_payload:
+            add_bytes(
+                archive,
+                f"{bundle}/containerlab-inspect.json",
+                (inspection_payload + "\n").encode("utf-8"),
+            )
 """
 
 
@@ -352,6 +664,113 @@ def _gns3_image_references(
     return sorted(references)
 
 
+def _inspect_containerlab_archive(
+    handle: tarfile.TarFile,
+    members: list[tuple[tarfile.TarInfo, str]],
+) -> dict[str, Any]:
+    named_members = {name: member for member, name in members if name}
+    roots = {
+        PurePosixPath(name).parts[0]
+        for name in named_members
+        if PurePosixPath(name).parts
+    }
+    if len(roots) != 1:
+        raise ValueError("Containerlab archive must contain one recovery bundle root")
+    bundle_root = next(iter(roots))
+    manifest_name = f"{bundle_root}/hybridops-recovery-manifest.json"
+    manifest_member = named_members.get(manifest_name)
+    if manifest_member is None or not manifest_member.isfile():
+        raise ValueError("Containerlab archive has no recovery manifest")
+    try:
+        manifest = json.loads(_read_definition(handle, manifest_member))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("Containerlab recovery manifest is invalid") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("Containerlab recovery manifest is invalid")
+    if manifest.get("schema") != "hybridops.containerlab.recovery/v1":
+        raise ValueError("Containerlab recovery manifest schema is unsupported")
+    if manifest.get("mode") not in {"ephemeral", "rebuild", "snapshot"}:
+        raise ValueError("Containerlab recovery mode is unsupported")
+
+    topology_relpath = str(manifest.get("topology_relpath") or "").strip()
+    if (
+        not topology_relpath
+        or topology_relpath.startswith("/")
+        or "\\" in topology_relpath
+        or ".." in PurePosixPath(topology_relpath).parts
+        or any(ord(character) < 32 for character in topology_relpath)
+    ):
+        raise ValueError("Containerlab recovery topology path is unsafe")
+    topology_relpath = PurePosixPath(topology_relpath).as_posix()
+
+    source_root_included = manifest.get("source_root_included")
+    if not isinstance(source_root_included, bool):
+        raise ValueError("Containerlab recovery source-root flag is invalid")
+    source_prefix = f"{bundle_root}/lab-source" if source_root_included else bundle_root
+    topology_name = f"{source_prefix}/{topology_relpath}"
+    topology_member = named_members.get(topology_name)
+    if topology_member is None or not topology_member.isfile():
+        raise ValueError("Containerlab recovery topology is missing")
+    topology_sha256 = str(manifest.get("topology_sha256") or "").strip().lower()
+    if not _SHA256_RE.fullmatch(topology_sha256):
+        raise ValueError("Containerlab recovery topology checksum is invalid")
+    topology_payload = _read_definition(handle, topology_member)
+    if hashlib.sha256(topology_payload).hexdigest() != topology_sha256:
+        raise ValueError("Containerlab recovery topology checksum does not match")
+
+    labdir_base = str(manifest.get("labdir_base") or "").strip()
+    if (
+        not labdir_base.startswith("/")
+        or "\\" in labdir_base
+        or ".." in PurePosixPath(labdir_base).parts
+        or any(ord(character) < 32 for character in labdir_base)
+    ):
+        raise ValueError("Containerlab recovery labdir base is invalid")
+    image_refs = manifest.get("image_refs")
+    if not isinstance(image_refs, list) or len(image_refs) > 10_000:
+        raise ValueError("Containerlab recovery image references are invalid")
+    references: list[str] = []
+    for value in image_refs:
+        reference = str(value or "").strip() if isinstance(value, str) else ""
+        if (
+            not reference
+            or len(reference) > 1024
+            or any(ord(character) < 32 for character in reference)
+        ):
+            raise ValueError("Containerlab recovery image reference is invalid")
+        references.append(reference)
+    native_config_save_attempted = manifest.get("native_config_save_attempted", False)
+    if not isinstance(native_config_save_attempted, bool):
+        raise ValueError("Containerlab native configuration-save flag is invalid")
+    native_config_save_rc = manifest.get("native_config_save_rc")
+    if native_config_save_rc is not None and (
+        isinstance(native_config_save_rc, bool)
+        or not isinstance(native_config_save_rc, int)
+    ):
+        raise ValueError("Containerlab native configuration-save result is invalid")
+    if native_config_save_attempted != (native_config_save_rc is not None):
+        raise ValueError("Containerlab native configuration-save state is inconsistent")
+
+    files = [(member, name) for member, name in members if member.isfile()]
+    return {
+        "definition_count": 1,
+        "expanded_size_bytes": sum(member.size for member, _ in files),
+        "image_references": sorted(set(references)),
+        "images_included": False,
+        "member_count": len(members),
+        "containerlab": {
+            "bundle_root": bundle_root,
+            "mode": str(manifest["mode"]),
+            "topology_relpath": topology_relpath,
+            "topology_sha256": topology_sha256,
+            "source_root_included": source_root_included,
+            "labdir_base": labdir_base,
+            "native_config_save_attempted": native_config_save_attempted,
+            "native_config_save_rc": native_config_save_rc,
+        },
+    }
+
+
 def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
     try:
         with tarfile.open(path, mode="r:*") as handle:
@@ -377,6 +796,9 @@ def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
                     "images_included": False,
                     "member_count": len(members),
                 }
+
+            if platform == "containerlab":
+                return _inspect_containerlab_archive(handle, members)
 
             allowed_roots = {
                 "projects",
@@ -605,9 +1027,24 @@ def inspect_migration_archive(
     warnings: list[str] = []
     images_included = bool(primary["images_included"] or image_report)
     if primary["image_references"] and not images_included:
-        warnings.append("referenced base images must be available on the target")
+        if platform_name == "containerlab":
+            warnings.append(
+                "referenced container images must be available on the target"
+            )
+        else:
+            warnings.append("referenced base images must be available on the target")
     if platform_name == "eve-ng" and node_report is None:
         warnings.append("writable QEMU node state is not included")
+    containerlab_metadata = primary.get("containerlab")
+    if (
+        platform_name == "containerlab"
+        and isinstance(containerlab_metadata, dict)
+        and containerlab_metadata.get("native_config_save_attempted")
+        and containerlab_metadata.get("native_config_save_rc") != 0
+    ):
+        warnings.append(
+            "Containerlab native configuration save did not complete; the source tree is retained"
+        )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -626,6 +1063,7 @@ def inspect_migration_archive(
         "images_included": images_included,
         "images": image_report,
         "node_state": node_report,
+        "containerlab": containerlab_metadata,
         "warnings": warnings,
     }
 
@@ -636,6 +1074,10 @@ def _remote_capture_script(
     node_state: bool = False,
     image_state: bool = False,
     include_images: bool = False,
+    source_root: str = "",
+    topology_relpath: str = "",
+    source_labdir_base: str = "",
+    target_labdir_base: str = "",
     output_available_bytes: int,
 ) -> str:
     usable_bytes = max(0, output_available_bytes - _FREE_SPACE_RESERVE_BYTES)
@@ -646,6 +1088,34 @@ if [ "$required" -gt "$capacity" ]; then
   exit 23
 fi
 """
+    if platform == "containerlab":
+        capture_command = " ".join(
+            [
+                "python3 -c",
+                shlex.quote(_CONTAINERLAB_CAPTURE_PROGRAM),
+                "capture",
+                shlex.quote(source_root),
+                shlex.quote(topology_relpath),
+                shlex.quote(source_labdir_base),
+                shlex.quote(target_labdir_base),
+            ]
+        )
+        assessment_command = " ".join(
+            [
+                "python3 -c",
+                shlex.quote(_CONTAINERLAB_CAPTURE_PROGRAM),
+                "assess",
+                shlex.quote(source_root),
+                shlex.quote(topology_relpath),
+                shlex.quote(source_labdir_base),
+                shlex.quote(target_labdir_base),
+            ]
+        )
+        return f"""set -eu
+required=$({assessment_command})
+{capacity_check}exec {capture_command}
+"""
+
     if platform == "eve-ng":
         compressor = "compressor='gzip -1'\ncommand -v pigz >/dev/null 2>&1 && compressor='pigz -1'"
         if image_state:
@@ -725,7 +1195,28 @@ def _remote_capture_assessment_script(
     *,
     include_node_state: bool = False,
     include_images: bool = False,
+    source_root: str = "",
+    topology_relpath: str = "",
+    source_labdir_base: str = "",
+    target_labdir_base: str = "",
 ) -> str:
+    if platform == "containerlab":
+        assessment_command = " ".join(
+            [
+                "python3 -c",
+                shlex.quote(_CONTAINERLAB_CAPTURE_PROGRAM),
+                "assess",
+                shlex.quote(source_root),
+                shlex.quote(topology_relpath),
+                shlex.quote(source_labdir_base),
+                shlex.quote(target_labdir_base),
+            ]
+        )
+        return f"""set -eu
+primary_bytes=$({assessment_command})
+printf 'primary_bytes=%s\nnode_state_bytes=0\nimage_bytes=0\n' "$primary_bytes"
+"""
+
     if platform == "eve-ng":
         node_state_assessment = "node_state_bytes=0"
         image_assessment = "image_bytes=0"
@@ -1062,6 +1553,10 @@ def capture_existing_lab(
     node_state_output: str | Path | None = None,
     include_images: bool = False,
     images_output: str | Path | None = None,
+    source_root: str = "",
+    topology_relpath: str = "lab.clab.yml",
+    source_labdir_base: str = "",
+    target_labdir_base: str = "/var/lib/hybridops/containerlab/labdirs",
     force: bool = False,
     progress: CaptureProgress | None = None,
 ) -> dict[str, Any]:
@@ -1074,6 +1569,21 @@ def capture_existing_lab(
         raise ValueError("--node-state-output requires --include-node-state")
     if images_output and not (include_images and platform_name == "eve-ng"):
         raise ValueError("--images-output requires EVE-NG --include-images")
+    if platform_name == "containerlab":
+        if not str(source_root or "").strip():
+            raise ValueError("Containerlab capture requires --source-root")
+        if include_images:
+            raise ValueError(
+                "Containerlab migration retains image references; --include-images is not supported"
+            )
+        if not str(topology_relpath or "").strip():
+            raise ValueError("Containerlab capture requires --topology-relpath")
+        if not str(target_labdir_base or "").strip():
+            raise ValueError("Containerlab capture requires --target-labdir-base")
+    elif source_root or source_labdir_base:
+        raise ValueError(
+            "--source-root and --source-labdir-base are only valid for Containerlab"
+        )
 
     destination = _capture_destination(output, "output")
     node_destination: Path | None = None
@@ -1122,6 +1632,10 @@ def capture_existing_lab(
                 platform_name,
                 include_node_state=include_node_state,
                 include_images=include_images,
+                source_root=source_root,
+                topology_relpath=topology_relpath,
+                source_labdir_base=source_labdir_base,
+                target_labdir_base=target_labdir_base,
             ),
             control_path=control_path,
         )
@@ -1154,13 +1668,19 @@ def capture_existing_lab(
             script=_remote_capture_script(
                 platform_name,
                 include_images=include_images,
+                source_root=source_root,
+                topology_relpath=topology_relpath,
+                source_labdir_base=source_labdir_base,
+                target_labdir_base=target_labdir_base,
                 output_available_bytes=_available_disk_bytes(destination.parent),
             ),
             control_path=control_path,
         )
-        primary_stage = (
-            "lab_definitions" if platform_name == "eve-ng" else "gns3_projects"
-        )
+        primary_stage = {
+            "eve-ng": "lab_definitions",
+            "gns3": "gns3_projects",
+            "containerlab": "containerlab_source",
+        }[platform_name]
         _capture_stream(
             primary_argv,
             primary_candidate,
@@ -1253,6 +1773,15 @@ def capture_existing_lab(
         if isinstance(report.get("images"), dict) and image_destination is not None:
             report["images"]["path"] = str(image_destination)
         report["source"] = {"host": host, "user": user or None}
+        if platform_name == "containerlab":
+            report["source"].update(
+                {
+                    "source_root": str(source_root),
+                    "topology_relpath": str(topology_relpath),
+                    "source_labdir_base": str(source_labdir_base) or None,
+                    "target_labdir_base": str(target_labdir_base),
+                }
+            )
         return report
     finally:
         _close_ssh_control(
@@ -1272,14 +1801,20 @@ def capture_existing_lab(
 
 def platform_for_blueprint(payload: dict[str, Any]) -> str:
     lifecycle = payload.get("archive_before_destroy")
-    if not isinstance(lifecycle, dict) or not lifecycle:
-        raise ValueError("target blueprint does not declare a lab archive lifecycle")
-    module_ref = str(lifecycle.get("module_ref") or "").strip()
-    prefix = str(lifecycle.get("contract_prefix") or "").strip()
-    if module_ref.endswith("/eve-ng-lab-archive") or prefix.startswith("eveng_"):
-        return "eve-ng"
-    if module_ref.endswith("/gns3-lab-archive") or prefix.startswith("gns3_"):
-        return "gns3"
+    if isinstance(lifecycle, dict) and lifecycle:
+        module_ref = str(lifecycle.get("module_ref") or "").strip()
+        prefix = str(lifecycle.get("contract_prefix") or "").strip()
+        if module_ref.endswith("/eve-ng-lab-archive") or prefix.startswith("eveng_"):
+            return "eve-ng"
+        if module_ref.endswith("/gns3-lab-archive") or prefix.startswith("gns3_"):
+            return "gns3"
+    steps = payload.get("steps")
+    if isinstance(steps, list) and any(
+        str(step.get("module_ref") or "").endswith("/containerlab-lab")
+        for step in steps
+        if isinstance(step, dict)
+    ):
+        return "containerlab"
     raise ValueError("target blueprint does not support lab migration intake")
 
 
@@ -1294,6 +1829,89 @@ def _record_slug(blueprint_ref: str) -> str:
 
 def migration_record_path(paths, blueprint_ref: str) -> Path:
     return paths.state_dir / "lab-migrations" / f"{_record_slug(blueprint_ref)}.json"
+
+
+def _containerlab_target_contract(payload: dict[str, Any]) -> tuple[str, str]:
+    for step in payload.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        if not str(step.get("module_ref") or "").endswith("/containerlab-lab"):
+            continue
+        inputs = step.get("inputs") if isinstance(step.get("inputs"), dict) else {}
+        topology_relpath = str(
+            inputs.get("containerlab_lab_topology_relpath") or ""
+        ).strip()
+        labdir_base = str(inputs.get("containerlab_lab_labdir_base") or "").strip()
+        if not topology_relpath or not labdir_base:
+            raise ValueError(
+                "target Containerlab blueprint has an incomplete recovery contract"
+            )
+        return topology_relpath, labdir_base
+    raise ValueError("target blueprint has no Containerlab lab step")
+
+
+def _publish_containerlab_latest(
+    *,
+    paths,
+    archive_path: Path,
+    checksum: str,
+    metadata: dict[str, Any],
+    image_references: list[str],
+    force: bool,
+) -> dict[str, Any]:
+    from hyops.runtime.state import write_json_atomic, write_text_atomic
+
+    recovery_dir = paths.root / "artifacts" / "containerlab" / "recovery"
+    recovery_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(recovery_dir, 0o700)
+    latest = recovery_dir / "latest.tar.gz"
+    if latest.exists() and latest.is_dir():
+        raise ValueError(f"Containerlab latest recovery path is a directory: {latest}")
+    latest_checksum = latest.with_name(latest.name + ".sha256")
+    latest_metadata = latest.with_name(latest.name + ".json")
+    markers = (latest, latest_checksum, latest_metadata)
+    if any(path.exists() or path.is_symlink() for path in markers):
+        complete = all(path.exists() or path.is_symlink() for path in markers)
+        existing_checksum = ""
+        if latest_checksum.is_file():
+            existing_checksum = latest_checksum.read_text(encoding="utf-8").strip()
+        if (not complete or existing_checksum != checksum) and not force:
+            raise ValueError(
+                "a different or incomplete Containerlab latest recovery set exists; "
+                "use --force to replace it"
+            )
+    write_text_atomic(latest_checksum, checksum + "\n", mode=0o600)
+    write_json_atomic(
+        latest_metadata,
+        {
+            "schema": "hybridops.containerlab.latest/v1",
+            "archive_sha256": checksum,
+            "topology_sha256": metadata["topology_sha256"],
+            "mode": metadata["mode"],
+            "image_refs": image_references,
+            "labdir_base": metadata["labdir_base"],
+            "timestamp_archive": str(archive_path.resolve()),
+        },
+        mode=0o600,
+    )
+    fd, candidate_name = tempfile.mkstemp(
+        prefix=".latest.",
+        suffix=".candidate",
+        dir=str(recovery_dir),
+    )
+    os.close(fd)
+    candidate = Path(candidate_name)
+    candidate.unlink()
+    try:
+        os.symlink(str(archive_path.resolve()), candidate)
+        os.replace(candidate, latest)
+    finally:
+        candidate.unlink(missing_ok=True)
+    return {
+        "latest_path": str(latest),
+        "sha256_path": str(latest_checksum),
+        "metadata_path": str(latest_metadata),
+    }
 
 
 def _copy_verified(source: Path, destination: Path, checksum: str) -> None:
@@ -1370,6 +1988,25 @@ def stage_migration_archive(
         node_state_expected_sha256=node_state_expected_sha256,
         images_expected_sha256=images_expected_sha256,
     )
+    containerlab_metadata = inspection.get("containerlab")
+    if platform_name == "containerlab":
+        if not isinstance(containerlab_metadata, dict):
+            raise ValueError("Containerlab migration archive has no recovery metadata")
+        target_topology_relpath, target_labdir_base = _containerlab_target_contract(
+            payload
+        )
+        if containerlab_metadata["topology_relpath"] != target_topology_relpath:
+            raise ValueError(
+                "Containerlab topology path does not match the target blueprint: "
+                f"archive={containerlab_metadata['topology_relpath']} "
+                f"target={target_topology_relpath}"
+            )
+        if containerlab_metadata["labdir_base"] != target_labdir_base:
+            raise ValueError(
+                "Containerlab labdir base does not match the target blueprint: "
+                f"archive={containerlab_metadata['labdir_base']} "
+                f"target={target_labdir_base}"
+            )
 
     blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
     record_path = migration_record_path(paths, blueprint_ref)
@@ -1504,6 +2141,7 @@ def stage_migration_archive(
         "definition_count": inspection["definition_count"],
         "image_references": inspection["image_references"],
         "images_included": inspection["images_included"],
+        "containerlab": containerlab_metadata,
         "warnings": inspection["warnings"],
     }
     record["archive"]["path"] = str(archive_destination)
@@ -1522,6 +2160,15 @@ def stage_migration_archive(
             "images_sha256": existing_image_checksum,
             "imported_at": str(existing.get("imported_at") or ""),
         }
+    if platform_name == "containerlab":
+        record["containerlab_latest"] = _publish_containerlab_latest(
+            paths=paths,
+            archive_path=archive_destination,
+            checksum=record["archive"]["sha256"],
+            metadata=containerlab_metadata,
+            image_references=record["image_references"],
+            force=force,
+        )
     _write_record(record_path, record)
     return record
 

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -11,15 +11,18 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+import threading
+import time
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 
 SCHEMA_VERSION = 1
 RECORD_KIND = "hybridops/lab-migration"
 SUPPORTED_PLATFORMS = ("eve-ng", "gns3")
+CaptureProgress = Callable[[dict[str, Any]], None]
 _MAX_DEFINITION_BYTES = 32 * 1024 * 1024
 _MAX_MEMBERS = 200_000
 _FREE_SPACE_RESERVE_BYTES = 64 * 1024 * 1024
@@ -288,7 +291,9 @@ def _eve_image_references(
     for member in definitions:
         definition = _read_definition(handle, member)
         if re.search(rb"<!\s*(?:DOCTYPE|ENTITY)\b", definition, flags=re.IGNORECASE):
-            raise ValueError(f"EVE-NG lab definition contains a DTD or entity declaration: {member.name}")
+            raise ValueError(
+                f"EVE-NG lab definition contains a DTD or entity declaration: {member.name}"
+            )
         try:
             root = ET.fromstring(definition)
         except ET.ParseError as exc:
@@ -302,7 +307,9 @@ def _eve_image_references(
                     or "\\" in image
                     or any(ord(character) < 32 for character in image)
                 ):
-                    raise ValueError(f"EVE-NG lab contains an unsafe image reference: {image}")
+                    raise ValueError(
+                        f"EVE-NG lab contains an unsafe image reference: {image}"
+                    )
                 references.add(image)
                 node_type = str(element.attrib.get("type") or "").strip().lower()
                 if node_type == "qemu":
@@ -352,11 +359,15 @@ def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
             names = [name for _, name in members if name]
             files = [(member, name) for member, name in members if member.isfile()]
             if platform == "eve-ng":
-                definitions = [member for member, name in files if name.lower().endswith(".unl")]
+                definitions = [
+                    member for member, name in files if name.lower().endswith(".unl")
+                ]
                 if not definitions:
                     raise ValueError("EVE-NG archive contains no .unl lab definitions")
                 if any(name.startswith("opt/unetlab/labs/") for name in names):
-                    raise ValueError("EVE-NG archive must be relative to /opt/unetlab/labs")
+                    raise ValueError(
+                        "EVE-NG archive must be relative to /opt/unetlab/labs"
+                    )
                 references, requirements = _eve_image_references(handle, definitions)
                 return {
                     "definition_count": len(definitions),
@@ -376,11 +387,19 @@ def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
             outside = sorted(
                 name
                 for name in names
-                if name.split("/", 1)[0] not in allowed_roots and name != ".config/GNS3" and not name.startswith(".config/GNS3/")
+                if name.split("/", 1)[0] not in allowed_roots
+                and name != ".config/GNS3"
+                and not name.startswith(".config/GNS3/")
             )
             if outside:
-                raise ValueError(f"GNS3 archive contains an unsupported root: {outside[0]}")
-            definitions = [member for member, name in files if name.startswith("projects/") and name.lower().endswith(".gns3")]
+                raise ValueError(
+                    f"GNS3 archive contains an unsupported root: {outside[0]}"
+                )
+            definitions = [
+                member
+                for member, name in files
+                if name.startswith("projects/") and name.lower().endswith(".gns3")
+            ]
             if not definitions:
                 raise ValueError("GNS3 archive contains no project definitions")
             references = _gns3_image_references(handle, definitions)
@@ -388,7 +407,9 @@ def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
                 "definition_count": len(definitions),
                 "expanded_size_bytes": sum(member.size for member, _ in files),
                 "image_references": references,
-                "images_included": any(name == "images" or name.startswith("images/") for name in names),
+                "images_included": any(
+                    name == "images" or name.startswith("images/") for name in names
+                ),
                 "member_count": len(members),
             }
     except tarfile.TarError as exc:
@@ -404,14 +425,20 @@ def _inspect_eve_node_state(path: Path) -> dict[str, Any]:
                 raise ValueError("EVE-NG node-state archive contains no files")
             invalid = [name for name in files if not _EVE_NODE_STATE_RE.fullmatch(name)]
             if invalid:
-                raise ValueError(f"EVE-NG node-state member has an invalid path: {invalid[0]}")
+                raise ValueError(
+                    f"EVE-NG node-state member has an invalid path: {invalid[0]}"
+                )
             return {
-                "expanded_size_bytes": sum(member.size for member, _ in members if member.isfile()),
+                "expanded_size_bytes": sum(
+                    member.size for member, _ in members if member.isfile()
+                ),
                 "member_count": len(members),
                 "overlay_count": len(files),
             }
     except tarfile.TarError as exc:
-        raise ValueError(f"node-state archive is not a readable tar archive: {path}") from exc
+        raise ValueError(
+            f"node-state archive is not a readable tar archive: {path}"
+        ) from exc
 
 
 def _inspect_eve_images(
@@ -433,10 +460,18 @@ def _inspect_eve_images(
             )
             invalid = [name for name in files if not name.startswith(allowed)]
             if invalid:
-                raise ValueError(f"EVE-NG image archive contains an unsupported path: {invalid[0]}")
-            licence_files = [name for name in files if name.lower() in {"iol/bin/iourc", "iol/bin/iourc.txt"}]
+                raise ValueError(
+                    f"EVE-NG image archive contains an unsupported path: {invalid[0]}"
+                )
+            licence_files = [
+                name
+                for name in files
+                if name.lower() in {"iol/bin/iourc", "iol/bin/iourc.txt"}
+            ]
             if licence_files:
-                raise ValueError("EVE-NG image archive must not contain IOL licence material")
+                raise ValueError(
+                    "EVE-NG image archive must not contain IOL licence material"
+                )
 
             selected: set[tuple[str, str]] = set()
             invalid_layout: list[str] = []
@@ -451,15 +486,26 @@ def _inspect_eve_images(
                 else:
                     invalid_layout.append(name)
             if invalid_layout:
-                raise ValueError(f"EVE-NG image archive contains an invalid image path: {invalid_layout[0]}")
+                raise ValueError(
+                    f"EVE-NG image archive contains an invalid image path: {invalid_layout[0]}"
+                )
 
             missing: list[str] = []
             allowed_selected: set[tuple[str, str]] = set()
             for root_name, reference in requirements:
-                if not reference or reference in {".", ".."} or PurePosixPath(reference).name != reference or "\\" in reference:
-                    raise ValueError(f"EVE-NG lab contains an unsafe image reference: {reference}")
+                if (
+                    not reference
+                    or reference in {".", ".."}
+                    or PurePosixPath(reference).name != reference
+                    or "\\" in reference
+                ):
+                    raise ValueError(
+                        f"EVE-NG lab contains an unsafe image reference: {reference}"
+                    )
                 if root_name == "*":
-                    matches = {candidate for candidate in selected if candidate[1] == reference}
+                    matches = {
+                        candidate for candidate in selected if candidate[1] == reference
+                    }
                     if not matches:
                         missing.append(reference)
                     allowed_selected.update(matches)
@@ -469,18 +515,26 @@ def _inspect_eve_images(
                         missing.append(f"{root_name}/{reference}")
                     allowed_selected.add(candidate)
             if missing:
-                raise ValueError(f"EVE-NG image archive is missing a referenced base: {missing[0]}")
+                raise ValueError(
+                    f"EVE-NG image archive is missing a referenced base: {missing[0]}"
+                )
             extra = sorted(selected - allowed_selected)
             if extra:
                 root_name, reference = extra[0]
-                raise ValueError(f"EVE-NG image archive contains an unreferenced base: {root_name}/{reference}")
+                raise ValueError(
+                    f"EVE-NG image archive contains an unreferenced base: {root_name}/{reference}"
+                )
             return {
-                "expanded_size_bytes": sum(member.size for member, _ in members if member.isfile()),
+                "expanded_size_bytes": sum(
+                    member.size for member, _ in members if member.isfile()
+                ),
                 "image_count": len(selected),
                 "member_count": len(members),
             }
     except tarfile.TarError as exc:
-        raise ValueError(f"image archive is not a readable tar archive: {path}") from exc
+        raise ValueError(
+            f"image archive is not a readable tar archive: {path}"
+        ) from exc
 
 
 def inspect_migration_archive(
@@ -595,8 +649,16 @@ fi
     if platform == "eve-ng":
         compressor = "compressor='gzip -1'\ncommand -v pigz >/dev/null 2>&1 && compressor='pigz -1'"
         if image_state:
-            image_command = "python3 -c " + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM) + " capture /opt/unetlab/labs /opt/unetlab/addons"
-            assessment_command = "python3 -c " + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM) + " assess /opt/unetlab/labs /opt/unetlab/addons"
+            image_command = (
+                "python3 -c "
+                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
+                + " capture /opt/unetlab/labs /opt/unetlab/addons"
+            )
+            assessment_command = (
+                "python3 -c "
+                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
+                + " assess /opt/unetlab/labs /opt/unetlab/addons"
+            )
             return f"""set -eu
 required=$({assessment_command})
 {capacity_check}exec {image_command}
@@ -668,7 +730,11 @@ def _remote_capture_assessment_script(
         node_state_assessment = "node_state_bytes=0"
         image_assessment = "image_bytes=0"
         if include_images:
-            image_command = "python3 -c " + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM) + " assess /opt/unetlab/labs /opt/unetlab/addons"
+            image_command = (
+                "python3 -c "
+                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
+                + " assess /opt/unetlab/labs /opt/unetlab/addons"
+            )
             image_assessment = f"image_bytes=$({image_command})"
         if include_node_state:
             node_state_assessment = """node_root=/opt/unetlab/tmp
@@ -751,8 +817,13 @@ def _ssh_capture_argv(
 def _capture_error(result: subprocess.CompletedProcess[bytes]) -> ValueError:
     detail = result.stderr.decode("utf-8", errors="replace").strip()
     lowered_detail = detail.lower()
-    if "no space left on device" in lowered_detail or "disk quota exceeded" in lowered_detail:
-        return ValueError("insufficient disk space for lab capture: the output filesystem became full while writing the archive")
+    if (
+        "no space left on device" in lowered_detail
+        or "disk quota exceeded" in lowered_detail
+    ):
+        return ValueError(
+            "insufficient disk space for lab capture: the output filesystem became full while writing the archive"
+        )
     capacity_match = re.search(
         r"source requires at least (\d+) bytes; "
         r"output filesystem has (\d+) bytes available",
@@ -768,7 +839,9 @@ def _capture_error(result: subprocess.CompletedProcess[bytes]) -> ValueError:
             f"{_format_bytes(available)} available"
         )
     lines = [line.strip() for line in detail.splitlines() if line.strip()]
-    concise = "; ".join(lines[-3:])[-800:] or f"ssh exited with status {result.returncode}"
+    concise = (
+        "; ".join(lines[-3:])[-800:] or f"ssh exited with status {result.returncode}"
+    )
     return ValueError(f"source capture failed: {concise}")
 
 
@@ -834,7 +907,46 @@ def _close_ssh_control(
         pass
 
 
-def _capture_stream(argv: list[str], candidate: Path) -> None:
+def _capture_stream(
+    argv: list[str],
+    candidate: Path,
+    *,
+    stage: str = "archive",
+    expected_source_bytes: int = 0,
+    progress: CaptureProgress | None = None,
+) -> None:
+    started = time.monotonic()
+    stopped = threading.Event()
+
+    def emit(phase: str, *, status: str = "running") -> None:
+        if progress is None:
+            return
+        elapsed = max(0.0, time.monotonic() - started)
+        try:
+            written = candidate.stat().st_size
+        except OSError:
+            written = 0
+        progress(
+            {
+                "phase": phase,
+                "stage": stage,
+                "status": status,
+                "bytes_written": written,
+                "expected_source_bytes": max(0, int(expected_source_bytes)),
+                "elapsed_seconds": elapsed,
+                "bytes_per_second": written / elapsed if elapsed > 0 else 0.0,
+            }
+        )
+
+    def monitor() -> None:
+        while not stopped.wait(1.0):
+            emit("stream_progress")
+
+    monitor_thread: threading.Thread | None = None
+    emit("stream_started")
+    if progress is not None:
+        monitor_thread = threading.Thread(target=monitor, daemon=True)
+        monitor_thread.start()
     try:
         with candidate.open("wb") as output:
             result = subprocess.run(
@@ -846,10 +958,17 @@ def _capture_stream(argv: list[str], candidate: Path) -> None:
             output.flush()
             os.fsync(output.fileno())
     except FileNotFoundError as exc:
+        emit("stream_finished", status="failed")
         raise ValueError("ssh is not installed or is not available on PATH") from exc
+    finally:
+        stopped.set()
+        if monitor_thread is not None:
+            monitor_thread.join(timeout=2)
     if result.returncode == 0:
         os.chmod(candidate, 0o600)
+        emit("stream_finished", status="ok")
         return
+    emit("stream_finished", status="failed")
     raise _capture_error(result)
 
 
@@ -896,7 +1015,9 @@ def _capture_candidate(path: Path, force: bool) -> Path:
         if not path.is_file():
             raise ValueError(f"output is not a regular file: {path}")
         if not force:
-            raise ValueError(f"output already exists: {path}; use --force to replace it")
+            raise ValueError(
+                f"output already exists: {path}; use --force to replace it"
+            )
     parent_existed = path.parent.exists()
     path.parent.mkdir(parents=True, exist_ok=True)
     if not parent_existed:
@@ -942,6 +1063,7 @@ def capture_existing_lab(
     include_images: bool = False,
     images_output: str | Path | None = None,
     force: bool = False,
+    progress: CaptureProgress | None = None,
 ) -> dict[str, Any]:
     platform_name = str(platform or "").strip().lower()
     if platform_name not in SUPPORTED_PLATFORMS:
@@ -958,12 +1080,18 @@ def capture_existing_lab(
     image_destination: Path | None = None
     if include_node_state:
         node_destination = (
-            _capture_destination(node_state_output, "node-state output") if node_state_output else _default_node_state_output(destination)
+            _capture_destination(node_state_output, "node-state output")
+            if node_state_output
+            else _default_node_state_output(destination)
         )
         if node_destination == destination:
             raise ValueError("node-state output must differ from the primary output")
     if include_images and platform_name == "eve-ng":
-        image_destination = _capture_destination(images_output, "images output") if images_output else _default_images_output(destination)
+        image_destination = (
+            _capture_destination(images_output, "images output")
+            if images_output
+            else _default_images_output(destination)
+        )
         if image_destination in {destination, node_destination}:
             raise ValueError("images output must differ from other capture outputs")
 
@@ -997,7 +1125,18 @@ def capture_existing_lab(
             ),
             control_path=control_path,
         )
+        if progress is not None:
+            progress({"phase": "assessment_started", "stage": "assessment"})
         requirements = _capture_requirements(assessment_argv)
+        if progress is not None:
+            progress(
+                {
+                    "phase": "assessment_finished",
+                    "primary_bytes": requirements["primary_bytes"],
+                    "node_state_bytes": requirements["node_state_bytes"],
+                    "image_bytes": requirements["image_bytes"],
+                }
+            )
         _require_capture_capacity(
             destination=destination,
             primary_bytes=requirements["primary_bytes"],
@@ -1019,7 +1158,16 @@ def capture_existing_lab(
             ),
             control_path=control_path,
         )
-        _capture_stream(primary_argv, primary_candidate)
+        primary_stage = (
+            "lab_definitions" if platform_name == "eve-ng" else "gns3_projects"
+        )
+        _capture_stream(
+            primary_argv,
+            primary_candidate,
+            stage=primary_stage,
+            expected_source_bytes=requirements["primary_bytes"],
+            progress=progress,
+        )
         if node_candidate is not None:
             node_argv = _ssh_capture_argv(
                 host=host,
@@ -1030,11 +1178,19 @@ def capture_existing_lab(
                 script=_remote_capture_script(
                     platform_name,
                     node_state=True,
-                    output_available_bytes=_available_disk_bytes(node_destination.parent),
+                    output_available_bytes=_available_disk_bytes(
+                        node_destination.parent
+                    ),
                 ),
                 control_path=control_path,
             )
-            _capture_stream(node_argv, node_candidate)
+            _capture_stream(
+                node_argv,
+                node_candidate,
+                stage="node_state",
+                expected_source_bytes=requirements["node_state_bytes"],
+                progress=progress,
+            )
         if image_candidate is not None and image_destination is not None:
             image_argv = _ssh_capture_argv(
                 host=host,
@@ -1045,18 +1201,47 @@ def capture_existing_lab(
                 script=_remote_capture_script(
                     platform_name,
                     image_state=True,
-                    output_available_bytes=_available_disk_bytes(image_destination.parent),
+                    output_available_bytes=_available_disk_bytes(
+                        image_destination.parent
+                    ),
                 ),
                 control_path=control_path,
             )
-            _capture_stream(image_argv, image_candidate)
+            _capture_stream(
+                image_argv,
+                image_candidate,
+                stage="referenced_images",
+                expected_source_bytes=requirements["image_bytes"],
+                progress=progress,
+            )
 
-        report = inspect_migration_archive(
-            platform=platform_name,
-            archive=primary_candidate,
-            node_state=node_candidate,
-            images=image_candidate,
-        )
+        if progress is not None:
+            progress({"phase": "verification_started", "stage": "verification"})
+        try:
+            report = inspect_migration_archive(
+                platform=platform_name,
+                archive=primary_candidate,
+                node_state=node_candidate,
+                images=image_candidate,
+            )
+        except (OSError, ValueError):
+            if progress is not None:
+                progress(
+                    {
+                        "phase": "verification_finished",
+                        "stage": "verification",
+                        "status": "failed",
+                    }
+                )
+            raise
+        if progress is not None:
+            progress(
+                {
+                    "phase": "verification_finished",
+                    "stage": "verification",
+                    "status": "ok",
+                }
+            )
         if node_candidate is not None and node_destination is not None:
             os.replace(node_candidate, node_destination)
         if image_candidate is not None and image_destination is not None:
@@ -1173,7 +1358,9 @@ def stage_migration_archive(
     platform_name = str(platform or "").strip().lower()
     target_platform = platform_for_blueprint(payload)
     if platform_name != target_platform:
-        raise ValueError(f"source platform {platform_name} does not match target blueprint platform {target_platform}")
+        raise ValueError(
+            f"source platform {platform_name} does not match target blueprint platform {target_platform}"
+        )
     inspection = inspect_migration_archive(
         platform=platform_name,
         archive=archive,
@@ -1195,15 +1382,29 @@ def stage_migration_archive(
         if isinstance(loaded, dict):
             existing = loaded
     existing_archive = (existing or {}).get("archive")
-    existing_checksum = str(existing_archive.get("sha256") or "") if isinstance(existing_archive, dict) else ""
+    existing_checksum = (
+        str(existing_archive.get("sha256") or "")
+        if isinstance(existing_archive, dict)
+        else ""
+    )
     node_inspection = inspection.get("node_state")
     node_checksum = str(node_inspection.get("sha256") or "") if node_inspection else ""
     existing_node = (existing or {}).get("node_state")
-    existing_node_checksum = str(existing_node.get("sha256") or "") if isinstance(existing_node, dict) else ""
+    existing_node_checksum = (
+        str(existing_node.get("sha256") or "")
+        if isinstance(existing_node, dict)
+        else ""
+    )
     image_inspection = inspection.get("images")
-    image_checksum = str(image_inspection.get("sha256") or "") if image_inspection else ""
+    image_checksum = (
+        str(image_inspection.get("sha256") or "") if image_inspection else ""
+    )
     existing_images = (existing or {}).get("images")
-    existing_image_checksum = str(existing_images.get("sha256") or "") if isinstance(existing_images, dict) else ""
+    existing_image_checksum = (
+        str(existing_images.get("sha256") or "")
+        if isinstance(existing_images, dict)
+        else ""
+    )
     if (
         existing
         and (
@@ -1218,25 +1419,42 @@ def stage_migration_archive(
         )
         and not force
     ):
-        raise ValueError("a different migration bundle is already staged for this blueprint; use --force to replace the active record")
+        raise ValueError(
+            "a different migration bundle is already staged for this blueprint; use --force to replace the active record"
+        )
 
     bundle_id = _bundle_id(
         inspection["archive"]["sha256"],
         node_checksum,
         image_checksum,
     )
-    destination_root = paths.root / "artifacts" / "lab-migrations" / _record_slug(blueprint_ref) / bundle_id
+    destination_root = (
+        paths.root
+        / "artifacts"
+        / "lab-migrations"
+        / _record_slug(blueprint_ref)
+        / bundle_id
+    )
     archive_destination = destination_root / "labs.tar.gz"
     copy_bytes = 0
-    if not (archive_destination.is_file() and _sha256(archive_destination) == inspection["archive"]["sha256"]):
+    if not (
+        archive_destination.is_file()
+        and _sha256(archive_destination) == inspection["archive"]["sha256"]
+    ):
         copy_bytes += int(inspection["archive"]["size_bytes"])
     if node_inspection:
         node_destination = destination_root / "labs.node-state.tar.gz"
-        if not (node_destination.is_file() and _sha256(node_destination) == node_inspection["sha256"]):
+        if not (
+            node_destination.is_file()
+            and _sha256(node_destination) == node_inspection["sha256"]
+        ):
             copy_bytes += int(node_inspection["size_bytes"])
     if image_inspection:
         image_destination = destination_root / "labs.images.tar.gz"
-        if not (image_destination.is_file() and _sha256(image_destination) == image_inspection["sha256"]):
+        if not (
+            image_destination.is_file()
+            and _sha256(image_destination) == image_inspection["sha256"]
+        ):
             copy_bytes += int(image_inspection["size_bytes"])
     if copy_bytes:
         _require_disk_space(destination_root, copy_bytes, "migration import")
@@ -1254,7 +1472,9 @@ def stage_migration_archive(
             node_destination,
             node_inspection["sha256"],
         )
-        staged_node = {key: value for key, value in node_inspection.items() if key != "path"}
+        staged_node = {
+            key: value for key, value in node_inspection.items() if key != "path"
+        }
         staged_node["path"] = str(node_destination)
 
     staged_images: dict[str, Any] | None = None
@@ -1264,7 +1484,9 @@ def stage_migration_archive(
             image_destination,
             image_inspection["sha256"],
         )
-        staged_images = {key: value for key, value in image_inspection.items() if key != "path"}
+        staged_images = {
+            key: value for key, value in image_inspection.items() if key != "path"
+        }
         staged_images["path"] = str(image_destination)
 
     record = {
@@ -1274,7 +1496,9 @@ def stage_migration_archive(
         "imported_at": _utc_now(),
         "platform": platform_name,
         "blueprint_ref": blueprint_ref,
-        "archive": {key: value for key, value in inspection["archive"].items() if key != "path"},
+        "archive": {
+            key: value for key, value in inspection["archive"].items() if key != "path"
+        },
         "node_state": staged_node,
         "images": staged_images,
         "definition_count": inspection["definition_count"],
@@ -1334,7 +1558,10 @@ def _load_migration_record(*, paths, payload: dict[str, Any]) -> dict[str, Any] 
         raise ValueError(f"migration record is unreadable: {path}") from exc
     if not isinstance(record, dict):
         raise ValueError(f"migration record is invalid: {path}")
-    if record.get("schema_version") != SCHEMA_VERSION or record.get("kind") != RECORD_KIND:
+    if (
+        record.get("schema_version") != SCHEMA_VERSION
+        or record.get("kind") != RECORD_KIND
+    ):
         raise ValueError(f"migration record has an unsupported schema: {path}")
     if record.get("status") != "verified":
         raise ValueError(f"migration record is not verified: {path}")
@@ -1342,7 +1569,9 @@ def _load_migration_record(*, paths, payload: dict[str, Any]) -> dict[str, Any] 
         raise ValueError(f"migration record blueprint does not match {blueprint_ref}")
     platform = str(record.get("platform") or "")
     if platform != platform_for_blueprint(payload):
-        raise ValueError("migration record platform does not match the target blueprint")
+        raise ValueError(
+            "migration record platform does not match the target blueprint"
+        )
     return record
 
 

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -1,0 +1,856 @@
+"""Verified intake for existing EVE-NG and GNS3 lab archives."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+RECORD_KIND = "hybridops/lab-migration"
+SUPPORTED_PLATFORMS = ("eve-ng", "gns3")
+_MAX_DEFINITION_BYTES = 32 * 1024 * 1024
+_MAX_MEMBERS = 200_000
+_FREE_SPACE_RESERVE_BYTES = 64 * 1024 * 1024
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_EVE_NODE_STATE_RE = re.compile(r"^[0-9]+/[^/]+/[0-9]+/[^/]+\.qcow2$")
+_SSH_HOST_RE = re.compile(r"^[a-zA-Z0-9_.:-]+$")
+_SSH_USER_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _existing_filesystem_path(path: Path) -> Path:
+    candidate = path.expanduser().resolve()
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    return candidate
+
+
+def _available_disk_bytes(path: Path) -> int:
+    return shutil.disk_usage(_existing_filesystem_path(path)).free
+
+
+def _require_disk_space(path: Path, payload_bytes: int, operation: str) -> None:
+    filesystem_path = _existing_filesystem_path(path)
+    available = shutil.disk_usage(filesystem_path).free
+    required = int(payload_bytes) + _FREE_SPACE_RESERVE_BYTES
+    if available < required:
+        raise ValueError(
+            f"insufficient disk space for {operation}: required {required} bytes, "
+            f"available {available} bytes on the filesystem containing "
+            f"{filesystem_path}"
+        )
+
+
+def _regular_file(raw: str | Path, field: str) -> Path:
+    path = Path(raw).expanduser().resolve()
+    if not path.is_file():
+        raise ValueError(f"{field} is not a regular file: {path}")
+    if Path(raw).expanduser().is_symlink():
+        raise ValueError(f"{field} must not be a symbolic link: {raw}")
+    return path
+
+
+def _expected_checksum(value: str, field: str) -> str:
+    checksum = str(value or "").strip().lower()
+    if checksum and not _SHA256_RE.fullmatch(checksum):
+        raise ValueError(f"{field} must contain 64 hexadecimal characters")
+    return checksum
+
+
+def _ssh_name(value: str, field: str) -> str:
+    candidate = str(value or "").strip()
+    pattern = _SSH_USER_RE if field == "user" else _SSH_HOST_RE
+    if not candidate or candidate.startswith("-") or not pattern.fullmatch(candidate):
+        raise ValueError(f"{field} is not a valid SSH name")
+    return candidate
+
+
+def _normalised_member_name(name: str) -> str:
+    if "\\" in name:
+        raise ValueError(f"archive member uses a non-portable path: {name}")
+    if name.startswith("/"):
+        raise ValueError(f"archive contains an absolute path: {name}")
+    path = PurePosixPath(name)
+    if ".." in path.parts:
+        raise ValueError(f"archive member escapes its root: {name}")
+    normalised = str(path)
+    while normalised.startswith("./"):
+        normalised = normalised[2:]
+    return "" if normalised == "." else normalised.rstrip("/")
+
+
+def _safe_members(handle: tarfile.TarFile) -> list[tuple[tarfile.TarInfo, str]]:
+    checked: list[tuple[tarfile.TarInfo, str]] = []
+    seen: set[str] = set()
+    for index, member in enumerate(handle, start=1):
+        if index > _MAX_MEMBERS:
+            raise ValueError(f"archive contains more than {_MAX_MEMBERS} members")
+        name = _normalised_member_name(member.name)
+        if member.issym() or member.islnk():
+            raise ValueError(f"archive contains a link: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise ValueError(f"archive contains an unsupported member: {member.name}")
+        if member.isfile() and not name:
+            raise ValueError("archive contains a file with an empty path")
+        if name and name in seen:
+            raise ValueError(f"archive contains a duplicate member: {name}")
+        if name:
+            seen.add(name)
+        checked.append((member, name))
+    if not checked:
+        raise ValueError("archive is empty")
+    return checked
+
+
+def _read_definition(handle: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
+    if member.size > _MAX_DEFINITION_BYTES:
+        raise ValueError(f"lab definition is too large to inspect: {member.name}")
+    source = handle.extractfile(member)
+    if source is None:
+        raise ValueError(f"unable to read lab definition: {member.name}")
+    with source:
+        payload = source.read(_MAX_DEFINITION_BYTES + 1)
+    if len(payload) > _MAX_DEFINITION_BYTES:
+        raise ValueError(f"lab definition is too large to inspect: {member.name}")
+    return payload
+
+
+def _eve_image_references(
+    handle: tarfile.TarFile,
+    definitions: Iterable[tarfile.TarInfo],
+) -> list[str]:
+    references: set[str] = set()
+    for member in definitions:
+        try:
+            root = ET.fromstring(_read_definition(handle, member))
+        except ET.ParseError as exc:
+            raise ValueError(f"invalid EVE-NG lab definition: {member.name}") from exc
+        for element in root.iter():
+            image = str(element.attrib.get("image") or "").strip()
+            if image:
+                references.add(image)
+    return sorted(references)
+
+
+def _walk_json_images(value: Any, *, key: str = "") -> Iterable[str]:
+    if isinstance(value, dict):
+        for child_key, child in value.items():
+            yield from _walk_json_images(child, key=str(child_key).lower())
+        return
+    if isinstance(value, list):
+        for child in value:
+            yield from _walk_json_images(child, key=key)
+        return
+    if isinstance(value, str) and ("image" in key or "disk" in key):
+        candidate = value.strip()
+        if candidate:
+            yield candidate
+
+
+def _gns3_image_references(
+    handle: tarfile.TarFile,
+    definitions: Iterable[tarfile.TarInfo],
+) -> list[str]:
+    references: set[str] = set()
+    for member in definitions:
+        try:
+            payload = json.loads(_read_definition(handle, member))
+        except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+            raise ValueError(f"invalid GNS3 project definition: {member.name}") from exc
+        references.update(_walk_json_images(payload))
+    return sorted(references)
+
+
+def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
+    try:
+        with tarfile.open(path, mode="r:*") as handle:
+            members = _safe_members(handle)
+            names = [name for _, name in members if name]
+            files = [(member, name) for member, name in members if member.isfile()]
+            if platform == "eve-ng":
+                definitions = [
+                    member for member, name in files if name.lower().endswith(".unl")
+                ]
+                if not definitions:
+                    raise ValueError("EVE-NG archive contains no .unl lab definitions")
+                if any(name.startswith("opt/unetlab/labs/") for name in names):
+                    raise ValueError(
+                        "EVE-NG archive must be relative to /opt/unetlab/labs"
+                    )
+                references = _eve_image_references(handle, definitions)
+                return {
+                    "definition_count": len(definitions),
+                    "expanded_size_bytes": sum(member.size for member, _ in files),
+                    "image_references": references,
+                    "images_included": False,
+                    "member_count": len(members),
+                }
+
+            allowed_roots = {
+                "projects",
+                "appliances",
+                "symbols",
+                "images",
+            }
+            outside = sorted(
+                name
+                for name in names
+                if name.split("/", 1)[0] not in allowed_roots
+                and name != ".config/GNS3"
+                and not name.startswith(".config/GNS3/")
+            )
+            if outside:
+                raise ValueError(
+                    f"GNS3 archive contains an unsupported root: {outside[0]}"
+                )
+            definitions = [
+                member
+                for member, name in files
+                if name.startswith("projects/") and name.lower().endswith(".gns3")
+            ]
+            if not definitions:
+                raise ValueError("GNS3 archive contains no project definitions")
+            references = _gns3_image_references(handle, definitions)
+            return {
+                "definition_count": len(definitions),
+                "expanded_size_bytes": sum(member.size for member, _ in files),
+                "image_references": references,
+                "images_included": any(
+                    name == "images" or name.startswith("images/") for name in names
+                ),
+                "member_count": len(members),
+            }
+    except tarfile.TarError as exc:
+        raise ValueError(f"archive is not a readable tar archive: {path}") from exc
+
+
+def _inspect_eve_node_state(path: Path) -> dict[str, Any]:
+    try:
+        with tarfile.open(path, mode="r:*") as handle:
+            members = _safe_members(handle)
+            files = [name for member, name in members if member.isfile()]
+            if not files:
+                raise ValueError("EVE-NG node-state archive contains no files")
+            invalid = [name for name in files if not _EVE_NODE_STATE_RE.fullmatch(name)]
+            if invalid:
+                raise ValueError(
+                    f"EVE-NG node-state member has an invalid path: {invalid[0]}"
+                )
+            return {
+                "expanded_size_bytes": sum(
+                    member.size for member, _ in members if member.isfile()
+                ),
+                "member_count": len(members),
+                "overlay_count": len(files),
+            }
+    except tarfile.TarError as exc:
+        raise ValueError(
+            f"node-state archive is not a readable tar archive: {path}"
+        ) from exc
+
+
+def inspect_migration_archive(
+    *,
+    platform: str,
+    archive: str | Path,
+    node_state: str | Path | None = None,
+    expected_sha256: str = "",
+    node_state_expected_sha256: str = "",
+) -> dict[str, Any]:
+    platform_name = str(platform or "").strip().lower()
+    if platform_name not in SUPPORTED_PLATFORMS:
+        raise ValueError(
+            "platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS)
+        )
+
+    archive_path = _regular_file(archive, "archive")
+    archive_checksum = _sha256(archive_path)
+    expected = _expected_checksum(expected_sha256, "expected SHA-256")
+    if expected and archive_checksum != expected:
+        raise ValueError("archive SHA-256 checksum does not match")
+
+    primary = _inspect_primary(archive_path, platform_name)
+    node_report: dict[str, Any] | None = None
+    node_path: Path | None = None
+    if node_state:
+        if platform_name != "eve-ng":
+            raise ValueError("a separate node-state archive is only valid for EVE-NG")
+        node_path = _regular_file(node_state, "node-state archive")
+        node_checksum = _sha256(node_path)
+        node_expected = _expected_checksum(
+            node_state_expected_sha256,
+            "node-state expected SHA-256",
+        )
+        if node_expected and node_checksum != node_expected:
+            raise ValueError("node-state archive SHA-256 checksum does not match")
+        node_report = {
+            "path": str(node_path),
+            "size_bytes": node_path.stat().st_size,
+            "sha256": node_checksum,
+            **_inspect_eve_node_state(node_path),
+        }
+    elif node_state_expected_sha256:
+        raise ValueError("node-state expected SHA-256 requires --node-state")
+
+    warnings: list[str] = []
+    if primary["image_references"] and not primary["images_included"]:
+        warnings.append("referenced base images must be available on the target")
+    if platform_name == "eve-ng" and node_report is None:
+        warnings.append("writable QEMU node state is not included")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "hybridops/lab-migration-inspection",
+        "status": "compatible",
+        "platform": platform_name,
+        "archive": {
+            "path": str(archive_path),
+            "size_bytes": archive_path.stat().st_size,
+            "expanded_size_bytes": primary["expanded_size_bytes"],
+            "sha256": archive_checksum,
+            "member_count": primary["member_count"],
+        },
+        "definition_count": primary["definition_count"],
+        "image_references": primary["image_references"],
+        "images_included": primary["images_included"],
+        "node_state": node_report,
+        "warnings": warnings,
+    }
+
+
+def _remote_capture_script(
+    platform: str,
+    *,
+    node_state: bool = False,
+    include_images: bool = False,
+    output_available_bytes: int,
+) -> str:
+    usable_bytes = max(0, output_available_bytes - _FREE_SPACE_RESERVE_BYTES)
+    capacity_check = f"""available={output_available_bytes}
+capacity={usable_bytes}
+if [ "$required" -gt "$capacity" ]; then
+  echo "Insufficient disk space for lab capture: source requires at least $required bytes; output filesystem has $available bytes available" >&2
+  exit 23
+fi
+"""
+    if platform == "eve-ng":
+        if node_state:
+            return f"""set -eu
+root=/opt/unetlab/tmp
+test -d "$root" || {{ echo 'EVE-NG node-state root not found' >&2; exit 20; }}
+if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then
+  echo 'EVE-NG QEMU nodes are running; stop them before capture' >&2
+  exit 21
+fi
+cd "$root"
+find . -type f -name '*.qcow2' -printf '%P\\n' -quit | grep -q . || {{
+  echo 'No EVE-NG QEMU node state was found' >&2
+  exit 22
+}}
+required=$(find . -type f -name '*.qcow2' -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
+{capacity_check}find . -type f -name '*.qcow2' -printf '%P\\0' | sort -z | \
+  tar --null --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+  -czf - --files-from=-
+"""
+        return f"""set -eu
+root=/opt/unetlab/labs
+test -d "$root" || {{ echo 'EVE-NG labs root not found' >&2; exit 20; }}
+if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then
+  echo 'EVE-NG QEMU nodes are running; stop them before capture' >&2
+  exit 21
+fi
+find "$root" -type f -name '*.unl' -print -quit | grep -q . || {{
+  echo 'No EVE-NG lab definitions were found' >&2
+  exit 22
+}}
+required=$(find "$root" -type f -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
+{capacity_check}exec tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+  -czf - -C "$root" .
+"""
+
+    image_member = " images" if include_images else ""
+    return f"""set -eu
+root=/var/lib/gns3
+test -d "$root/projects" || {{ echo 'GNS3 projects root not found' >&2; exit 20; }}
+if pgrep -af '[g]ns3server' >/dev/null; then
+  echo 'GNS3 is running; stop it before capture' >&2
+  exit 21
+fi
+cd "$root"
+set -- projects
+for member in appliances symbols .config/GNS3{image_member}; do
+  test -e "$root/$member" && set -- "$@" "$member"
+done
+required=$(du -s --block-size=1 "$@" | awk '{{total += $1}} END {{printf "%.0f\\n", total}}')
+{capacity_check}exec tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+  -czf - -C "$root" "$@"
+"""
+
+
+def _ssh_capture_argv(
+    *,
+    host: str,
+    user: str,
+    port: int,
+    identity_file: str | Path | None,
+    become: bool,
+    script: str,
+) -> list[str]:
+    host_name = _ssh_name(host, "host")
+    user_name = _ssh_name(user, "user") if user else ""
+    if not 1 <= int(port) <= 65535:
+        raise ValueError("SSH port must be between 1 and 65535")
+    target = f"{user_name}@{host_name}" if user_name else host_name
+    argv = ["ssh", "-T", "-p", str(port)]
+    if identity_file:
+        identity = _regular_file(identity_file, "identity file")
+        argv.extend(["-i", str(identity)])
+    remote = ["sudo", "-n", "sh", "-c", script] if become else ["sh", "-c", script]
+    return [*argv, target, shlex.join(remote)]
+
+
+def _capture_stream(argv: list[str], candidate: Path) -> None:
+    try:
+        with candidate.open("wb") as output:
+            result = subprocess.run(
+                argv,
+                stdout=output,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            output.flush()
+            os.fsync(output.fileno())
+    except FileNotFoundError as exc:
+        raise ValueError("ssh is not installed or is not available on PATH") from exc
+    if result.returncode == 0:
+        os.chmod(candidate, 0o600)
+        return
+    detail = result.stderr.decode("utf-8", errors="replace").strip()
+    lowered_detail = detail.lower()
+    if "no space left on device" in lowered_detail or "disk quota exceeded" in lowered_detail:
+        raise ValueError(
+            "insufficient disk space for lab capture: the output filesystem "
+            "became full while writing the archive"
+        )
+    lines = [line.strip() for line in detail.splitlines() if line.strip()]
+    concise = "; ".join(lines[-3:])[-800:] or f"ssh exited with status {result.returncode}"
+    raise ValueError(f"source capture failed: {concise}")
+
+
+def _capture_destination(raw: str | Path, field: str) -> Path:
+    expanded = Path(raw).expanduser()
+    if expanded.is_symlink():
+        raise ValueError(f"{field} must not be a symbolic link: {expanded}")
+    return expanded.parent.resolve() / expanded.name
+
+
+def _capture_candidate(path: Path, force: bool) -> Path:
+    if path.exists():
+        if not path.is_file():
+            raise ValueError(f"output is not a regular file: {path}")
+        if not force:
+            raise ValueError(f"output already exists: {path}; use --force to replace it")
+    parent_existed = path.parent.exists()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not parent_existed:
+        os.chmod(path.parent, 0o700)
+    fd, candidate_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".candidate",
+        dir=str(path.parent),
+    )
+    os.close(fd)
+    candidate = Path(candidate_name)
+    os.chmod(candidate, 0o600)
+    return candidate
+
+
+def _default_node_state_output(primary: Path) -> Path:
+    name = primary.name
+    for suffix in (".tar.gz", ".tgz", ".tar"):
+        if name.lower().endswith(suffix):
+            return primary.with_name(name[: -len(suffix)] + ".node-state.tar.gz")
+    return primary.with_name(name + ".node-state.tar.gz")
+
+
+def capture_existing_lab(
+    *,
+    platform: str,
+    host: str,
+    output: str | Path,
+    user: str = "",
+    port: int = 22,
+    identity_file: str | Path | None = None,
+    become: bool = False,
+    include_node_state: bool = False,
+    node_state_output: str | Path | None = None,
+    include_images: bool = False,
+    force: bool = False,
+) -> dict[str, Any]:
+    platform_name = str(platform or "").strip().lower()
+    if platform_name not in SUPPORTED_PLATFORMS:
+        raise ValueError(
+            "platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS)
+        )
+    if include_node_state and platform_name != "eve-ng":
+        raise ValueError("separate node-state capture is only valid for EVE-NG")
+    if include_images and platform_name != "gns3":
+        raise ValueError("--include-images is only valid for GNS3")
+    if node_state_output and not include_node_state:
+        raise ValueError("--node-state-output requires --include-node-state")
+
+    destination = _capture_destination(output, "output")
+    node_destination: Path | None = None
+    if include_node_state:
+        node_destination = (
+            _capture_destination(node_state_output, "node-state output")
+            if node_state_output
+            else _default_node_state_output(destination)
+        )
+        if node_destination == destination:
+            raise ValueError("node-state output must differ from the primary output")
+
+    primary_candidate: Path | None = None
+    node_candidate: Path | None = None
+    try:
+        primary_candidate = _capture_candidate(destination, force)
+        if node_destination is not None:
+            node_candidate = _capture_candidate(node_destination, force)
+        primary_argv = _ssh_capture_argv(
+            host=host,
+            user=user,
+            port=port,
+            identity_file=identity_file,
+            become=become,
+            script=_remote_capture_script(
+                platform_name,
+                include_images=include_images,
+                output_available_bytes=_available_disk_bytes(destination.parent),
+            ),
+        )
+        _capture_stream(primary_argv, primary_candidate)
+        if node_candidate is not None:
+            node_argv = _ssh_capture_argv(
+                host=host,
+                user=user,
+                port=port,
+                identity_file=identity_file,
+                become=become,
+                script=_remote_capture_script(
+                    platform_name,
+                    node_state=True,
+                    output_available_bytes=_available_disk_bytes(
+                        node_destination.parent
+                    ),
+                ),
+            )
+            _capture_stream(node_argv, node_candidate)
+
+        report = inspect_migration_archive(
+            platform=platform_name,
+            archive=primary_candidate,
+            node_state=node_candidate,
+        )
+        os.replace(primary_candidate, destination)
+        if node_candidate is not None and node_destination is not None:
+            os.replace(node_candidate, node_destination)
+        report["archive"]["path"] = str(destination)
+        if isinstance(report.get("node_state"), dict) and node_destination is not None:
+            report["node_state"]["path"] = str(node_destination)
+        report["source"] = {"host": host, "user": user or None}
+        return report
+    finally:
+        if primary_candidate is not None:
+            primary_candidate.unlink(missing_ok=True)
+        if node_candidate is not None:
+            node_candidate.unlink(missing_ok=True)
+
+
+def platform_for_blueprint(payload: dict[str, Any]) -> str:
+    lifecycle = payload.get("archive_before_destroy")
+    if not isinstance(lifecycle, dict) or not lifecycle:
+        raise ValueError("target blueprint does not declare a lab archive lifecycle")
+    module_ref = str(lifecycle.get("module_ref") or "").strip()
+    prefix = str(lifecycle.get("contract_prefix") or "").strip()
+    if module_ref.endswith("/eve-ng-lab-archive") or prefix.startswith("eveng_"):
+        return "eve-ng"
+    if module_ref.endswith("/gns3-lab-archive") or prefix.startswith("gns3_"):
+        return "gns3"
+    raise ValueError("target blueprint does not support lab migration intake")
+
+
+def _record_slug(blueprint_ref: str) -> str:
+    reference = str(blueprint_ref or "").strip()
+    if not reference:
+        raise ValueError("target blueprint has no blueprint_ref")
+    readable = re.sub(r"[^a-zA-Z0-9_.-]+", "_", reference).strip("_")
+    suffix = hashlib.sha256(reference.encode("utf-8")).hexdigest()[:8]
+    return f"{readable}-{suffix}"
+
+
+def migration_record_path(paths, blueprint_ref: str) -> Path:
+    return paths.state_dir / "lab-migrations" / f"{_record_slug(blueprint_ref)}.json"
+
+
+def _copy_verified(source: Path, destination: Path, checksum: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(destination.parent, 0o700)
+    if destination.is_symlink():
+        raise ValueError(f"staged archive must not be a symbolic link: {destination}")
+    if destination.exists() and not destination.is_file():
+        raise ValueError(f"staged archive is not a regular file: {destination}")
+    if destination.is_file() and _sha256(destination) == checksum:
+        os.chmod(destination, 0o600)
+        return
+    fd, candidate_name = tempfile.mkstemp(
+        prefix=destination.name + ".",
+        suffix=".candidate",
+        dir=str(destination.parent),
+    )
+    candidate = Path(candidate_name)
+    try:
+        with os.fdopen(fd, "wb") as target_handle, source.open("rb") as source_handle:
+            shutil.copyfileobj(source_handle, target_handle, length=1024 * 1024)
+            target_handle.flush()
+            os.fsync(target_handle.fileno())
+        os.chmod(candidate, 0o600)
+        if _sha256(candidate) != checksum:
+            raise ValueError(f"staged archive checksum verification failed: {source}")
+        os.replace(candidate, destination)
+    finally:
+        candidate.unlink(missing_ok=True)
+
+
+def _write_record(path: Path, record: dict[str, Any]) -> None:
+    from hyops.runtime.state import write_json_atomic
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    write_json_atomic(path, record, mode=0o600)
+
+
+def _bundle_id(primary_checksum: str, node_checksum: str) -> str:
+    identity = f"{primary_checksum}:{node_checksum}".encode("ascii")
+    return hashlib.sha256(identity).hexdigest()[:16]
+
+
+def stage_migration_archive(
+    *,
+    paths,
+    payload: dict[str, Any],
+    platform: str,
+    archive: str | Path,
+    node_state: str | Path | None = None,
+    expected_sha256: str = "",
+    node_state_expected_sha256: str = "",
+    force: bool = False,
+) -> dict[str, Any]:
+    platform_name = str(platform or "").strip().lower()
+    target_platform = platform_for_blueprint(payload)
+    if platform_name != target_platform:
+        raise ValueError(
+            f"source platform {platform_name} does not match target blueprint platform "
+            f"{target_platform}"
+        )
+    inspection = inspect_migration_archive(
+        platform=platform_name,
+        archive=archive,
+        node_state=node_state,
+        expected_sha256=expected_sha256,
+        node_state_expected_sha256=node_state_expected_sha256,
+    )
+
+    blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
+    record_path = migration_record_path(paths, blueprint_ref)
+    existing: dict[str, Any] | None = None
+    if record_path.is_file():
+        try:
+            loaded = json.loads(record_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"migration record is unreadable: {record_path}") from exc
+        if isinstance(loaded, dict):
+            existing = loaded
+    existing_archive = (existing or {}).get("archive")
+    existing_checksum = (
+        str(existing_archive.get("sha256") or "")
+        if isinstance(existing_archive, dict)
+        else ""
+    )
+    node_inspection = inspection.get("node_state")
+    node_checksum = str(node_inspection.get("sha256") or "") if node_inspection else ""
+    existing_node = (existing or {}).get("node_state")
+    existing_node_checksum = (
+        str(existing_node.get("sha256") or "") if isinstance(existing_node, dict) else ""
+    )
+    if existing and (existing_checksum, existing_node_checksum) != (
+        inspection["archive"]["sha256"],
+        node_checksum,
+    ) and not force:
+        raise ValueError(
+            "a different migration bundle is already staged for this blueprint; "
+            "use --force to replace the active record"
+        )
+
+    bundle_id = _bundle_id(inspection["archive"]["sha256"], node_checksum)
+    destination_root = (
+        paths.root / "artifacts" / "lab-migrations" / _record_slug(blueprint_ref) / bundle_id
+    )
+    archive_destination = destination_root / "labs.tar.gz"
+    copy_bytes = 0
+    if not (
+        archive_destination.is_file()
+        and _sha256(archive_destination) == inspection["archive"]["sha256"]
+    ):
+        copy_bytes += int(inspection["archive"]["size_bytes"])
+    if node_inspection:
+        node_destination = destination_root / "labs.node-state.tar.gz"
+        if not (
+            node_destination.is_file()
+            and _sha256(node_destination) == node_inspection["sha256"]
+        ):
+            copy_bytes += int(node_inspection["size_bytes"])
+    if copy_bytes:
+        _require_disk_space(destination_root, copy_bytes, "migration import")
+
+    _copy_verified(
+        Path(inspection["archive"]["path"]),
+        archive_destination,
+        inspection["archive"]["sha256"],
+    )
+
+    staged_node: dict[str, Any] | None = None
+    if node_inspection:
+        _copy_verified(
+            Path(node_inspection["path"]),
+            node_destination,
+            node_inspection["sha256"],
+        )
+        staged_node = {
+            key: value for key, value in node_inspection.items() if key != "path"
+        }
+        staged_node["path"] = str(node_destination)
+
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": RECORD_KIND,
+        "status": "verified",
+        "imported_at": _utc_now(),
+        "platform": platform_name,
+        "blueprint_ref": blueprint_ref,
+        "archive": {
+            key: value for key, value in inspection["archive"].items() if key != "path"
+        },
+        "node_state": staged_node,
+        "definition_count": inspection["definition_count"],
+        "image_references": inspection["image_references"],
+        "images_included": inspection["images_included"],
+        "warnings": inspection["warnings"],
+    }
+    record["archive"]["path"] = str(archive_destination)
+    if existing and (existing_checksum, existing_node_checksum) != (
+        record["archive"]["sha256"],
+        node_checksum,
+    ):
+        record["supersedes"] = {
+            "archive_sha256": existing_checksum,
+            "node_state_sha256": existing_node_checksum,
+            "imported_at": str(existing.get("imported_at") or ""),
+        }
+    _write_record(record_path, record)
+    return record
+
+
+def _verified_staged_file(
+    *,
+    paths,
+    value: Any,
+    checksum: Any,
+    field: str,
+) -> tuple[Path, str]:
+    path = Path(str(value or "")).expanduser().resolve()
+    allowed = (paths.root / "artifacts" / "lab-migrations").resolve()
+    try:
+        path.relative_to(allowed)
+    except ValueError as exc:
+        raise ValueError(f"{field} is outside the migration artifact root") from exc
+    expected = str(checksum or "").strip().lower()
+    if not path.is_file() or not _SHA256_RE.fullmatch(expected):
+        raise ValueError(f"{field} is missing or unverifiable")
+    if _sha256(path) != expected:
+        raise ValueError(f"{field} checksum verification failed: {path}")
+    return path, expected
+
+
+def load_migration_archive(
+    *,
+    paths,
+    payload: dict[str, Any],
+) -> tuple[Path, str, Path | None, str] | None:
+    blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
+    path = migration_record_path(paths, blueprint_ref)
+    if not path.is_file():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"migration record is unreadable: {path}") from exc
+    if not isinstance(record, dict):
+        raise ValueError(f"migration record is invalid: {path}")
+    if record.get("schema_version") != SCHEMA_VERSION or record.get("kind") != RECORD_KIND:
+        raise ValueError(f"migration record has an unsupported schema: {path}")
+    if record.get("status") != "verified":
+        raise ValueError(f"migration record is not verified: {path}")
+    if str(record.get("blueprint_ref") or "") != blueprint_ref:
+        raise ValueError(f"migration record blueprint does not match {blueprint_ref}")
+    platform = str(record.get("platform") or "")
+    if platform != platform_for_blueprint(payload):
+        raise ValueError("migration record platform does not match the target blueprint")
+
+    archive_data = record.get("archive")
+    if not isinstance(archive_data, dict):
+        raise ValueError(f"migration record has no archive: {path}")
+    archive_path, checksum = _verified_staged_file(
+        paths=paths,
+        value=archive_data.get("path"),
+        checksum=archive_data.get("sha256"),
+        field="migration archive",
+    )
+
+    node_path: Path | None = None
+    node_checksum = ""
+    node_data = record.get("node_state")
+    if node_data is not None:
+        if platform != "eve-ng":
+            raise ValueError(f"migration node-state record is invalid: {path}")
+        if not isinstance(node_data, dict):
+            raise ValueError(f"migration node-state record is invalid: {path}")
+        node_path, node_checksum = _verified_staged_file(
+            paths=paths,
+            value=node_data.get("path"),
+            checksum=node_data.get("sha256"),
+            field="migration node-state archive",
+        )
+    return archive_path, checksum, node_path, node_checksum

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -1914,33 +1914,84 @@ def _publish_containerlab_latest(
     }
 
 
-def _copy_verified(source: Path, destination: Path, checksum: str) -> None:
+def _copy_verified(
+    source: Path,
+    destination: Path,
+    checksum: str,
+    *,
+    stage: str,
+    progress: CaptureProgress | None = None,
+) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     os.chmod(destination.parent, 0o700)
     if destination.is_symlink():
         raise ValueError(f"staged archive must not be a symbolic link: {destination}")
     if destination.exists() and not destination.is_file():
         raise ValueError(f"staged archive is not a regular file: {destination}")
-    if destination.is_file() and _sha256(destination) == checksum:
-        os.chmod(destination, 0o600)
-        return
-    fd, candidate_name = tempfile.mkstemp(
-        prefix=destination.name + ".",
-        suffix=".candidate",
-        dir=str(destination.parent),
-    )
-    candidate = Path(candidate_name)
+    total = source.stat().st_size
+    started = time.monotonic()
+    written = 0
+    finished = False
+
+    def emit(phase: str, *, status: str = "running") -> None:
+        if progress is None:
+            return
+        elapsed = max(0.0, time.monotonic() - started)
+        progress(
+            {
+                "phase": phase,
+                "stage": stage,
+                "status": status,
+                "bytes_written": written,
+                "total_bytes": total,
+                "elapsed_seconds": elapsed,
+                "bytes_per_second": written / elapsed if elapsed > 0 else 0.0,
+            }
+        )
+
+    emit("stage_started")
     try:
-        with os.fdopen(fd, "wb") as target_handle, source.open("rb") as source_handle:
-            shutil.copyfileobj(source_handle, target_handle, length=1024 * 1024)
-            target_handle.flush()
-            os.fsync(target_handle.fileno())
-        os.chmod(candidate, 0o600)
-        if _sha256(candidate) != checksum:
-            raise ValueError(f"staged archive checksum verification failed: {source}")
-        os.replace(candidate, destination)
-    finally:
-        candidate.unlink(missing_ok=True)
+        if destination.is_file() and _sha256(destination) == checksum:
+            written = total
+            os.chmod(destination, 0o600)
+            emit("stage_finished", status="skipped")
+            finished = True
+            return
+
+        fd, candidate_name = tempfile.mkstemp(
+            prefix=destination.name + ".",
+            suffix=".candidate",
+            dir=str(destination.parent),
+        )
+        candidate = Path(candidate_name)
+        try:
+            last_update = started
+            with os.fdopen(fd, "wb") as target_handle, source.open("rb") as source_handle:
+                while chunk := source_handle.read(1024 * 1024):
+                    target_handle.write(chunk)
+                    written += len(chunk)
+                    now = time.monotonic()
+                    if now - last_update >= 1.0:
+                        emit("stage_progress")
+                        last_update = now
+                emit("stage_progress")
+                target_handle.flush()
+                os.fsync(target_handle.fileno())
+            os.chmod(candidate, 0o600)
+            emit("stage_verifying")
+            if _sha256(candidate) != checksum:
+                raise ValueError(
+                    f"staged archive checksum verification failed: {source}"
+                )
+            os.replace(candidate, destination)
+        finally:
+            candidate.unlink(missing_ok=True)
+        emit("stage_finished", status="ok")
+        finished = True
+    except Exception:
+        if not finished:
+            emit("stage_finished", status="failed")
+        raise
 
 
 def _write_record(path: Path, record: dict[str, Any]) -> None:
@@ -1972,6 +2023,7 @@ def stage_migration_archive(
     node_state_expected_sha256: str = "",
     images_expected_sha256: str = "",
     force: bool = False,
+    progress: CaptureProgress | None = None,
 ) -> dict[str, Any]:
     platform_name = str(platform or "").strip().lower()
     target_platform = platform_for_blueprint(payload)
@@ -1979,15 +2031,36 @@ def stage_migration_archive(
         raise ValueError(
             f"source platform {platform_name} does not match target blueprint platform {target_platform}"
         )
-    inspection = inspect_migration_archive(
-        platform=platform_name,
-        archive=archive,
-        node_state=node_state,
-        images=images,
-        expected_sha256=expected_sha256,
-        node_state_expected_sha256=node_state_expected_sha256,
-        images_expected_sha256=images_expected_sha256,
-    )
+    if progress is not None:
+        progress({"phase": "import_verification_started", "stage": "verification"})
+    try:
+        inspection = inspect_migration_archive(
+            platform=platform_name,
+            archive=archive,
+            node_state=node_state,
+            images=images,
+            expected_sha256=expected_sha256,
+            node_state_expected_sha256=node_state_expected_sha256,
+            images_expected_sha256=images_expected_sha256,
+        )
+    except Exception:
+        if progress is not None:
+            progress(
+                {
+                    "phase": "import_verification_finished",
+                    "stage": "verification",
+                    "status": "failed",
+                }
+            )
+        raise
+    if progress is not None:
+        progress(
+            {
+                "phase": "import_verification_finished",
+                "stage": "verification",
+                "status": "ok",
+            }
+        )
     containerlab_metadata = inspection.get("containerlab")
     if platform_name == "containerlab":
         if not isinstance(containerlab_metadata, dict):
@@ -2100,6 +2173,8 @@ def stage_migration_archive(
         Path(inspection["archive"]["path"]),
         archive_destination,
         inspection["archive"]["sha256"],
+        stage="lab_definitions",
+        progress=progress,
     )
 
     staged_node: dict[str, Any] | None = None
@@ -2108,6 +2183,8 @@ def stage_migration_archive(
             Path(node_inspection["path"]),
             node_destination,
             node_inspection["sha256"],
+            stage="node_state",
+            progress=progress,
         )
         staged_node = {
             key: value for key, value in node_inspection.items() if key != "path"
@@ -2120,6 +2197,8 @@ def stage_migration_archive(
             Path(image_inspection["path"]),
             image_destination,
             image_inspection["sha256"],
+            stage="referenced_images",
+            progress=progress,
         )
         staged_images = {
             key: value for key, value in image_inspection.items() if key != "path"

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -52,14 +52,28 @@ def _available_disk_bytes(path: Path) -> int:
     return shutil.disk_usage(_existing_filesystem_path(path)).free
 
 
+def _format_bytes(value: int) -> str:
+    size = max(0, int(value))
+    for unit, divisor in (
+        ("TiB", 1024**4),
+        ("GiB", 1024**3),
+        ("MiB", 1024**2),
+        ("KiB", 1024),
+    ):
+        if size >= divisor:
+            return f"{size / divisor:.1f} {unit} ({size} bytes)"
+    return f"{size} bytes"
+
+
 def _require_disk_space(path: Path, payload_bytes: int, operation: str) -> None:
     filesystem_path = _existing_filesystem_path(path)
     available = shutil.disk_usage(filesystem_path).free
     required = int(payload_bytes) + _FREE_SPACE_RESERVE_BYTES
     if available < required:
         raise ValueError(
-            f"insufficient disk space for {operation}: required {required} bytes, "
-            f"available {available} bytes on the filesystem containing "
+            f"insufficient disk space for {operation}: "
+            f"required {_format_bytes(required)}, "
+            f"available {_format_bytes(available)} on the filesystem containing "
             f"{filesystem_path}"
         )
 
@@ -144,8 +158,14 @@ def _eve_image_references(
 ) -> list[str]:
     references: set[str] = set()
     for member in definitions:
+        definition = _read_definition(handle, member)
+        if re.search(br"<!\s*(?:DOCTYPE|ENTITY)\b", definition, flags=re.IGNORECASE):
+            raise ValueError(
+                f"EVE-NG lab definition contains a DTD or entity declaration: "
+                f"{member.name}"
+            )
         try:
-            root = ET.fromstring(_read_definition(handle, member))
+            root = ET.fromstring(definition)
         except ET.ParseError as exc:
             raise ValueError(f"invalid EVE-NG lab definition: {member.name}") from exc
         for element in root.iter():
@@ -410,6 +430,57 @@ required=$(du -s --block-size=1 "$@" | awk '{{total += $1}} END {{printf "%.0f\\
 """
 
 
+def _remote_capture_assessment_script(
+    platform: str,
+    *,
+    include_node_state: bool = False,
+    include_images: bool = False,
+) -> str:
+    if platform == "eve-ng":
+        node_state_assessment = "node_state_bytes=0"
+        if include_node_state:
+            node_state_assessment = """node_root=/opt/unetlab/tmp
+test -d "$node_root" || { echo 'EVE-NG node-state root not found' >&2; exit 20; }
+cd "$node_root"
+find . -type f -name '*.qcow2' -printf '%P\\n' -quit | grep -q . || {
+  echo 'No EVE-NG QEMU node state was found' >&2
+  exit 22
+}
+node_state_bytes=$(find . -type f -name '*.qcow2' -printf '%b\\n' | awk '{total += $1} END {printf "%.0f\\n", total * 512}')"""
+        return f"""set -eu
+root=/opt/unetlab/labs
+test -d "$root" || {{ echo 'EVE-NG labs root not found' >&2; exit 20; }}
+if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then
+  echo 'EVE-NG QEMU nodes are running; stop them before capture' >&2
+  exit 21
+fi
+find "$root" -type f -name '*.unl' -print -quit | grep -q . || {{
+  echo 'No EVE-NG lab definitions were found' >&2
+  exit 22
+}}
+primary_bytes=$(find "$root" -type f -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
+{node_state_assessment}
+printf 'primary_bytes=%s\\nnode_state_bytes=%s\\n' "$primary_bytes" "$node_state_bytes"
+"""
+
+    image_member = " images" if include_images else ""
+    return f"""set -eu
+root=/var/lib/gns3
+test -d "$root/projects" || {{ echo 'GNS3 projects root not found' >&2; exit 20; }}
+if pgrep -af '[g]ns3server' >/dev/null; then
+  echo 'GNS3 is running; stop it before capture' >&2
+  exit 21
+fi
+cd "$root"
+set -- projects
+for member in appliances symbols .config/GNS3{image_member}; do
+  test -e "$root/$member" && set -- "$@" "$member"
+done
+primary_bytes=$(du -s --block-size=1 "$@" | awk '{{total += $1}} END {{printf "%.0f\\n", total}}')
+printf 'primary_bytes=%s\\nnode_state_bytes=0\\n' "$primary_bytes"
+"""
+
+
 def _ssh_capture_argv(
     *,
     host: str,
@@ -418,6 +489,7 @@ def _ssh_capture_argv(
     identity_file: str | Path | None,
     become: bool,
     script: str,
+    control_path: Path | None = None,
 ) -> list[str]:
     host_name = _ssh_name(host, "host")
     user_name = _ssh_name(user, "user") if user else ""
@@ -425,11 +497,107 @@ def _ssh_capture_argv(
         raise ValueError("SSH port must be between 1 and 65535")
     target = f"{user_name}@{host_name}" if user_name else host_name
     argv = ["ssh", "-T", "-p", str(port)]
+    if control_path is not None:
+        argv.extend(
+            [
+                "-o",
+                "ControlMaster=auto",
+                "-o",
+                "ControlPersist=30",
+                "-o",
+                f"ControlPath={control_path}",
+            ]
+        )
     if identity_file:
         identity = _regular_file(identity_file, "identity file")
         argv.extend(["-i", str(identity)])
     remote = ["sudo", "-n", "sh", "-c", script] if become else ["sh", "-c", script]
     return [*argv, target, shlex.join(remote)]
+
+
+def _capture_error(result: subprocess.CompletedProcess[bytes]) -> ValueError:
+    detail = result.stderr.decode("utf-8", errors="replace").strip()
+    lowered_detail = detail.lower()
+    if "no space left on device" in lowered_detail or "disk quota exceeded" in lowered_detail:
+        return ValueError(
+            "insufficient disk space for lab capture: the output filesystem "
+            "became full while writing the archive"
+        )
+    capacity_match = re.search(
+        r"source requires at least (\d+) bytes; "
+        r"output filesystem has (\d+) bytes available",
+        detail,
+        flags=re.IGNORECASE,
+    )
+    if capacity_match:
+        required = int(capacity_match.group(1))
+        available = int(capacity_match.group(2))
+        return ValueError(
+            "insufficient disk space for lab capture: source requires at least "
+            f"{_format_bytes(required)}; output filesystem has "
+            f"{_format_bytes(available)} available"
+        )
+    lines = [line.strip() for line in detail.splitlines() if line.strip()]
+    concise = "; ".join(lines[-3:])[-800:] or f"ssh exited with status {result.returncode}"
+    return ValueError(f"source capture failed: {concise}")
+
+
+def _capture_requirements(argv: list[str]) -> dict[str, int]:
+    try:
+        result = subprocess.run(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError("ssh is not installed or is not available on PATH") from exc
+    if result.returncode != 0:
+        raise _capture_error(result)
+
+    values: dict[str, int] = {}
+    for raw_line in result.stdout.decode("utf-8", errors="replace").splitlines():
+        key, separator, raw_value = raw_line.strip().partition("=")
+        if not separator or key not in {"primary_bytes", "node_state_bytes"}:
+            raise ValueError("source capture assessment returned invalid output")
+        if key in values:
+            raise ValueError("source capture assessment returned a duplicate size")
+        if not raw_value.isdigit():
+            raise ValueError("source capture assessment returned an invalid size")
+        values[key] = int(raw_value)
+    if "primary_bytes" not in values or "node_state_bytes" not in values:
+        raise ValueError("source capture assessment did not return required sizes")
+    return values
+
+
+def _close_ssh_control(
+    *,
+    host: str,
+    user: str,
+    port: int,
+    control_path: Path,
+) -> None:
+    host_name = _ssh_name(host, "host")
+    user_name = _ssh_name(user, "user") if user else ""
+    target = f"{user_name}@{host_name}" if user_name else host_name
+    try:
+        subprocess.run(
+            [
+                "ssh",
+                "-O",
+                "exit",
+                "-S",
+                str(control_path),
+                "-p",
+                str(port),
+                target,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except FileNotFoundError:
+        pass
 
 
 def _capture_stream(argv: list[str], candidate: Path) -> None:
@@ -448,16 +616,31 @@ def _capture_stream(argv: list[str], candidate: Path) -> None:
     if result.returncode == 0:
         os.chmod(candidate, 0o600)
         return
-    detail = result.stderr.decode("utf-8", errors="replace").strip()
-    lowered_detail = detail.lower()
-    if "no space left on device" in lowered_detail or "disk quota exceeded" in lowered_detail:
-        raise ValueError(
-            "insufficient disk space for lab capture: the output filesystem "
-            "became full while writing the archive"
+    raise _capture_error(result)
+
+
+def _require_capture_capacity(
+    *,
+    destination: Path,
+    primary_bytes: int,
+    node_destination: Path | None,
+    node_state_bytes: int,
+) -> None:
+    if node_destination is None:
+        _require_disk_space(destination.parent, primary_bytes, "lab capture")
+        return
+
+    primary_filesystem = _existing_filesystem_path(destination.parent)
+    node_filesystem = _existing_filesystem_path(node_destination.parent)
+    if primary_filesystem.stat().st_dev == node_filesystem.stat().st_dev:
+        _require_disk_space(
+            destination.parent,
+            primary_bytes + node_state_bytes,
+            "lab capture",
         )
-    lines = [line.strip() for line in detail.splitlines() if line.strip()]
-    concise = "; ".join(lines[-3:])[-800:] or f"ssh exited with status {result.returncode}"
-    raise ValueError(f"source capture failed: {concise}")
+        return
+    _require_disk_space(destination.parent, primary_bytes, "lab capture")
+    _require_disk_space(node_destination.parent, node_state_bytes, "node-state capture")
 
 
 def _capture_destination(raw: str | Path, field: str) -> Path:
@@ -535,10 +718,38 @@ def capture_existing_lab(
 
     primary_candidate: Path | None = None
     node_candidate: Path | None = None
+    control_root = Path(
+        tempfile.mkdtemp(
+            prefix="hyops-ssh-",
+            dir="/tmp" if Path("/tmp").is_dir() else None,
+        )
+    )
+    os.chmod(control_root, 0o700)
+    control_path = control_root / "control"
     try:
         primary_candidate = _capture_candidate(destination, force)
         if node_destination is not None:
             node_candidate = _capture_candidate(node_destination, force)
+        assessment_argv = _ssh_capture_argv(
+            host=host,
+            user=user,
+            port=port,
+            identity_file=identity_file,
+            become=become,
+            script=_remote_capture_assessment_script(
+                platform_name,
+                include_node_state=include_node_state,
+                include_images=include_images,
+            ),
+            control_path=control_path,
+        )
+        requirements = _capture_requirements(assessment_argv)
+        _require_capture_capacity(
+            destination=destination,
+            primary_bytes=requirements["primary_bytes"],
+            node_destination=node_destination,
+            node_state_bytes=requirements["node_state_bytes"],
+        )
         primary_argv = _ssh_capture_argv(
             host=host,
             user=user,
@@ -550,6 +761,7 @@ def capture_existing_lab(
                 include_images=include_images,
                 output_available_bytes=_available_disk_bytes(destination.parent),
             ),
+            control_path=control_path,
         )
         _capture_stream(primary_argv, primary_candidate)
         if node_candidate is not None:
@@ -566,6 +778,7 @@ def capture_existing_lab(
                         node_destination.parent
                     ),
                 ),
+                control_path=control_path,
             )
             _capture_stream(node_argv, node_candidate)
 
@@ -583,10 +796,17 @@ def capture_existing_lab(
         report["source"] = {"host": host, "user": user or None}
         return report
     finally:
+        _close_ssh_control(
+            host=host,
+            user=user,
+            port=port,
+            control_path=control_path,
+        )
         if primary_candidate is not None:
             primary_candidate.unlink(missing_ok=True)
         if node_candidate is not None:
             node_candidate.unlink(missing_ok=True)
+        shutil.rmtree(control_root, ignore_errors=True)
 
 
 def platform_for_blueprint(payload: dict[str, Any]) -> str:

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -1230,17 +1230,20 @@ if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then
   exit 21
 fi
 cd "$root"
-find . -type f -name '*.qcow2' -printf '%P\\n' -quit | grep -q . || {{
+find . -mindepth 4 -maxdepth 4 -type f -name '*.qcow2' \
+  -printf '%P\\n' -quit | grep -q . || {{
   echo 'No EVE-NG QEMU node state was found' >&2
   exit 22
 }}
-required=$(find . -type f -name '*.qcow2' -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
+required=$(find . -mindepth 4 -maxdepth 4 -type f -name '*.qcow2' \
+  -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
 {capacity_check}{compressor}
 metadata_dir=$(mktemp -d)
 trap 'find "$metadata_dir" -depth -delete' EXIT
 mkdir -p "$metadata_dir/hybridops"
 printf '%s\\n' {shlex.quote(metadata)} > "$metadata_dir/{_EVE_NODE_STATE_METADATA}"
-find . -type f -name '*.qcow2' -printf '%P\\n' | sort > "$metadata_dir/members.txt"
+find . -mindepth 4 -maxdepth 4 -type f -name '*.qcow2' \
+  -printf '%P\\n' | sort > "$metadata_dir/members.txt"
 tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
   --sparse -I "$compressor" -cf - -C "$root" -T "$metadata_dir/members.txt" \
   -C "$metadata_dir" {_EVE_NODE_STATE_METADATA}
@@ -1325,11 +1328,13 @@ printf 'primary_bytes=%s\nnode_state_bytes=0\nimage_bytes=0\n' "$primary_bytes"
             node_state_assessment = """node_root=/opt/unetlab/tmp
 test -d "$node_root" || { echo 'EVE-NG node-state root not found' >&2; exit 20; }
 cd "$node_root"
-find . -type f -name '*.qcow2' -printf '%P\\n' -quit | grep -q . || {
+find . -mindepth 4 -maxdepth 4 -type f -name '*.qcow2' \
+  -printf '%P\\n' -quit | grep -q . || {
   echo 'No EVE-NG QEMU node state was found' >&2
   exit 22
 }
-node_state_bytes=$(find . -type f -name '*.qcow2' -printf '%b\\n' | awk '{total += $1} END {printf "%.0f\\n", total * 512}')"""
+node_state_bytes=$(find . -mindepth 4 -maxdepth 4 -type f -name '*.qcow2' \
+  -printf '%b\\n' | awk '{total += $1} END {printf "%.0f\\n", total * 512}')"""
         running_node_check = ""
         if not allow_running_eve_nodes:
             running_node_check = """if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -24,10 +24,13 @@ RECORD_KIND = "hybridops/lab-migration"
 SUPPORTED_PLATFORMS = ("eve-ng", "gns3", "containerlab")
 CaptureProgress = Callable[[dict[str, Any]], None]
 _MAX_DEFINITION_BYTES = 32 * 1024 * 1024
+_MAX_QUIESCENCE_SCRIPT_BYTES = 1024 * 1024
 _MAX_MEMBERS = 200_000
 _FREE_SPACE_RESERVE_BYTES = 64 * 1024 * 1024
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _EVE_NODE_STATE_RE = re.compile(r"^[0-9]+/[^/]+/[0-9]+/[^/]+\.qcow2$")
+_EVE_NODE_STATE_METADATA = "hybridops/capture.json"
+_EVE_NODE_STATE_METADATA_SCHEMA = "hybridops.eve-node-state-capture/v1"
 _SSH_HOST_RE = re.compile(r"^[a-zA-Z0-9_.:-]+$")
 _SSH_USER_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
 _EVE_IMAGE_CAPTURE_PROGRAM = r"""
@@ -845,18 +848,84 @@ def _inspect_eve_node_state(path: Path) -> dict[str, Any]:
             files = [name for member, name in members if member.isfile()]
             if not files:
                 raise ValueError("EVE-NG node-state archive contains no files")
-            invalid = [name for name in files if not _EVE_NODE_STATE_RE.fullmatch(name)]
+            overlays = [name for name in files if _EVE_NODE_STATE_RE.fullmatch(name)]
+            invalid = [
+                name
+                for name in files
+                if name != _EVE_NODE_STATE_METADATA
+                and not _EVE_NODE_STATE_RE.fullmatch(name)
+            ]
             if invalid:
                 raise ValueError(
                     f"EVE-NG node-state member has an invalid path: {invalid[0]}"
                 )
-            return {
+            if not overlays:
+                raise ValueError("EVE-NG node-state archive contains no overlays")
+
+            report: dict[str, Any] = {
                 "expanded_size_bytes": sum(
                     member.size for member, _ in members if member.isfile()
                 ),
                 "member_count": len(members),
-                "overlay_count": len(files),
+                "overlay_count": len(overlays),
+                "capture_consistency": "unrecorded",
             }
+            metadata_member = next(
+                (
+                    member
+                    for member, name in members
+                    if name == _EVE_NODE_STATE_METADATA
+                ),
+                None,
+            )
+            if metadata_member is None:
+                return report
+            try:
+                metadata = json.loads(_read_definition(handle, metadata_member))
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                raise ValueError(
+                    "EVE-NG node-state capture metadata is invalid"
+                ) from exc
+            if not isinstance(metadata, dict) or metadata.get("schema") != (
+                _EVE_NODE_STATE_METADATA_SCHEMA
+            ):
+                raise ValueError(
+                    "EVE-NG node-state capture metadata schema is unsupported"
+                )
+            quiescence = metadata.get("quiescence")
+            if not isinstance(quiescence, dict):
+                raise ValueError(
+                    "EVE-NG node-state capture metadata has no quiescence record"
+                )
+            method = str(quiescence.get("method") or "").strip()
+            if method not in {"operator-attestation", "operator-script"}:
+                raise ValueError(
+                    "EVE-NG node-state capture metadata has an invalid quiescence method"
+                )
+            if quiescence.get("qemu_processes_absent") is not True:
+                raise ValueError(
+                    "EVE-NG node-state capture metadata does not verify stopped QEMU processes"
+                )
+            verified_at = str(quiescence.get("verified_at") or "").strip()
+            script_sha256 = str(quiescence.get("script_sha256") or "").strip()
+            if method == "operator-script" and not _SHA256_RE.fullmatch(
+                script_sha256
+            ):
+                raise ValueError(
+                    "EVE-NG node-state capture metadata has an invalid script checksum"
+                )
+            if method == "operator-attestation" and script_sha256:
+                raise ValueError(
+                    "EVE-NG node-state attestation must not contain a script checksum"
+                )
+            report["capture_consistency"] = "guest-quiesced"
+            report["quiescence"] = {
+                "method": method,
+                "qemu_processes_absent": True,
+                "verified_at": verified_at or None,
+                "script_sha256": script_sha256 or None,
+            }
+            return report
     except tarfile.TarError as exc:
         raise ValueError(
             f"node-state archive is not a readable tar archive: {path}"
@@ -1035,6 +1104,14 @@ def inspect_migration_archive(
             warnings.append("referenced base images must be available on the target")
     if platform_name == "eve-ng" and node_report is None:
         warnings.append("writable QEMU node state is not included")
+    elif (
+        platform_name == "eve-ng"
+        and isinstance(node_report, dict)
+        and node_report.get("capture_consistency") != "guest-quiesced"
+    ):
+        warnings.append(
+            "node-state archive has no verified guest-quiescence evidence"
+        )
     containerlab_metadata = primary.get("containerlab")
     if (
         platform_name == "containerlab"
@@ -1079,6 +1156,7 @@ def _remote_capture_script(
     source_labdir_base: str = "",
     target_labdir_base: str = "",
     output_available_bytes: int,
+    node_state_evidence: dict[str, Any] | None = None,
 ) -> str:
     usable_bytes = max(0, output_available_bytes - _FREE_SPACE_RESERVE_BYTES)
     capacity_check = f"""available={output_available_bytes}
@@ -1134,6 +1212,16 @@ required=$({assessment_command})
 {capacity_check}exec {image_command}
 """
         if node_state:
+            persisted_evidence = dict(node_state_evidence or {})
+            persisted_evidence.pop("verified_at", None)
+            metadata = json.dumps(
+                {
+                    "schema": _EVE_NODE_STATE_METADATA_SCHEMA,
+                    "quiescence": persisted_evidence,
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            )
             return f"""set -eu
 root=/opt/unetlab/tmp
 test -d "$root" || {{ echo 'EVE-NG node-state root not found' >&2; exit 20; }}
@@ -1148,9 +1236,14 @@ find . -type f -name '*.qcow2' -printf '%P\\n' -quit | grep -q . || {{
 }}
 required=$(find . -type f -name '*.qcow2' -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
 {capacity_check}{compressor}
-find . -type f -name '*.qcow2' -printf '%P\\0' | sort -z | \
-  tar --null --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
-  --sparse -I "$compressor" -cf - --files-from=-
+metadata_dir=$(mktemp -d)
+trap 'find "$metadata_dir" -depth -delete' EXIT
+mkdir -p "$metadata_dir/hybridops"
+printf '%s\\n' {shlex.quote(metadata)} > "$metadata_dir/{_EVE_NODE_STATE_METADATA}"
+find . -type f -name '*.qcow2' -printf '%P\\n' | sort > "$metadata_dir/members.txt"
+tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+  --sparse -I "$compressor" -cf - -C "$root" -T "$metadata_dir/members.txt" \
+  -C "$metadata_dir" {_EVE_NODE_STATE_METADATA}
 """
         return f"""set -eu
 root=/opt/unetlab/labs
@@ -1199,6 +1292,7 @@ def _remote_capture_assessment_script(
     topology_relpath: str = "",
     source_labdir_base: str = "",
     target_labdir_base: str = "",
+    allow_running_eve_nodes: bool = False,
 ) -> str:
     if platform == "containerlab":
         assessment_command = " ".join(
@@ -1236,14 +1330,17 @@ find . -type f -name '*.qcow2' -printf '%P\\n' -quit | grep -q . || {
   exit 22
 }
 node_state_bytes=$(find . -type f -name '*.qcow2' -printf '%b\\n' | awk '{total += $1} END {printf "%.0f\\n", total * 512}')"""
-        return f"""set -eu
-root=/opt/unetlab/labs
-test -d "$root" || {{ echo 'EVE-NG labs root not found' >&2; exit 20; }}
-if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then
+        running_node_check = ""
+        if not allow_running_eve_nodes:
+            running_node_check = """if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then
   echo 'EVE-NG QEMU nodes are running; stop them before capture' >&2
   exit 21
 fi
-find "$root" -type f -name '*.unl' -print -quit | grep -q . || {{
+"""
+        return f"""set -eu
+root=/opt/unetlab/labs
+test -d "$root" || {{ echo 'EVE-NG labs root not found' >&2; exit 20; }}
+{running_node_check}find "$root" -type f -name '*.unl' -print -quit | grep -q . || {{
   echo 'No EVE-NG lab definitions were found' >&2
   exit 22
 }}
@@ -1281,6 +1378,29 @@ def _ssh_capture_argv(
     script: str,
     control_path: Path | None = None,
 ) -> list[str]:
+    argv, target = _ssh_argv(
+        host=host,
+        user=user,
+        port=port,
+        identity_file=identity_file,
+        control_path=control_path,
+    )
+    remote = (
+        ["sudo", "-n", "sh", "-c", script]
+        if become
+        else ["sh", "-c", script]
+    )
+    return [*argv, target, shlex.join(remote)]
+
+
+def _ssh_argv(
+    *,
+    host: str,
+    user: str,
+    port: int,
+    identity_file: str | Path | None,
+    control_path: Path | None = None,
+) -> tuple[list[str], str]:
     host_name = _ssh_name(host, "host")
     user_name = _ssh_name(user, "user") if user else ""
     if not 1 <= int(port) <= 65535:
@@ -1301,8 +1421,151 @@ def _ssh_capture_argv(
     if identity_file:
         identity = _regular_file(identity_file, "identity file")
         argv.extend(["-i", str(identity)])
-    remote = ["sudo", "-n", "sh", "-c", script] if become else ["sh", "-c", script]
-    return [*argv, target, shlex.join(remote)]
+    return argv, target
+
+
+def _read_quiescence_script(raw: str | Path) -> tuple[bytes, str]:
+    path = _regular_file(raw, "quiescence script")
+    size = path.stat().st_size
+    if size == 0:
+        raise ValueError("quiescence script is empty")
+    if size > _MAX_QUIESCENCE_SCRIPT_BYTES:
+        raise ValueError("quiescence script exceeds the 1 MiB limit")
+    payload = path.read_bytes()
+    if b"\x00" in payload:
+        raise ValueError("quiescence script contains a NUL byte")
+    return payload, hashlib.sha256(payload).hexdigest()
+
+
+def _run_quiescence_script(
+    *,
+    host: str,
+    user: str,
+    port: int,
+    identity_file: str | Path | None,
+    become: bool,
+    payload: bytes,
+    script_sha256: str,
+    timeout_s: int,
+    control_path: Path,
+    progress: CaptureProgress | None,
+) -> dict[str, Any]:
+    if progress is not None:
+        progress({"phase": "quiescence_started", "stage": "quiescence"})
+    argv, target = _ssh_argv(
+        host=host,
+        user=user,
+        port=port,
+        identity_file=identity_file,
+        control_path=control_path,
+    )
+    started_at = time.monotonic()
+    command = [
+        "timeout",
+        "--signal=TERM",
+        "--kill-after=5",
+        str(timeout_s),
+        "sh",
+        "-s",
+        "--",
+    ]
+    remote = ["sudo", "-n", *command] if become else command
+    try:
+        result = subprocess.run(
+            [*argv, target, shlex.join(remote)],
+            input=payload,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=timeout_s + 10,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError("ssh is not installed or is not available on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        if progress is not None:
+            progress(
+                {
+                    "phase": "quiescence_finished",
+                    "stage": "quiescence",
+                    "status": "failed",
+                }
+            )
+        raise ValueError(
+            "quiescence timed out; source state was not captured"
+        ) from exc
+    if result.returncode != 0:
+        if progress is not None:
+            progress(
+                {
+                    "phase": "quiescence_finished",
+                    "stage": "quiescence",
+                    "status": "failed",
+                }
+            )
+        if result.returncode in {124, 137}:
+            raise ValueError(
+                "quiescence timed out; source state was not captured"
+            )
+        raise ValueError(
+            "quiescence script failed with status "
+            f"{result.returncode}; source state was not captured"
+        )
+
+    remaining_s = max(1, int(timeout_s - (time.monotonic() - started_at)))
+    wait_script = f"""set -eu
+deadline=$(( $(date +%s) + {remaining_s} ))
+while pgrep -f '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo 'Timed out waiting for EVE-NG QEMU guests to stop' >&2
+    exit 21
+  fi
+  sleep 2
+done
+"""
+    wait_argv = _ssh_capture_argv(
+        host=host,
+        user=user,
+        port=port,
+        identity_file=identity_file,
+        become=become,
+        script=wait_script,
+        control_path=control_path,
+    )
+    result = subprocess.run(
+        wait_argv,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        if progress is not None:
+            progress(
+                {
+                    "phase": "quiescence_finished",
+                    "stage": "quiescence",
+                    "status": "failed",
+                }
+            )
+        if result.returncode == 21:
+            raise ValueError(
+                "quiescence timed out while EVE-NG QEMU guests were still running"
+            )
+        raise _capture_error(result)
+    evidence = {
+        "method": "operator-script",
+        "qemu_processes_absent": True,
+        "verified_at": _utc_now(),
+        "script_sha256": script_sha256,
+    }
+    if progress is not None:
+        progress(
+            {
+                "phase": "quiescence_finished",
+                "stage": "quiescence",
+                "status": "ok",
+            }
+        )
+    return evidence
 
 
 def _capture_error(result: subprocess.CompletedProcess[bytes]) -> ValueError:
@@ -1551,6 +1814,8 @@ def capture_existing_lab(
     become: bool = False,
     include_node_state: bool = False,
     guest_quiesced: bool = False,
+    quiesce_script: str | Path | None = None,
+    quiesce_timeout_s: int = 300,
     node_state_output: str | Path | None = None,
     include_images: bool = False,
     images_output: str | Path | None = None,
@@ -1566,14 +1831,21 @@ def capture_existing_lab(
         raise ValueError("platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS))
     if include_node_state and platform_name != "eve-ng":
         raise ValueError("separate node-state capture is only valid for EVE-NG")
+    if quiesce_script and platform_name != "eve-ng":
+        raise ValueError("--quiesce-script is only valid for EVE-NG")
     if guest_quiesced and not include_node_state:
         raise ValueError("--guest-quiesced requires --include-node-state")
-    if include_node_state and not guest_quiesced:
+    if quiesce_script and not include_node_state:
+        raise ValueError("--quiesce-script requires --include-node-state")
+    if guest_quiesced and quiesce_script:
+        raise ValueError("--guest-quiesced and --quiesce-script are mutually exclusive")
+    if include_node_state and not (guest_quiesced or quiesce_script):
         raise ValueError(
-            "EVE-NG node-state capture requires --guest-quiesced after shutting "
-            "down each stateful guest inside its operating system; stopping a "
-            "node in EVE-NG is not a clean guest shutdown"
+            "EVE-NG node-state capture requires --guest-quiesced or "
+            "--quiesce-script"
         )
+    if not 1 <= int(quiesce_timeout_s) <= 3600:
+        raise ValueError("quiescence timeout must be between 1 and 3600 seconds")
     if node_state_output and not include_node_state:
         raise ValueError("--node-state-output requires --include-node-state")
     if images_output and not (include_images and platform_name == "eve-ng"):
@@ -1595,6 +1867,12 @@ def capture_existing_lab(
         )
 
     destination = _capture_destination(output, "output")
+    quiescence_payload: bytes | None = None
+    quiescence_script_sha256 = ""
+    if quiesce_script:
+        quiescence_payload, quiescence_script_sha256 = _read_quiescence_script(
+            quiesce_script
+        )
     node_destination: Path | None = None
     image_destination: Path | None = None
     if include_node_state:
@@ -1625,6 +1903,7 @@ def capture_existing_lab(
     )
     os.chmod(control_root, 0o700)
     control_path = control_root / "control"
+    quiescence_evidence: dict[str, Any] | None = None
     try:
         primary_candidate = _capture_candidate(destination, force)
         if node_destination is not None:
@@ -1645,12 +1924,20 @@ def capture_existing_lab(
                 topology_relpath=topology_relpath,
                 source_labdir_base=source_labdir_base,
                 target_labdir_base=target_labdir_base,
+                allow_running_eve_nodes=quiescence_payload is not None,
             ),
             control_path=control_path,
         )
         if progress is not None:
             progress({"phase": "assessment_started", "stage": "assessment"})
         requirements = _capture_requirements(assessment_argv)
+        if include_node_state and quiescence_payload is None:
+            quiescence_evidence = {
+                "method": "operator-attestation",
+                "qemu_processes_absent": True,
+                "verified_at": _utc_now(),
+                "script_sha256": None,
+            }
         if progress is not None:
             progress(
                 {
@@ -1668,6 +1955,19 @@ def capture_existing_lab(
             image_destination=image_destination,
             image_bytes=requirements["image_bytes"],
         )
+        if quiescence_payload is not None:
+            quiescence_evidence = _run_quiescence_script(
+                host=host,
+                user=user,
+                port=port,
+                identity_file=identity_file,
+                become=become,
+                payload=quiescence_payload,
+                script_sha256=quiescence_script_sha256,
+                timeout_s=int(quiesce_timeout_s),
+                control_path=control_path,
+                progress=progress,
+            )
         primary_argv = _ssh_capture_argv(
             host=host,
             user=user,
@@ -1707,6 +2007,7 @@ def capture_existing_lab(
                 script=_remote_capture_script(
                     platform_name,
                     node_state=True,
+                    node_state_evidence=quiescence_evidence,
                     output_available_bytes=_available_disk_bytes(
                         node_destination.parent
                     ),
@@ -1780,6 +2081,7 @@ def capture_existing_lab(
         if isinstance(report.get("node_state"), dict) and node_destination is not None:
             report["node_state"]["path"] = str(node_destination)
             report["node_state"]["capture_consistency"] = "guest-quiesced"
+            report["node_state"]["quiescence"] = quiescence_evidence
         if isinstance(report.get("images"), dict) and image_destination is not None:
             report["images"]["path"] = str(image_destination)
         report["source"] = {"host": host, "user": user or None}

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -282,15 +282,13 @@ def _read_definition(handle: tarfile.TarFile, member: tarfile.TarInfo) -> bytes:
 def _eve_image_references(
     handle: tarfile.TarFile,
     definitions: Iterable[tarfile.TarInfo],
-) -> list[str]:
+) -> tuple[list[str], list[tuple[str, str]]]:
     references: set[str] = set()
+    requirements: set[tuple[str, str]] = set()
     for member in definitions:
         definition = _read_definition(handle, member)
-        if re.search(br"<!\s*(?:DOCTYPE|ENTITY)\b", definition, flags=re.IGNORECASE):
-            raise ValueError(
-                f"EVE-NG lab definition contains a DTD or entity declaration: "
-                f"{member.name}"
-            )
+        if re.search(rb"<!\s*(?:DOCTYPE|ENTITY)\b", definition, flags=re.IGNORECASE):
+            raise ValueError(f"EVE-NG lab definition contains a DTD or entity declaration: {member.name}")
         try:
             root = ET.fromstring(definition)
         except ET.ParseError as exc:
@@ -298,8 +296,24 @@ def _eve_image_references(
         for element in root.iter():
             image = str(element.attrib.get("image") or "").strip()
             if image:
+                if (
+                    image in {".", ".."}
+                    or PurePosixPath(image).name != image
+                    or "\\" in image
+                    or any(ord(character) < 32 for character in image)
+                ):
+                    raise ValueError(f"EVE-NG lab contains an unsafe image reference: {image}")
                 references.add(image)
-    return sorted(references)
+                node_type = str(element.attrib.get("type") or "").strip().lower()
+                if node_type == "qemu":
+                    requirements.add(("qemu", image))
+                elif node_type.startswith("iol"):
+                    requirements.add(("iol/bin", image))
+                elif node_type == "dynamips":
+                    requirements.add(("dynamips", image))
+                else:
+                    requirements.add(("*", image))
+    return sorted(references), sorted(requirements)
 
 
 def _walk_json_images(value: Any, *, key: str = "") -> Iterable[str]:
@@ -338,20 +352,17 @@ def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
             names = [name for _, name in members if name]
             files = [(member, name) for member, name in members if member.isfile()]
             if platform == "eve-ng":
-                definitions = [
-                    member for member, name in files if name.lower().endswith(".unl")
-                ]
+                definitions = [member for member, name in files if name.lower().endswith(".unl")]
                 if not definitions:
                     raise ValueError("EVE-NG archive contains no .unl lab definitions")
                 if any(name.startswith("opt/unetlab/labs/") for name in names):
-                    raise ValueError(
-                        "EVE-NG archive must be relative to /opt/unetlab/labs"
-                    )
-                references = _eve_image_references(handle, definitions)
+                    raise ValueError("EVE-NG archive must be relative to /opt/unetlab/labs")
+                references, requirements = _eve_image_references(handle, definitions)
                 return {
                     "definition_count": len(definitions),
                     "expanded_size_bytes": sum(member.size for member, _ in files),
                     "image_references": references,
+                    "image_requirements": requirements,
                     "images_included": False,
                     "member_count": len(members),
                 }
@@ -365,19 +376,11 @@ def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
             outside = sorted(
                 name
                 for name in names
-                if name.split("/", 1)[0] not in allowed_roots
-                and name != ".config/GNS3"
-                and not name.startswith(".config/GNS3/")
+                if name.split("/", 1)[0] not in allowed_roots and name != ".config/GNS3" and not name.startswith(".config/GNS3/")
             )
             if outside:
-                raise ValueError(
-                    f"GNS3 archive contains an unsupported root: {outside[0]}"
-                )
-            definitions = [
-                member
-                for member, name in files
-                if name.startswith("projects/") and name.lower().endswith(".gns3")
-            ]
+                raise ValueError(f"GNS3 archive contains an unsupported root: {outside[0]}")
+            definitions = [member for member, name in files if name.startswith("projects/") and name.lower().endswith(".gns3")]
             if not definitions:
                 raise ValueError("GNS3 archive contains no project definitions")
             references = _gns3_image_references(handle, definitions)
@@ -385,9 +388,7 @@ def _inspect_primary(path: Path, platform: str) -> dict[str, Any]:
                 "definition_count": len(definitions),
                 "expanded_size_bytes": sum(member.size for member, _ in files),
                 "image_references": references,
-                "images_included": any(
-                    name == "images" or name.startswith("images/") for name in names
-                ),
+                "images_included": any(name == "images" or name.startswith("images/") for name in names),
                 "member_count": len(members),
             }
     except tarfile.TarError as exc:
@@ -403,24 +404,21 @@ def _inspect_eve_node_state(path: Path) -> dict[str, Any]:
                 raise ValueError("EVE-NG node-state archive contains no files")
             invalid = [name for name in files if not _EVE_NODE_STATE_RE.fullmatch(name)]
             if invalid:
-                raise ValueError(
-                    f"EVE-NG node-state member has an invalid path: {invalid[0]}"
-                )
+                raise ValueError(f"EVE-NG node-state member has an invalid path: {invalid[0]}")
             return {
-                "expanded_size_bytes": sum(
-                    member.size for member, _ in members if member.isfile()
-                ),
+                "expanded_size_bytes": sum(member.size for member, _ in members if member.isfile()),
                 "member_count": len(members),
                 "overlay_count": len(files),
             }
     except tarfile.TarError as exc:
-        raise ValueError(
-            f"node-state archive is not a readable tar archive: {path}"
-        ) from exc
+        raise ValueError(f"node-state archive is not a readable tar archive: {path}") from exc
 
 
-def _inspect_eve_images(path: Path, references: list[str]) -> dict[str, Any]:
-    if not references:
+def _inspect_eve_images(
+    path: Path,
+    requirements: list[tuple[str, str]],
+) -> dict[str, Any]:
+    if not requirements:
         raise ValueError("EVE-NG image archive has no referenced base images")
     try:
         with tarfile.open(path, mode="r:*") as handle:
@@ -435,46 +433,54 @@ def _inspect_eve_images(path: Path, references: list[str]) -> dict[str, Any]:
             )
             invalid = [name for name in files if not name.startswith(allowed)]
             if invalid:
-                raise ValueError(
-                    f"EVE-NG image archive contains an unsupported path: {invalid[0]}"
-                )
+                raise ValueError(f"EVE-NG image archive contains an unsupported path: {invalid[0]}")
+            licence_files = [name for name in files if name.lower() in {"iol/bin/iourc", "iol/bin/iourc.txt"}]
+            if licence_files:
+                raise ValueError("EVE-NG image archive must not contain IOL licence material")
+
+            selected: set[tuple[str, str]] = set()
+            invalid_layout: list[str] = []
+            for name in files:
+                parts = PurePosixPath(name).parts
+                if parts[0] == "qemu" and len(parts) >= 2:
+                    selected.add(("qemu", parts[1]))
+                elif parts[:2] == ("iol", "bin") and len(parts) == 3:
+                    selected.add(("iol/bin", parts[2]))
+                elif parts[0] == "dynamips" and len(parts) == 2:
+                    selected.add(("dynamips", parts[1]))
+                else:
+                    invalid_layout.append(name)
+            if invalid_layout:
+                raise ValueError(f"EVE-NG image archive contains an invalid image path: {invalid_layout[0]}")
+
             missing: list[str] = []
-            for reference in references:
-                if (
-                    not reference
-                    or reference in {".", ".."}
-                    or PurePosixPath(reference).name != reference
-                    or "\\" in reference
-                ):
-                    raise ValueError(
-                        f"EVE-NG lab contains an unsafe image reference: {reference}"
-                    )
-                candidates = (
-                    f"qemu/{reference}",
-                    f"iol/bin/{reference}",
-                    f"dynamips/{reference}",
-                )
-                if not any(
-                    name == candidate or name.startswith(candidate + "/")
-                    for candidate in candidates
-                    for name in files
-                ):
-                    missing.append(reference)
+            allowed_selected: set[tuple[str, str]] = set()
+            for root_name, reference in requirements:
+                if not reference or reference in {".", ".."} or PurePosixPath(reference).name != reference or "\\" in reference:
+                    raise ValueError(f"EVE-NG lab contains an unsafe image reference: {reference}")
+                if root_name == "*":
+                    matches = {candidate for candidate in selected if candidate[1] == reference}
+                    if not matches:
+                        missing.append(reference)
+                    allowed_selected.update(matches)
+                else:
+                    candidate = (root_name, reference)
+                    if candidate not in selected:
+                        missing.append(f"{root_name}/{reference}")
+                    allowed_selected.add(candidate)
             if missing:
-                raise ValueError(
-                    f"EVE-NG image archive is missing a referenced base: {missing[0]}"
-                )
+                raise ValueError(f"EVE-NG image archive is missing a referenced base: {missing[0]}")
+            extra = sorted(selected - allowed_selected)
+            if extra:
+                root_name, reference = extra[0]
+                raise ValueError(f"EVE-NG image archive contains an unreferenced base: {root_name}/{reference}")
             return {
-                "expanded_size_bytes": sum(
-                    member.size for member, _ in members if member.isfile()
-                ),
-                "image_count": len(references),
+                "expanded_size_bytes": sum(member.size for member, _ in members if member.isfile()),
+                "image_count": len(selected),
                 "member_count": len(members),
             }
     except tarfile.TarError as exc:
-        raise ValueError(
-            f"image archive is not a readable tar archive: {path}"
-        ) from exc
+        raise ValueError(f"image archive is not a readable tar archive: {path}") from exc
 
 
 def inspect_migration_archive(
@@ -489,9 +495,7 @@ def inspect_migration_archive(
 ) -> dict[str, Any]:
     platform_name = str(platform or "").strip().lower()
     if platform_name not in SUPPORTED_PLATFORMS:
-        raise ValueError(
-            "platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS)
-        )
+        raise ValueError("platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS))
 
     archive_path = _regular_file(archive, "archive")
     archive_checksum = _sha256(archive_path)
@@ -539,7 +543,7 @@ def inspect_migration_archive(
             "path": str(image_path),
             "size_bytes": image_path.stat().st_size,
             "sha256": image_checksum,
-            **_inspect_eve_images(image_path, primary["image_references"]),
+            **_inspect_eve_images(image_path, primary["image_requirements"]),
         }
     elif images_expected_sha256:
         raise ValueError("image expected SHA-256 requires --images")
@@ -591,16 +595,8 @@ fi
     if platform == "eve-ng":
         compressor = "compressor='gzip -1'\ncommand -v pigz >/dev/null 2>&1 && compressor='pigz -1'"
         if image_state:
-            image_command = (
-                "python3 -c "
-                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
-                + " capture /opt/unetlab/labs /opt/unetlab/addons"
-            )
-            assessment_command = (
-                "python3 -c "
-                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
-                + " assess /opt/unetlab/labs /opt/unetlab/addons"
-            )
+            image_command = "python3 -c " + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM) + " capture /opt/unetlab/labs /opt/unetlab/addons"
+            assessment_command = "python3 -c " + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM) + " assess /opt/unetlab/labs /opt/unetlab/addons"
             return f"""set -eu
 required=$({assessment_command})
 {capacity_check}exec {image_command}
@@ -672,11 +668,7 @@ def _remote_capture_assessment_script(
         node_state_assessment = "node_state_bytes=0"
         image_assessment = "image_bytes=0"
         if include_images:
-            image_command = (
-                "python3 -c "
-                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
-                + " assess /opt/unetlab/labs /opt/unetlab/addons"
-            )
+            image_command = "python3 -c " + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM) + " assess /opt/unetlab/labs /opt/unetlab/addons"
             image_assessment = f"image_bytes=$({image_command})"
         if include_node_state:
             node_state_assessment = """node_root=/opt/unetlab/tmp
@@ -760,10 +752,7 @@ def _capture_error(result: subprocess.CompletedProcess[bytes]) -> ValueError:
     detail = result.stderr.decode("utf-8", errors="replace").strip()
     lowered_detail = detail.lower()
     if "no space left on device" in lowered_detail or "disk quota exceeded" in lowered_detail:
-        return ValueError(
-            "insufficient disk space for lab capture: the output filesystem "
-            "became full while writing the archive"
-        )
+        return ValueError("insufficient disk space for lab capture: the output filesystem became full while writing the archive")
     capacity_match = re.search(
         r"source requires at least (\d+) bytes; "
         r"output filesystem has (\d+) bytes available",
@@ -956,9 +945,7 @@ def capture_existing_lab(
 ) -> dict[str, Any]:
     platform_name = str(platform or "").strip().lower()
     if platform_name not in SUPPORTED_PLATFORMS:
-        raise ValueError(
-            "platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS)
-        )
+        raise ValueError("platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS))
     if include_node_state and platform_name != "eve-ng":
         raise ValueError("separate node-state capture is only valid for EVE-NG")
     if node_state_output and not include_node_state:
@@ -971,18 +958,12 @@ def capture_existing_lab(
     image_destination: Path | None = None
     if include_node_state:
         node_destination = (
-            _capture_destination(node_state_output, "node-state output")
-            if node_state_output
-            else _default_node_state_output(destination)
+            _capture_destination(node_state_output, "node-state output") if node_state_output else _default_node_state_output(destination)
         )
         if node_destination == destination:
             raise ValueError("node-state output must differ from the primary output")
     if include_images and platform_name == "eve-ng":
-        image_destination = (
-            _capture_destination(images_output, "images output")
-            if images_output
-            else _default_images_output(destination)
-        )
+        image_destination = _capture_destination(images_output, "images output") if images_output else _default_images_output(destination)
         if image_destination in {destination, node_destination}:
             raise ValueError("images output must differ from other capture outputs")
 
@@ -1049,9 +1030,7 @@ def capture_existing_lab(
                 script=_remote_capture_script(
                     platform_name,
                     node_state=True,
-                    output_available_bytes=_available_disk_bytes(
-                        node_destination.parent
-                    ),
+                    output_available_bytes=_available_disk_bytes(node_destination.parent),
                 ),
                 control_path=control_path,
             )
@@ -1066,9 +1045,7 @@ def capture_existing_lab(
                 script=_remote_capture_script(
                     platform_name,
                     image_state=True,
-                    output_available_bytes=_available_disk_bytes(
-                        image_destination.parent
-                    ),
+                    output_available_bytes=_available_disk_bytes(image_destination.parent),
                 ),
                 control_path=control_path,
             )
@@ -1196,10 +1173,7 @@ def stage_migration_archive(
     platform_name = str(platform or "").strip().lower()
     target_platform = platform_for_blueprint(payload)
     if platform_name != target_platform:
-        raise ValueError(
-            f"source platform {platform_name} does not match target blueprint platform "
-            f"{target_platform}"
-        )
+        raise ValueError(f"source platform {platform_name} does not match target blueprint platform {target_platform}")
     inspection = inspect_migration_archive(
         platform=platform_name,
         archive=archive,
@@ -1221,69 +1195,48 @@ def stage_migration_archive(
         if isinstance(loaded, dict):
             existing = loaded
     existing_archive = (existing or {}).get("archive")
-    existing_checksum = (
-        str(existing_archive.get("sha256") or "")
-        if isinstance(existing_archive, dict)
-        else ""
-    )
+    existing_checksum = str(existing_archive.get("sha256") or "") if isinstance(existing_archive, dict) else ""
     node_inspection = inspection.get("node_state")
     node_checksum = str(node_inspection.get("sha256") or "") if node_inspection else ""
     existing_node = (existing or {}).get("node_state")
-    existing_node_checksum = (
-        str(existing_node.get("sha256") or "") if isinstance(existing_node, dict) else ""
-    )
+    existing_node_checksum = str(existing_node.get("sha256") or "") if isinstance(existing_node, dict) else ""
     image_inspection = inspection.get("images")
-    image_checksum = (
-        str(image_inspection.get("sha256") or "") if image_inspection else ""
-    )
+    image_checksum = str(image_inspection.get("sha256") or "") if image_inspection else ""
     existing_images = (existing or {}).get("images")
-    existing_image_checksum = (
-        str(existing_images.get("sha256") or "")
-        if isinstance(existing_images, dict)
-        else ""
-    )
-    if existing and (
-        existing_checksum,
-        existing_node_checksum,
-        existing_image_checksum,
-    ) != (
-        inspection["archive"]["sha256"],
-        node_checksum,
-        image_checksum,
-    ) and not force:
-        raise ValueError(
-            "a different migration bundle is already staged for this blueprint; "
-            "use --force to replace the active record"
+    existing_image_checksum = str(existing_images.get("sha256") or "") if isinstance(existing_images, dict) else ""
+    if (
+        existing
+        and (
+            existing_checksum,
+            existing_node_checksum,
+            existing_image_checksum,
         )
+        != (
+            inspection["archive"]["sha256"],
+            node_checksum,
+            image_checksum,
+        )
+        and not force
+    ):
+        raise ValueError("a different migration bundle is already staged for this blueprint; use --force to replace the active record")
 
     bundle_id = _bundle_id(
         inspection["archive"]["sha256"],
         node_checksum,
         image_checksum,
     )
-    destination_root = (
-        paths.root / "artifacts" / "lab-migrations" / _record_slug(blueprint_ref) / bundle_id
-    )
+    destination_root = paths.root / "artifacts" / "lab-migrations" / _record_slug(blueprint_ref) / bundle_id
     archive_destination = destination_root / "labs.tar.gz"
     copy_bytes = 0
-    if not (
-        archive_destination.is_file()
-        and _sha256(archive_destination) == inspection["archive"]["sha256"]
-    ):
+    if not (archive_destination.is_file() and _sha256(archive_destination) == inspection["archive"]["sha256"]):
         copy_bytes += int(inspection["archive"]["size_bytes"])
     if node_inspection:
         node_destination = destination_root / "labs.node-state.tar.gz"
-        if not (
-            node_destination.is_file()
-            and _sha256(node_destination) == node_inspection["sha256"]
-        ):
+        if not (node_destination.is_file() and _sha256(node_destination) == node_inspection["sha256"]):
             copy_bytes += int(node_inspection["size_bytes"])
     if image_inspection:
         image_destination = destination_root / "labs.images.tar.gz"
-        if not (
-            image_destination.is_file()
-            and _sha256(image_destination) == image_inspection["sha256"]
-        ):
+        if not (image_destination.is_file() and _sha256(image_destination) == image_inspection["sha256"]):
             copy_bytes += int(image_inspection["size_bytes"])
     if copy_bytes:
         _require_disk_space(destination_root, copy_bytes, "migration import")
@@ -1301,9 +1254,7 @@ def stage_migration_archive(
             node_destination,
             node_inspection["sha256"],
         )
-        staged_node = {
-            key: value for key, value in node_inspection.items() if key != "path"
-        }
+        staged_node = {key: value for key, value in node_inspection.items() if key != "path"}
         staged_node["path"] = str(node_destination)
 
     staged_images: dict[str, Any] | None = None
@@ -1313,9 +1264,7 @@ def stage_migration_archive(
             image_destination,
             image_inspection["sha256"],
         )
-        staged_images = {
-            key: value for key, value in image_inspection.items() if key != "path"
-        }
+        staged_images = {key: value for key, value in image_inspection.items() if key != "path"}
         staged_images["path"] = str(image_destination)
 
     record = {
@@ -1325,9 +1274,7 @@ def stage_migration_archive(
         "imported_at": _utc_now(),
         "platform": platform_name,
         "blueprint_ref": blueprint_ref,
-        "archive": {
-            key: value for key, value in inspection["archive"].items() if key != "path"
-        },
+        "archive": {key: value for key, value in inspection["archive"].items() if key != "path"},
         "node_state": staged_node,
         "images": staged_images,
         "definition_count": inspection["definition_count"],
@@ -1376,11 +1323,7 @@ def _verified_staged_file(
     return path, expected
 
 
-def load_migration_archive(
-    *,
-    paths,
-    payload: dict[str, Any],
-) -> tuple[Path, str, Path | None, str, Path | None, str] | None:
+def _load_migration_record(*, paths, payload: dict[str, Any]) -> dict[str, Any] | None:
     blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
     path = migration_record_path(paths, blueprint_ref)
     if not path.is_file():
@@ -1400,6 +1343,43 @@ def load_migration_archive(
     platform = str(record.get("platform") or "")
     if platform != platform_for_blueprint(payload):
         raise ValueError("migration record platform does not match the target blueprint")
+    return record
+
+
+def load_migration_images(
+    *,
+    paths,
+    payload: dict[str, Any],
+) -> tuple[Path, str] | None:
+    if not str(payload.get("blueprint_ref") or "").strip():
+        return None
+    record = _load_migration_record(paths=paths, payload=payload)
+    if record is None:
+        return None
+    image_data = record.get("images")
+    if image_data is None:
+        return None
+    if record.get("platform") != "eve-ng" or not isinstance(image_data, dict):
+        raise ValueError("migration image record is invalid")
+    return _verified_staged_file(
+        paths=paths,
+        value=image_data.get("path"),
+        checksum=image_data.get("sha256"),
+        field="migration image archive",
+    )
+
+
+def load_migration_archive(
+    *,
+    paths,
+    payload: dict[str, Any],
+) -> tuple[Path, str, Path | None, str, Path | None, str] | None:
+    record = _load_migration_record(paths=paths, payload=payload)
+    if record is None:
+        return None
+    blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
+    path = migration_record_path(paths, blueprint_ref)
+    platform = str(record.get("platform") or "")
 
     archive_data = record.get("archive")
     if not isinstance(archive_data, dict):

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -27,6 +27,133 @@ _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _EVE_NODE_STATE_RE = re.compile(r"^[0-9]+/[^/]+/[0-9]+/[^/]+\.qcow2$")
 _SSH_HOST_RE = re.compile(r"^[a-zA-Z0-9_.:-]+$")
 _SSH_USER_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+_EVE_IMAGE_CAPTURE_PROGRAM = r"""
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+mode = sys.argv[1]
+labs_root = Path(sys.argv[2])
+addons_root = Path(sys.argv[3])
+
+
+def fail(message, status=24):
+    print(message, file=sys.stderr)
+    raise SystemExit(status)
+
+
+def safe_reference(value):
+    if (
+        not value
+        or value in {".", ".."}
+        or Path(value).name != value
+        or "\\" in value
+        or any(ord(character) < 32 for character in value)
+    ):
+        fail(f"EVE-NG lab contains an unsafe image reference: {value!r}")
+    return value
+
+
+requirements = set()
+labs_resolved = labs_root.resolve()
+for definition in sorted(labs_root.rglob("*.unl")):
+    if definition.is_symlink():
+        fail(f"EVE-NG lab definition must not be a symbolic link: {definition}")
+    try:
+        definition.resolve(strict=True).relative_to(labs_resolved)
+    except (FileNotFoundError, ValueError):
+        fail(f"EVE-NG lab definition has an unsafe path: {definition}")
+    if definition.stat().st_size > 32 * 1024 * 1024:
+        fail(f"EVE-NG lab definition exceeds the 32 MiB limit: {definition}")
+    payload = definition.read_bytes()
+    if re.search(br"<!\s*(?:DOCTYPE|ENTITY)\b", payload, flags=re.IGNORECASE):
+        fail(f"EVE-NG lab definition contains a DTD or entity declaration: {definition}")
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError:
+        fail(f"Invalid EVE-NG lab definition: {definition}")
+    for element in root.iter():
+        image = safe_reference(str(element.attrib.get("image") or "").strip()) if element.attrib.get("image") else ""
+        if not image:
+            continue
+        node_type = str(element.attrib.get("type") or "").strip().lower()
+        if node_type == "qemu":
+            candidates = [Path("qemu") / image]
+        elif node_type.startswith("iol"):
+            candidates = [Path("iol/bin") / image]
+        elif node_type == "dynamips":
+            candidates = [Path("dynamips") / image]
+        else:
+            candidates = [
+                Path("qemu") / image,
+                Path("iol/bin") / image,
+                Path("dynamips") / image,
+            ]
+        matches = [candidate for candidate in candidates if (addons_root / candidate).exists()]
+        if not matches:
+            fail(f"Referenced EVE-NG base image was not found: {image}", 22)
+        requirements.update(matches)
+
+if not requirements:
+    fail("No referenced EVE-NG base images were found", 22)
+
+addons_resolved = addons_root.resolve()
+selected = []
+seen_inodes = set()
+allocated_bytes = 0
+for relative in sorted(requirements, key=lambda item: item.as_posix()):
+    source = addons_root / relative
+    try:
+        source.resolve(strict=True).relative_to(addons_resolved)
+    except (FileNotFoundError, ValueError):
+        fail(f"Referenced EVE-NG base image has an unsafe path: {relative}")
+    paths = [source]
+    if source.is_dir():
+        paths.extend(sorted(source.rglob("*")))
+    for path in paths:
+        if path.is_symlink():
+            fail(f"Referenced EVE-NG base image contains a symbolic link: {path}")
+        stat = path.stat()
+        inode = (stat.st_dev, stat.st_ino)
+        if inode in seen_inodes:
+            continue
+        seen_inodes.add(inode)
+        allocated_bytes += stat.st_blocks * 512
+    selected.append(relative.as_posix())
+
+if mode == "assess":
+    print(allocated_bytes)
+    raise SystemExit(0)
+if mode != "capture":
+    fail("Unsupported EVE-NG image capture mode")
+
+compressor = "pigz -1" if shutil.which("pigz") else "gzip -1"
+command = [
+    "tar",
+    "--sort=name",
+    "--mtime=@0",
+    "--owner=0",
+    "--group=0",
+    "--numeric-owner",
+    "--sparse",
+    "--null",
+    "--verbatim-files-from",
+    "-I",
+    compressor,
+    "-cf",
+    "-",
+    "-C",
+    str(addons_root),
+    "--files-from=-",
+]
+file_list = b"".join(os.fsencode(path) + b"\0" for path in selected)
+result = subprocess.run(command, input=file_list, stdout=sys.stdout.buffer, check=False)
+raise SystemExit(result.returncode)
+"""
 
 
 def _utc_now() -> str:
@@ -292,13 +419,73 @@ def _inspect_eve_node_state(path: Path) -> dict[str, Any]:
         ) from exc
 
 
+def _inspect_eve_images(path: Path, references: list[str]) -> dict[str, Any]:
+    if not references:
+        raise ValueError("EVE-NG image archive has no referenced base images")
+    try:
+        with tarfile.open(path, mode="r:*") as handle:
+            members = _safe_members(handle)
+            files = [name for member, name in members if member.isfile()]
+            if not files:
+                raise ValueError("EVE-NG image archive contains no files")
+            allowed = (
+                "qemu/",
+                "iol/bin/",
+                "dynamips/",
+            )
+            invalid = [name for name in files if not name.startswith(allowed)]
+            if invalid:
+                raise ValueError(
+                    f"EVE-NG image archive contains an unsupported path: {invalid[0]}"
+                )
+            missing: list[str] = []
+            for reference in references:
+                if (
+                    not reference
+                    or reference in {".", ".."}
+                    or PurePosixPath(reference).name != reference
+                    or "\\" in reference
+                ):
+                    raise ValueError(
+                        f"EVE-NG lab contains an unsafe image reference: {reference}"
+                    )
+                candidates = (
+                    f"qemu/{reference}",
+                    f"iol/bin/{reference}",
+                    f"dynamips/{reference}",
+                )
+                if not any(
+                    name == candidate or name.startswith(candidate + "/")
+                    for candidate in candidates
+                    for name in files
+                ):
+                    missing.append(reference)
+            if missing:
+                raise ValueError(
+                    f"EVE-NG image archive is missing a referenced base: {missing[0]}"
+                )
+            return {
+                "expanded_size_bytes": sum(
+                    member.size for member, _ in members if member.isfile()
+                ),
+                "image_count": len(references),
+                "member_count": len(members),
+            }
+    except tarfile.TarError as exc:
+        raise ValueError(
+            f"image archive is not a readable tar archive: {path}"
+        ) from exc
+
+
 def inspect_migration_archive(
     *,
     platform: str,
     archive: str | Path,
     node_state: str | Path | None = None,
+    images: str | Path | None = None,
     expected_sha256: str = "",
     node_state_expected_sha256: str = "",
+    images_expected_sha256: str = "",
 ) -> dict[str, Any]:
     platform_name = str(platform or "").strip().lower()
     if platform_name not in SUPPORTED_PLATFORMS:
@@ -335,8 +522,31 @@ def inspect_migration_archive(
     elif node_state_expected_sha256:
         raise ValueError("node-state expected SHA-256 requires --node-state")
 
+    image_report: dict[str, Any] | None = None
+    image_path: Path | None = None
+    if images:
+        if platform_name != "eve-ng":
+            raise ValueError("a separate image archive is only valid for EVE-NG")
+        image_path = _regular_file(images, "image archive")
+        image_checksum = _sha256(image_path)
+        image_expected = _expected_checksum(
+            images_expected_sha256,
+            "image expected SHA-256",
+        )
+        if image_expected and image_checksum != image_expected:
+            raise ValueError("image archive SHA-256 checksum does not match")
+        image_report = {
+            "path": str(image_path),
+            "size_bytes": image_path.stat().st_size,
+            "sha256": image_checksum,
+            **_inspect_eve_images(image_path, primary["image_references"]),
+        }
+    elif images_expected_sha256:
+        raise ValueError("image expected SHA-256 requires --images")
+
     warnings: list[str] = []
-    if primary["image_references"] and not primary["images_included"]:
+    images_included = bool(primary["images_included"] or image_report)
+    if primary["image_references"] and not images_included:
         warnings.append("referenced base images must be available on the target")
     if platform_name == "eve-ng" and node_report is None:
         warnings.append("writable QEMU node state is not included")
@@ -355,7 +565,8 @@ def inspect_migration_archive(
         },
         "definition_count": primary["definition_count"],
         "image_references": primary["image_references"],
-        "images_included": primary["images_included"],
+        "images_included": images_included,
+        "images": image_report,
         "node_state": node_report,
         "warnings": warnings,
     }
@@ -365,6 +576,7 @@ def _remote_capture_script(
     platform: str,
     *,
     node_state: bool = False,
+    image_state: bool = False,
     include_images: bool = False,
     output_available_bytes: int,
 ) -> str:
@@ -377,6 +589,22 @@ if [ "$required" -gt "$capacity" ]; then
 fi
 """
     if platform == "eve-ng":
+        compressor = "compressor='gzip -1'\ncommand -v pigz >/dev/null 2>&1 && compressor='pigz -1'"
+        if image_state:
+            image_command = (
+                "python3 -c "
+                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
+                + " capture /opt/unetlab/labs /opt/unetlab/addons"
+            )
+            assessment_command = (
+                "python3 -c "
+                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
+                + " assess /opt/unetlab/labs /opt/unetlab/addons"
+            )
+            return f"""set -eu
+required=$({assessment_command})
+{capacity_check}exec {image_command}
+"""
         if node_state:
             return f"""set -eu
 root=/opt/unetlab/tmp
@@ -391,9 +619,10 @@ find . -type f -name '*.qcow2' -printf '%P\\n' -quit | grep -q . || {{
   exit 22
 }}
 required=$(find . -type f -name '*.qcow2' -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
-{capacity_check}find . -type f -name '*.qcow2' -printf '%P\\0' | sort -z | \
+{capacity_check}{compressor}
+find . -type f -name '*.qcow2' -printf '%P\\0' | sort -z | \
   tar --null --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
-  -czf - --files-from=-
+  --sparse -I "$compressor" -cf - --files-from=-
 """
         return f"""set -eu
 root=/opt/unetlab/labs
@@ -407,8 +636,9 @@ find "$root" -type f -name '*.unl' -print -quit | grep -q . || {{
   exit 22
 }}
 required=$(find "$root" -type f -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
-{capacity_check}exec tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
-  -czf - -C "$root" .
+{capacity_check}{compressor}
+exec tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+  -I "$compressor" -cf - -C "$root" .
 """
 
     image_member = " images" if include_images else ""
@@ -425,8 +655,10 @@ for member in appliances symbols .config/GNS3{image_member}; do
   test -e "$root/$member" && set -- "$@" "$member"
 done
 required=$(du -s --block-size=1 "$@" | awk '{{total += $1}} END {{printf "%.0f\\n", total}}')
-{capacity_check}exec tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
-  -czf - -C "$root" "$@"
+{capacity_check}compressor='gzip -1'
+command -v pigz >/dev/null 2>&1 && compressor='pigz -1'
+exec tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+  --sparse -I "$compressor" -cf - -C "$root" "$@"
 """
 
 
@@ -438,6 +670,14 @@ def _remote_capture_assessment_script(
 ) -> str:
     if platform == "eve-ng":
         node_state_assessment = "node_state_bytes=0"
+        image_assessment = "image_bytes=0"
+        if include_images:
+            image_command = (
+                "python3 -c "
+                + shlex.quote(_EVE_IMAGE_CAPTURE_PROGRAM)
+                + " assess /opt/unetlab/labs /opt/unetlab/addons"
+            )
+            image_assessment = f"image_bytes=$({image_command})"
         if include_node_state:
             node_state_assessment = """node_root=/opt/unetlab/tmp
 test -d "$node_root" || { echo 'EVE-NG node-state root not found' >&2; exit 20; }
@@ -460,7 +700,8 @@ find "$root" -type f -name '*.unl' -print -quit | grep -q . || {{
 }}
 primary_bytes=$(find "$root" -type f -printf '%b\\n' | awk '{{total += $1}} END {{printf "%.0f\\n", total * 512}}')
 {node_state_assessment}
-printf 'primary_bytes=%s\\nnode_state_bytes=%s\\n' "$primary_bytes" "$node_state_bytes"
+{image_assessment}
+printf 'primary_bytes=%s\\nnode_state_bytes=%s\\nimage_bytes=%s\\n' "$primary_bytes" "$node_state_bytes" "$image_bytes"
 """
 
     image_member = " images" if include_images else ""
@@ -477,7 +718,7 @@ for member in appliances symbols .config/GNS3{image_member}; do
   test -e "$root/$member" && set -- "$@" "$member"
 done
 primary_bytes=$(du -s --block-size=1 "$@" | awk '{{total += $1}} END {{printf "%.0f\\n", total}}')
-printf 'primary_bytes=%s\\nnode_state_bytes=0\\n' "$primary_bytes"
+printf 'primary_bytes=%s\\nnode_state_bytes=0\\nimage_bytes=0\\n' "$primary_bytes"
 """
 
 
@@ -558,14 +799,18 @@ def _capture_requirements(argv: list[str]) -> dict[str, int]:
     values: dict[str, int] = {}
     for raw_line in result.stdout.decode("utf-8", errors="replace").splitlines():
         key, separator, raw_value = raw_line.strip().partition("=")
-        if not separator or key not in {"primary_bytes", "node_state_bytes"}:
+        if not separator or key not in {
+            "primary_bytes",
+            "node_state_bytes",
+            "image_bytes",
+        }:
             raise ValueError("source capture assessment returned invalid output")
         if key in values:
             raise ValueError("source capture assessment returned a duplicate size")
         if not raw_value.isdigit():
             raise ValueError("source capture assessment returned an invalid size")
         values[key] = int(raw_value)
-    if "primary_bytes" not in values or "node_state_bytes" not in values:
+    if not {"primary_bytes", "node_state_bytes", "image_bytes"}.issubset(values):
         raise ValueError("source capture assessment did not return required sizes")
     return values
 
@@ -625,22 +870,29 @@ def _require_capture_capacity(
     primary_bytes: int,
     node_destination: Path | None,
     node_state_bytes: int,
+    image_destination: Path | None,
+    image_bytes: int,
 ) -> None:
-    if node_destination is None:
-        _require_disk_space(destination.parent, primary_bytes, "lab capture")
-        return
-
-    primary_filesystem = _existing_filesystem_path(destination.parent)
-    node_filesystem = _existing_filesystem_path(node_destination.parent)
-    if primary_filesystem.stat().st_dev == node_filesystem.stat().st_dev:
-        _require_disk_space(
-            destination.parent,
-            primary_bytes + node_state_bytes,
-            "lab capture",
-        )
-        return
-    _require_disk_space(destination.parent, primary_bytes, "lab capture")
-    _require_disk_space(node_destination.parent, node_state_bytes, "node-state capture")
+    outputs = [(destination, primary_bytes, "lab capture")]
+    if node_destination is not None:
+        outputs.append((node_destination, node_state_bytes, "node-state capture"))
+    if image_destination is not None:
+        outputs.append((image_destination, image_bytes, "image capture"))
+    filesystems: dict[int, tuple[Path, int, str]] = {}
+    for output, required, operation in outputs:
+        filesystem = _existing_filesystem_path(output.parent)
+        device = filesystem.stat().st_dev
+        if device in filesystems:
+            prior_path, prior_required, _ = filesystems[device]
+            filesystems[device] = (
+                prior_path,
+                prior_required + required,
+                "lab capture",
+            )
+        else:
+            filesystems[device] = (output.parent, required, operation)
+    for path, required, operation in filesystems.values():
+        _require_disk_space(path, required, operation)
 
 
 def _capture_destination(raw: str | Path, field: str) -> Path:
@@ -679,6 +931,14 @@ def _default_node_state_output(primary: Path) -> Path:
     return primary.with_name(name + ".node-state.tar.gz")
 
 
+def _default_images_output(primary: Path) -> Path:
+    name = primary.name
+    for suffix in (".tar.gz", ".tgz", ".tar"):
+        if name.lower().endswith(suffix):
+            return primary.with_name(name[: -len(suffix)] + ".images.tar.gz")
+    return primary.with_name(name + ".images.tar.gz")
+
+
 def capture_existing_lab(
     *,
     platform: str,
@@ -691,6 +951,7 @@ def capture_existing_lab(
     include_node_state: bool = False,
     node_state_output: str | Path | None = None,
     include_images: bool = False,
+    images_output: str | Path | None = None,
     force: bool = False,
 ) -> dict[str, Any]:
     platform_name = str(platform or "").strip().lower()
@@ -700,13 +961,14 @@ def capture_existing_lab(
         )
     if include_node_state and platform_name != "eve-ng":
         raise ValueError("separate node-state capture is only valid for EVE-NG")
-    if include_images and platform_name != "gns3":
-        raise ValueError("--include-images is only valid for GNS3")
     if node_state_output and not include_node_state:
         raise ValueError("--node-state-output requires --include-node-state")
+    if images_output and not (include_images and platform_name == "eve-ng"):
+        raise ValueError("--images-output requires EVE-NG --include-images")
 
     destination = _capture_destination(output, "output")
     node_destination: Path | None = None
+    image_destination: Path | None = None
     if include_node_state:
         node_destination = (
             _capture_destination(node_state_output, "node-state output")
@@ -715,9 +977,18 @@ def capture_existing_lab(
         )
         if node_destination == destination:
             raise ValueError("node-state output must differ from the primary output")
+    if include_images and platform_name == "eve-ng":
+        image_destination = (
+            _capture_destination(images_output, "images output")
+            if images_output
+            else _default_images_output(destination)
+        )
+        if image_destination in {destination, node_destination}:
+            raise ValueError("images output must differ from other capture outputs")
 
     primary_candidate: Path | None = None
     node_candidate: Path | None = None
+    image_candidate: Path | None = None
     control_root = Path(
         tempfile.mkdtemp(
             prefix="hyops-ssh-",
@@ -730,6 +1001,8 @@ def capture_existing_lab(
         primary_candidate = _capture_candidate(destination, force)
         if node_destination is not None:
             node_candidate = _capture_candidate(node_destination, force)
+        if image_destination is not None:
+            image_candidate = _capture_candidate(image_destination, force)
         assessment_argv = _ssh_capture_argv(
             host=host,
             user=user,
@@ -749,6 +1022,8 @@ def capture_existing_lab(
             primary_bytes=requirements["primary_bytes"],
             node_destination=node_destination,
             node_state_bytes=requirements["node_state_bytes"],
+            image_destination=image_destination,
+            image_bytes=requirements["image_bytes"],
         )
         primary_argv = _ssh_capture_argv(
             host=host,
@@ -781,18 +1056,40 @@ def capture_existing_lab(
                 control_path=control_path,
             )
             _capture_stream(node_argv, node_candidate)
+        if image_candidate is not None and image_destination is not None:
+            image_argv = _ssh_capture_argv(
+                host=host,
+                user=user,
+                port=port,
+                identity_file=identity_file,
+                become=become,
+                script=_remote_capture_script(
+                    platform_name,
+                    image_state=True,
+                    output_available_bytes=_available_disk_bytes(
+                        image_destination.parent
+                    ),
+                ),
+                control_path=control_path,
+            )
+            _capture_stream(image_argv, image_candidate)
 
         report = inspect_migration_archive(
             platform=platform_name,
             archive=primary_candidate,
             node_state=node_candidate,
+            images=image_candidate,
         )
-        os.replace(primary_candidate, destination)
         if node_candidate is not None and node_destination is not None:
             os.replace(node_candidate, node_destination)
+        if image_candidate is not None and image_destination is not None:
+            os.replace(image_candidate, image_destination)
+        os.replace(primary_candidate, destination)
         report["archive"]["path"] = str(destination)
         if isinstance(report.get("node_state"), dict) and node_destination is not None:
             report["node_state"]["path"] = str(node_destination)
+        if isinstance(report.get("images"), dict) and image_destination is not None:
+            report["images"]["path"] = str(image_destination)
         report["source"] = {"host": host, "user": user or None}
         return report
     finally:
@@ -806,6 +1103,8 @@ def capture_existing_lab(
             primary_candidate.unlink(missing_ok=True)
         if node_candidate is not None:
             node_candidate.unlink(missing_ok=True)
+        if image_candidate is not None:
+            image_candidate.unlink(missing_ok=True)
         shutil.rmtree(control_root, ignore_errors=True)
 
 
@@ -872,8 +1171,12 @@ def _write_record(path: Path, record: dict[str, Any]) -> None:
     write_json_atomic(path, record, mode=0o600)
 
 
-def _bundle_id(primary_checksum: str, node_checksum: str) -> str:
-    identity = f"{primary_checksum}:{node_checksum}".encode("ascii")
+def _bundle_id(
+    primary_checksum: str,
+    node_checksum: str,
+    image_checksum: str,
+) -> str:
+    identity = f"{primary_checksum}:{node_checksum}:{image_checksum}".encode("ascii")
     return hashlib.sha256(identity).hexdigest()[:16]
 
 
@@ -884,8 +1187,10 @@ def stage_migration_archive(
     platform: str,
     archive: str | Path,
     node_state: str | Path | None = None,
+    images: str | Path | None = None,
     expected_sha256: str = "",
     node_state_expected_sha256: str = "",
+    images_expected_sha256: str = "",
     force: bool = False,
 ) -> dict[str, Any]:
     platform_name = str(platform or "").strip().lower()
@@ -899,8 +1204,10 @@ def stage_migration_archive(
         platform=platform_name,
         archive=archive,
         node_state=node_state,
+        images=images,
         expected_sha256=expected_sha256,
         node_state_expected_sha256=node_state_expected_sha256,
+        images_expected_sha256=images_expected_sha256,
     )
 
     blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
@@ -925,16 +1232,35 @@ def stage_migration_archive(
     existing_node_checksum = (
         str(existing_node.get("sha256") or "") if isinstance(existing_node, dict) else ""
     )
-    if existing and (existing_checksum, existing_node_checksum) != (
+    image_inspection = inspection.get("images")
+    image_checksum = (
+        str(image_inspection.get("sha256") or "") if image_inspection else ""
+    )
+    existing_images = (existing or {}).get("images")
+    existing_image_checksum = (
+        str(existing_images.get("sha256") or "")
+        if isinstance(existing_images, dict)
+        else ""
+    )
+    if existing and (
+        existing_checksum,
+        existing_node_checksum,
+        existing_image_checksum,
+    ) != (
         inspection["archive"]["sha256"],
         node_checksum,
+        image_checksum,
     ) and not force:
         raise ValueError(
             "a different migration bundle is already staged for this blueprint; "
             "use --force to replace the active record"
         )
 
-    bundle_id = _bundle_id(inspection["archive"]["sha256"], node_checksum)
+    bundle_id = _bundle_id(
+        inspection["archive"]["sha256"],
+        node_checksum,
+        image_checksum,
+    )
     destination_root = (
         paths.root / "artifacts" / "lab-migrations" / _record_slug(blueprint_ref) / bundle_id
     )
@@ -952,6 +1278,13 @@ def stage_migration_archive(
             and _sha256(node_destination) == node_inspection["sha256"]
         ):
             copy_bytes += int(node_inspection["size_bytes"])
+    if image_inspection:
+        image_destination = destination_root / "labs.images.tar.gz"
+        if not (
+            image_destination.is_file()
+            and _sha256(image_destination) == image_inspection["sha256"]
+        ):
+            copy_bytes += int(image_inspection["size_bytes"])
     if copy_bytes:
         _require_disk_space(destination_root, copy_bytes, "migration import")
 
@@ -973,6 +1306,18 @@ def stage_migration_archive(
         }
         staged_node["path"] = str(node_destination)
 
+    staged_images: dict[str, Any] | None = None
+    if image_inspection:
+        _copy_verified(
+            Path(image_inspection["path"]),
+            image_destination,
+            image_inspection["sha256"],
+        )
+        staged_images = {
+            key: value for key, value in image_inspection.items() if key != "path"
+        }
+        staged_images["path"] = str(image_destination)
+
     record = {
         "schema_version": SCHEMA_VERSION,
         "kind": RECORD_KIND,
@@ -984,19 +1329,26 @@ def stage_migration_archive(
             key: value for key, value in inspection["archive"].items() if key != "path"
         },
         "node_state": staged_node,
+        "images": staged_images,
         "definition_count": inspection["definition_count"],
         "image_references": inspection["image_references"],
         "images_included": inspection["images_included"],
         "warnings": inspection["warnings"],
     }
     record["archive"]["path"] = str(archive_destination)
-    if existing and (existing_checksum, existing_node_checksum) != (
+    if existing and (
+        existing_checksum,
+        existing_node_checksum,
+        existing_image_checksum,
+    ) != (
         record["archive"]["sha256"],
         node_checksum,
+        image_checksum,
     ):
         record["supersedes"] = {
             "archive_sha256": existing_checksum,
             "node_state_sha256": existing_node_checksum,
+            "images_sha256": existing_image_checksum,
             "imported_at": str(existing.get("imported_at") or ""),
         }
     _write_record(record_path, record)
@@ -1028,7 +1380,7 @@ def load_migration_archive(
     *,
     paths,
     payload: dict[str, Any],
-) -> tuple[Path, str, Path | None, str] | None:
+) -> tuple[Path, str, Path | None, str, Path | None, str] | None:
     blueprint_ref = str(payload.get("blueprint_ref") or "").strip()
     path = migration_record_path(paths, blueprint_ref)
     if not path.is_file():
@@ -1073,4 +1425,24 @@ def load_migration_archive(
             checksum=node_data.get("sha256"),
             field="migration node-state archive",
         )
-    return archive_path, checksum, node_path, node_checksum
+
+    image_path: Path | None = None
+    image_checksum = ""
+    image_data = record.get("images")
+    if image_data is not None:
+        if platform != "eve-ng" or not isinstance(image_data, dict):
+            raise ValueError(f"migration image record is invalid: {path}")
+        image_path, image_checksum = _verified_staged_file(
+            paths=paths,
+            value=image_data.get("path"),
+            checksum=image_data.get("sha256"),
+            field="migration image archive",
+        )
+    return (
+        archive_path,
+        checksum,
+        node_path,
+        node_checksum,
+        image_path,
+        image_checksum,
+    )

--- a/hyops/lab/migration.py
+++ b/hyops/lab/migration.py
@@ -1138,7 +1138,7 @@ required=$({assessment_command})
 root=/opt/unetlab/tmp
 test -d "$root" || {{ echo 'EVE-NG node-state root not found' >&2; exit 20; }}
 if pgrep -af '[/]opt/qemu[^ ]*/bin/qemu-system-' >/dev/null; then
-  echo 'EVE-NG QEMU nodes are running; stop them before capture' >&2
+  echo 'EVE-NG QEMU nodes are running; shut down stateful guests inside the guest and stop the remaining nodes before capture' >&2
   exit 21
 fi
 cd "$root"
@@ -1550,6 +1550,7 @@ def capture_existing_lab(
     identity_file: str | Path | None = None,
     become: bool = False,
     include_node_state: bool = False,
+    guest_quiesced: bool = False,
     node_state_output: str | Path | None = None,
     include_images: bool = False,
     images_output: str | Path | None = None,
@@ -1565,6 +1566,14 @@ def capture_existing_lab(
         raise ValueError("platform must be one of: " + ", ".join(SUPPORTED_PLATFORMS))
     if include_node_state and platform_name != "eve-ng":
         raise ValueError("separate node-state capture is only valid for EVE-NG")
+    if guest_quiesced and not include_node_state:
+        raise ValueError("--guest-quiesced requires --include-node-state")
+    if include_node_state and not guest_quiesced:
+        raise ValueError(
+            "EVE-NG node-state capture requires --guest-quiesced after shutting "
+            "down each stateful guest inside its operating system; stopping a "
+            "node in EVE-NG is not a clean guest shutdown"
+        )
     if node_state_output and not include_node_state:
         raise ValueError("--node-state-output requires --include-node-state")
     if images_output and not (include_images and platform_name == "eve-ng"):
@@ -1770,6 +1779,7 @@ def capture_existing_lab(
         report["archive"]["path"] = str(destination)
         if isinstance(report.get("node_state"), dict) and node_destination is not None:
             report["node_state"]["path"] = str(node_destination)
+            report["node_state"]["capture_consistency"] = "guest-quiesced"
         if isinstance(report.get("images"), dict) and image_destination is not None:
             report["images"]["path"] = str(image_destination)
         report["source"] = {"host": host, "user": user or None}

--- a/hyops/lab/tests/__init__.py
+++ b/hyops/lab/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Lab command tests."""

--- a/hyops/lab/tests/test_command.py
+++ b/hyops/lab/tests/test_command.py
@@ -4,7 +4,7 @@ import io
 from contextlib import redirect_stdout
 from unittest import TestCase
 
-from hyops.lab.command import _CaptureProgress
+from hyops.lab.command import _CaptureProgress, _ImportProgress
 
 
 class CaptureProgressTest(TestCase):
@@ -52,6 +52,66 @@ class CaptureProgressTest(TestCase):
         self.assertIn("capture=node_state status=running source_bytes=8192", text)
         self.assertIn("capture=node_state status=running bytes=2048", text)
         self.assertIn("capture=node_state status=ok bytes=4096", text)
+
+
+class ImportProgressTest(TestCase):
+    def test_non_tty_output_reports_verification_copy_and_completion(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            progress = _ImportProgress()
+            progress({"phase": "import_verification_started"})
+            progress(
+                {
+                    "phase": "import_verification_finished",
+                    "status": "ok",
+                }
+            )
+            progress(
+                {
+                    "phase": "stage_started",
+                    "stage": "referenced_images",
+                    "total_bytes": 8192,
+                }
+            )
+            progress(
+                {
+                    "phase": "stage_progress",
+                    "stage": "referenced_images",
+                    "bytes_written": 4096,
+                    "total_bytes": 8192,
+                    "bytes_per_second": 128,
+                    "elapsed_seconds": 31,
+                }
+            )
+            progress(
+                {
+                    "phase": "stage_verifying",
+                    "stage": "referenced_images",
+                    "bytes_written": 8192,
+                    "total_bytes": 8192,
+                }
+            )
+            progress(
+                {
+                    "phase": "stage_finished",
+                    "stage": "referenced_images",
+                    "status": "ok",
+                    "bytes_written": 8192,
+                    "total_bytes": 8192,
+                    "elapsed_seconds": 32,
+                }
+            )
+
+        text = output.getvalue()
+        self.assertIn("import=verification status=running", text)
+        self.assertIn("import=verification status=ok", text)
+        self.assertIn(
+            "import=referenced_images status=running bytes_total=8192",
+            text,
+        )
+        self.assertIn("import=referenced_images status=running bytes=4096", text)
+        self.assertIn("import=referenced_images status=verifying", text)
+        self.assertIn("import=referenced_images status=ok bytes=8192", text)
 
 
 if __name__ == "__main__":

--- a/hyops/lab/tests/test_command.py
+++ b/hyops/lab/tests/test_command.py
@@ -12,6 +12,7 @@ class CaptureProgressTest(TestCase):
         output = io.StringIO()
         with redirect_stdout(output):
             progress = _CaptureProgress()
+            self.assertFalse(progress.display.show_elapsed)
             progress(
                 {
                     "phase": "assessment_finished",
@@ -59,6 +60,7 @@ class ImportProgressTest(TestCase):
         output = io.StringIO()
         with redirect_stdout(output):
             progress = _ImportProgress()
+            self.assertFalse(progress.display.show_elapsed)
             progress({"phase": "import_verification_started"})
             progress(
                 {

--- a/hyops/lab/tests/test_command.py
+++ b/hyops/lab/tests/test_command.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from unittest import TestCase
+
+from hyops.lab.command import _CaptureProgress
+
+
+class CaptureProgressTest(TestCase):
+    def test_non_tty_output_reports_assessment_heartbeat_and_completion(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            progress = _CaptureProgress()
+            progress(
+                {
+                    "phase": "assessment_finished",
+                    "primary_bytes": 4096,
+                    "node_state_bytes": 8192,
+                    "image_bytes": 16384,
+                }
+            )
+            progress(
+                {
+                    "phase": "stream_started",
+                    "stage": "node_state",
+                    "expected_source_bytes": 8192,
+                }
+            )
+            progress(
+                {
+                    "phase": "stream_progress",
+                    "stage": "node_state",
+                    "bytes_written": 2048,
+                    "bytes_per_second": 64,
+                    "elapsed_seconds": 31,
+                }
+            )
+            progress(
+                {
+                    "phase": "stream_finished",
+                    "stage": "node_state",
+                    "status": "ok",
+                    "bytes_written": 4096,
+                    "bytes_per_second": 128,
+                    "elapsed_seconds": 32,
+                }
+            )
+
+        text = output.getvalue()
+        self.assertIn("source assessment:", text)
+        self.assertIn("capture=node_state status=running source_bytes=8192", text)
+        self.assertIn("capture=node_state status=running bytes=2048", text)
+        self.assertIn("capture=node_state status=ok bytes=4096", text)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -20,6 +20,7 @@ from hyops.lab.migration import (
     _capture_stream,
     _format_bytes,
     _remote_capture_assessment_script,
+    _remote_capture_script,
     _run_quiescence_script,
     capture_existing_lab,
     inspect_migration_archive,
@@ -826,6 +827,27 @@ class LabMigrationStagingTest(TestCase):
 
 
 class LabMigrationCaptureTest(TestCase):
+    def test_eve_node_state_capture_selects_only_runtime_overlays(self) -> None:
+        assessment = _remote_capture_assessment_script(
+            "eve-ng",
+            include_node_state=True,
+        )
+        capture = _remote_capture_script(
+            "eve-ng",
+            node_state=True,
+            output_available_bytes=1024 * 1024 * 1024,
+            node_state_evidence={
+                "method": "operator-attestation",
+                "qemu_processes_absent": True,
+                "verified_at": "2026-09-01T00:00:00Z",
+                "script_sha256": None,
+            },
+        )
+
+        selector = "-mindepth 4 -maxdepth 4 -type f -name '*.qcow2'"
+        self.assertEqual(assessment.count(selector), 2)
+        self.assertEqual(capture.count(selector), 3)
+
     def test_scripted_capture_assesses_source_before_stopping_qemu(self) -> None:
         script = _remote_capture_assessment_script(
             "eve-ng",

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -454,6 +454,50 @@ class LabMigrationStagingTest(TestCase):
             self.assertEqual(record["status"], "verified")
             self.assertTrue(migration_record_path(paths, "gcp/eve-ng@v1").is_file())
 
+    def test_import_reports_verification_and_archive_staging_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "eve.tar.gz"
+            node_state = Path(tmp) / "nodes.tar.gz"
+            images = Path(tmp) / "images.tar.gz"
+            _write_tar(
+                archive,
+                {"0/network.unl": b'<lab><node type="qemu" image="vios" /></lab>'},
+            )
+            _write_tar(node_state, {"0/network/1/virtioa.qcow2": b"overlay"})
+            _write_tar(images, {"qemu/vios/virtioa.qcow2": b"base"})
+            events: list[dict[str, object]] = []
+
+            stage_migration_archive(
+                paths=paths,
+                payload=_eve_payload(),
+                platform="eve-ng",
+                archive=archive,
+                node_state=node_state,
+                images=images,
+                progress=events.append,
+            )
+
+        phases = [event["phase"] for event in events]
+        self.assertEqual(phases[0], "import_verification_started")
+        self.assertEqual(phases[1], "import_verification_finished")
+        self.assertEqual(
+            [
+                event["stage"]
+                for event in events
+                if event["phase"] == "stage_finished"
+            ],
+            ["lab_definitions", "node_state", "referenced_images"],
+        )
+        self.assertTrue(
+            all(
+                event["status"] == "ok"
+                for event in events
+                if event["phase"] == "stage_finished"
+            )
+        )
+
     def test_import_is_idempotent_for_same_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             paths = RuntimePaths.from_root(Path(tmp) / "runtime")

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
 import subprocess
 import sys
 import tarfile
@@ -13,6 +14,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from hyops.lab.migration import (
+    _CONTAINERLAB_CAPTURE_PROGRAM,
     _EVE_IMAGE_CAPTURE_PROGRAM,
     _capture_requirements,
     _capture_stream,
@@ -23,6 +25,7 @@ from hyops.lab.migration import (
     load_migration_archive,
     load_migration_images,
     migration_record_path,
+    platform_for_blueprint,
     stage_migration_archive,
 )
 from hyops.runtime.layout import ensure_layout
@@ -66,6 +69,55 @@ def _gns3_payload() -> dict:
             "contract_prefix": "gns3_lab_archive",
         },
     }
+
+
+def _containerlab_payload() -> dict:
+    return {
+        "blueprint_ref": "gcp/containerlab@v1",
+        "steps": [
+            {
+                "module_ref": "platform/linux/containerlab-lab",
+                "inputs": {
+                    "containerlab_lab_topology_relpath": "lab.clab.yml",
+                    "containerlab_lab_labdir_base": (
+                        "/var/lib/hybridops/containerlab/labdirs"
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def _write_containerlab_archive(path: Path, topology: bytes | None = None) -> None:
+    topology_payload = topology or (
+        b"name: test\ntopology:\n  nodes:\n    r1:\n"
+        b"      kind: linux\n      image: alpine:3.20\n"
+    )
+    topology_checksum = hashlib.sha256(topology_payload).hexdigest()
+    manifest = json.dumps(
+        {
+            "schema": "hybridops.containerlab.recovery/v1",
+            "mode": "rebuild",
+            "topology_relpath": "lab.clab.yml",
+            "topology_sha256": topology_checksum,
+            "source_root_included": True,
+            "containerlab_version": "0.78.0",
+            "image_refs": ["alpine:3.20"],
+            "labdir_base": "/var/lib/hybridops/containerlab/labdirs",
+            "native_config_save_attempted": True,
+            "native_config_save_rc": 0,
+            "native_snapshots_requested": False,
+            "lab_directory_included": False,
+            "additional_paths_count": 0,
+        }
+    ).encode()
+    _write_tar(
+        path,
+        {
+            "containerlab-migration/lab-source/lab.clab.yml": topology_payload,
+            "containerlab-migration/hybridops-recovery-manifest.json": manifest,
+        },
+    )
 
 
 class LabMigrationInspectionTest(TestCase):
@@ -287,6 +339,50 @@ class LabMigrationInspectionTest(TestCase):
         self.assertEqual(report["image_references"], ["vios.qcow2"])
         self.assertFalse(report["images_included"])
 
+    def test_inspects_containerlab_recovery_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "containerlab.tar.gz"
+            _write_containerlab_archive(archive)
+
+            report = inspect_migration_archive(
+                platform="containerlab",
+                archive=archive,
+            )
+
+        self.assertEqual(report["definition_count"], 1)
+        self.assertEqual(report["image_references"], ["alpine:3.20"])
+        self.assertEqual(
+            report["containerlab"]["topology_relpath"],
+            "lab.clab.yml",
+        )
+        self.assertFalse(report["images_included"])
+
+    def test_rejects_containerlab_topology_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "containerlab.tar.gz"
+            _write_containerlab_archive(archive)
+            with tarfile.open(archive, mode="r:gz") as source:
+                manifest_member = source.getmember(
+                    "containerlab-migration/hybridops-recovery-manifest.json"
+                )
+                manifest = json.loads(source.extractfile(manifest_member).read())
+            manifest["topology_sha256"] = "a" * 64
+            _write_tar(
+                archive,
+                {
+                    "containerlab-migration/lab-source/lab.clab.yml": b"name: test\n",
+                    "containerlab-migration/hybridops-recovery-manifest.json": (
+                        json.dumps(manifest).encode()
+                    ),
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "checksum does not match"):
+                inspect_migration_archive(
+                    platform="containerlab",
+                    archive=archive,
+                )
+
     def test_expected_checksum_is_enforced(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             archive = Path(tmp) / "eve.tar.gz"
@@ -487,6 +583,107 @@ class LabMigrationStagingTest(TestCase):
     def test_gns3_payload_helper_is_valid(self) -> None:
         self.assertEqual(_gns3_payload()["blueprint_ref"], "gcp/gns3@v1")
 
+    def test_stages_containerlab_as_latest_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "containerlab.tar.gz"
+            _write_containerlab_archive(archive)
+
+            record = stage_migration_archive(
+                paths=paths,
+                payload=_containerlab_payload(),
+                platform="containerlab",
+                archive=archive,
+            )
+
+            latest = paths.root / "artifacts/containerlab/recovery/latest.tar.gz"
+            self.assertTrue(latest.is_symlink())
+            self.assertTrue(latest.resolve().is_file())
+            self.assertEqual(
+                latest.resolve(),
+                Path(record["archive"]["path"]).resolve(),
+            )
+            self.assertEqual(
+                latest.with_name(latest.name + ".sha256").read_text().strip(),
+                record["archive"]["sha256"],
+            )
+            metadata = json.loads(latest.with_name(latest.name + ".json").read_text())
+            self.assertEqual(
+                metadata["topology_sha256"],
+                record["containerlab"]["topology_sha256"],
+            )
+
+    def test_containerlab_latest_recovery_replacement_requires_force(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            recovery = paths.root / "artifacts/containerlab/recovery"
+            recovery.mkdir(parents=True)
+            latest = recovery / "latest.tar.gz"
+            latest.write_bytes(b"old archive")
+            latest.with_name(latest.name + ".sha256").write_text(
+                "a" * 64 + "\n",
+                encoding="utf-8",
+            )
+            latest.with_name(latest.name + ".json").write_text(
+                "{}\n",
+                encoding="utf-8",
+            )
+            archive = Path(tmp) / "containerlab.tar.gz"
+            _write_containerlab_archive(archive)
+
+            with self.assertRaisesRegex(ValueError, "latest recovery set"):
+                stage_migration_archive(
+                    paths=paths,
+                    payload=_containerlab_payload(),
+                    platform="containerlab",
+                    archive=archive,
+                )
+
+    def test_containerlab_import_requires_matching_topology_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "containerlab.tar.gz"
+            _write_containerlab_archive(archive)
+            payload = _containerlab_payload()
+            payload["steps"][0]["inputs"]["containerlab_lab_topology_relpath"] = (
+                "other.clab.yml"
+            )
+
+            with self.assertRaisesRegex(ValueError, "topology path does not match"):
+                stage_migration_archive(
+                    paths=paths,
+                    payload=payload,
+                    platform="containerlab",
+                    archive=archive,
+                )
+
+    def test_containerlab_import_requires_matching_labdir_base(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "containerlab.tar.gz"
+            _write_containerlab_archive(archive)
+            payload = _containerlab_payload()
+            payload["steps"][0]["inputs"]["containerlab_lab_labdir_base"] = (
+                "/var/lib/containerlab"
+            )
+
+            with self.assertRaisesRegex(ValueError, "labdir base does not match"):
+                stage_migration_archive(
+                    paths=paths,
+                    payload=payload,
+                    platform="containerlab",
+                    archive=archive,
+                )
+
+    def test_containerlab_blueprint_platform_is_detected_from_lab_step(self) -> None:
+        self.assertEqual(
+            platform_for_blueprint(_containerlab_payload()), "containerlab"
+        )
+
     def test_import_rejects_insufficient_controller_disk_space(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             paths = RuntimePaths.from_root(Path(tmp) / "runtime")
@@ -531,6 +728,144 @@ class LabMigrationCaptureTest(TestCase):
         self.assertIn("primary_bytes=", script)
         self.assertIn("node_state_bytes=", script)
         self.assertNotIn("tar --", script)
+
+    def test_containerlab_assessment_uses_declared_source(self) -> None:
+        script = _remote_capture_assessment_script(
+            "containerlab",
+            source_root="/srv/labs/demo",
+            topology_relpath="lab.clab.yml",
+            source_labdir_base="",
+            target_labdir_base="/var/lib/hybridops/containerlab/labdirs",
+        )
+
+        self.assertIn("/srv/labs/demo", script)
+        self.assertIn("primary_bytes=", script)
+        self.assertNotIn("tar --", script)
+
+    def test_containerlab_capture_requires_a_source_root(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires --source-root"):
+            capture_existing_lab(
+                platform="containerlab",
+                host="containerlab.example.test",
+                output="containerlab.tar.gz",
+            )
+
+    def test_containerlab_capture_rejects_image_export(self) -> None:
+        with self.assertRaisesRegex(ValueError, "image references"):
+            capture_existing_lab(
+                platform="containerlab",
+                host="containerlab.example.test",
+                output="containerlab.tar.gz",
+                source_root="/srv/labs/demo",
+                include_images=True,
+            )
+
+    def test_remote_containerlab_capture_builds_recovery_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source"
+            source.mkdir()
+            (source / "lab.clab.yml").write_text(
+                "name: test\ntopology:\n  nodes:\n    r1:\n"
+                "      kind: linux\n      image: alpine:3.20\n",
+                encoding="utf-8",
+            )
+            runtime = source / "clab-test"
+            runtime.mkdir()
+            (runtime / "transient").write_text("runtime", encoding="utf-8")
+
+            capture = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    _CONTAINERLAB_CAPTURE_PROGRAM,
+                    "capture",
+                    str(source),
+                    "lab.clab.yml",
+                    "",
+                    "/var/lib/hybridops/containerlab/labdirs",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(capture.returncode, 0, capture.stderr.decode())
+            archive = Path(tmp) / "containerlab.tar.gz"
+            archive.write_bytes(capture.stdout)
+            report = inspect_migration_archive(
+                platform="containerlab",
+                archive=archive,
+            )
+            with tarfile.open(archive, mode="r:gz") as handle:
+                names = handle.getnames()
+
+        self.assertEqual(report["image_references"], ["alpine:3.20"])
+        self.assertFalse(any("clab-test" in name for name in names))
+
+    def test_remote_containerlab_capture_merges_native_saved_configs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            existing_configs = source / "startup-configs"
+            existing_configs.mkdir(parents=True)
+            (existing_configs / "existing.cfg").write_text(
+                "existing\n",
+                encoding="utf-8",
+            )
+            (source / "lab.clab.yml").write_text(
+                "name: test\ntopology:\n  nodes:\n    r1:\n"
+                "      kind: linux\n      image: alpine:3.20\n",
+                encoding="utf-8",
+            )
+            executable = root / "containerlab"
+            executable.write_text(
+                "#!/bin/sh\n"
+                'case "$1" in\n'
+                "  save)\n"
+                '    [ "$CLAB_LABDIR_BASE" = '
+                '"/srv/containerlab/runtime" ] || exit 9\n'
+                "    for destination do :; done\n"
+                '    mkdir -p "$destination"\n'
+                '    printf "saved\\n" >"$destination/saved.cfg"\n'
+                "    ;;\n"
+                '  version) printf \'{"version":"0.78.0"}\\n\' ;;\n'
+                "  inspect) printf '[]\\n' ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
+            environment = dict(os.environ)
+            environment["PATH"] = f"{root}:{environment.get('PATH', '')}"
+
+            capture = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    _CONTAINERLAB_CAPTURE_PROGRAM,
+                    "capture",
+                    str(source),
+                    "lab.clab.yml",
+                    "/srv/containerlab/runtime",
+                    "/var/lib/hybridops/containerlab/labdirs",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                env=environment,
+            )
+            self.assertEqual(capture.returncode, 0, capture.stderr.decode())
+            archive = Path(tmp) / "containerlab.tar.gz"
+            archive.write_bytes(capture.stdout)
+            with tarfile.open(archive, mode="r:gz") as handle:
+                names = set(handle.getnames())
+
+        self.assertIn(
+            "containerlab-migration/lab-source/startup-configs/existing.cfg",
+            names,
+        )
+        self.assertIn(
+            "containerlab-migration/lab-source/startup-configs/saved.cfg",
+            names,
+        )
 
     def test_parses_capture_assessment(self) -> None:
         with patch(

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -1000,11 +1000,16 @@ class LabMigrationCaptureTest(TestCase):
                 user="operator",
                 output=output,
                 include_node_state=True,
+                guest_quiesced=True,
                 progress=progress_events.append,
             )
 
             self.assertTrue(output.is_file())
             self.assertTrue(Path(report["node_state"]["path"]).is_file())
+            self.assertEqual(
+                report["node_state"]["capture_consistency"],
+                "guest-quiesced",
+            )
             self.assertEqual(report["definition_count"], 1)
             self.assertEqual(run.call_count, 2)
             control_paths = set()
@@ -1153,11 +1158,30 @@ class LabMigrationCaptureTest(TestCase):
                     host="eve.example.test",
                     output=output,
                     include_node_state=True,
+                    guest_quiesced=True,
                     node_state_output=node_output,
                 )
 
             self.assertFalse(output.exists())
             self.assertEqual(list(Path(tmp).glob("*.candidate")), [])
+
+    def test_node_state_capture_requires_guest_quiescence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires --guest-quiesced"):
+            capture_existing_lab(
+                platform="eve-ng",
+                host="eve.example.test",
+                output="eve.tar.gz",
+                include_node_state=True,
+            )
+
+    def test_guest_quiescence_requires_node_state_capture(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires --include-node-state"):
+            capture_existing_lab(
+                platform="eve-ng",
+                host="eve.example.test",
+                output="eve.tar.gz",
+                guest_quiesced=True,
+            )
 
     def test_captures_referenced_eve_images_as_a_companion(self) -> None:
         primary = _tar_bytes(

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.lab.migration import (
+    _capture_stream,
+    capture_existing_lab,
+    inspect_migration_archive,
+    load_migration_archive,
+    migration_record_path,
+    stage_migration_archive,
+)
+from hyops.runtime.layout import ensure_layout
+from hyops.runtime.paths import RuntimePaths
+
+
+def _write_tar(path: Path, files: dict[str, bytes]) -> None:
+    with tarfile.open(path, mode="w:gz") as handle:
+        for name, payload in files.items():
+            member = tarfile.TarInfo(name=name)
+            member.size = len(payload)
+            handle.addfile(member, io.BytesIO(payload))
+
+
+def _tar_bytes(files: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as handle:
+        for name, payload in files.items():
+            member = tarfile.TarInfo(name=name)
+            member.size = len(payload)
+            handle.addfile(member, io.BytesIO(payload))
+    return output.getvalue()
+
+
+def _eve_payload() -> dict:
+    return {
+        "blueprint_ref": "gcp/eve-ng@v1",
+        "archive_before_destroy": {
+            "module_ref": "platform/linux/eve-ng-lab-archive",
+            "state_instance": "gcp_eve_ng_lab_archive",
+        },
+    }
+
+
+def _gns3_payload() -> dict:
+    return {
+        "blueprint_ref": "gcp/gns3@v1",
+        "archive_before_destroy": {
+            "module_ref": "platform/linux/gns3-lab-archive",
+            "state_instance": "gcp_gns3_lab_archive",
+            "contract_prefix": "gns3_lab_archive",
+        },
+    }
+
+
+class LabMigrationInspectionTest(TestCase):
+    def test_inspects_eve_archive_and_node_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            node_state = Path(tmp) / "nodes.tar.gz"
+            _write_tar(
+                archive,
+                {
+                    "0/network.unl": (
+                        b'<lab><node name="r1" image="vios-159" /></lab>'
+                    )
+                },
+            )
+            _write_tar(node_state, {"0/network/1/virtioa.qcow2": b"overlay"})
+
+            report = inspect_migration_archive(
+                platform="eve-ng",
+                archive=archive,
+                node_state=node_state,
+            )
+
+        self.assertEqual(report["status"], "compatible")
+        self.assertEqual(report["definition_count"], 1)
+        self.assertEqual(report["image_references"], ["vios-159"])
+        self.assertGreater(report["archive"]["expanded_size_bytes"], 0)
+        self.assertEqual(report["node_state"]["overlay_count"], 1)
+        self.assertGreater(report["node_state"]["expanded_size_bytes"], 0)
+
+    def test_rejects_unsafe_archive_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "unsafe.tar.gz"
+            _write_tar(archive, {"../network.unl": b"<lab />"})
+
+            with self.assertRaisesRegex(ValueError, "escapes its root"):
+                inspect_migration_archive(platform="eve-ng", archive=archive)
+
+    def test_rejects_duplicate_normalised_member(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "duplicate.tar.gz"
+            with tarfile.open(archive, mode="w:gz") as handle:
+                for name in ("0/network.unl", "./0/network.unl"):
+                    payload = b"<lab />"
+                    member = tarfile.TarInfo(name=name)
+                    member.size = len(payload)
+                    handle.addfile(member, io.BytesIO(payload))
+
+            with self.assertRaisesRegex(ValueError, "duplicate member"):
+                inspect_migration_archive(platform="eve-ng", archive=archive)
+
+    def test_rejects_eve_archive_with_host_root_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            _write_tar(
+                archive,
+                {"opt/unetlab/labs/0/network.unl": b"<lab />"},
+            )
+
+            with self.assertRaisesRegex(ValueError, "relative to /opt/unetlab/labs"):
+                inspect_migration_archive(platform="eve-ng", archive=archive)
+
+    def test_rejects_invalid_eve_node_state_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            node_state = Path(tmp) / "nodes.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+            _write_tar(node_state, {"tmp/network/overlay.qcow2": b"overlay"})
+
+            with self.assertRaisesRegex(ValueError, "invalid path"):
+                inspect_migration_archive(
+                    platform="eve-ng",
+                    archive=archive,
+                    node_state=node_state,
+                )
+
+    def test_inspects_gns3_projects_and_image_references(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "gns3.tar.gz"
+            project = json.dumps(
+                {
+                    "topology": {
+                        "nodes": [
+                            {"properties": {"hda_disk_image": "vios.qcow2"}}
+                        ]
+                    }
+                }
+            ).encode()
+            _write_tar(archive, {"projects/lab/project.gns3": project})
+
+            report = inspect_migration_archive(
+                platform="gns3",
+                archive=archive,
+            )
+
+        self.assertEqual(report["definition_count"], 1)
+        self.assertEqual(report["image_references"], ["vios.qcow2"])
+        self.assertFalse(report["images_included"])
+
+    def test_expected_checksum_is_enforced(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                inspect_migration_archive(
+                    platform="eve-ng",
+                    archive=archive,
+                    expected_sha256="a" * 64,
+                )
+
+
+class LabMigrationStagingTest(TestCase):
+    def test_stages_and_loads_verified_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "eve.tar.gz"
+            node_state = Path(tmp) / "nodes.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+            _write_tar(node_state, {"0/network/1/virtioa.qcow2": b"overlay"})
+
+            record = stage_migration_archive(
+                paths=paths,
+                payload=_eve_payload(),
+                platform="eve-ng",
+                archive=archive,
+                node_state=node_state,
+            )
+            loaded = load_migration_archive(paths=paths, payload=_eve_payload())
+
+            self.assertIsNotNone(loaded)
+            primary, checksum, node_path, node_checksum = loaded
+            self.assertTrue(primary.is_file())
+            self.assertTrue(node_path.is_file())
+            self.assertEqual(checksum, hashlib.sha256(archive.read_bytes()).hexdigest())
+            self.assertEqual(
+                node_checksum,
+                hashlib.sha256(node_state.read_bytes()).hexdigest(),
+            )
+            self.assertEqual(record["status"], "verified")
+            self.assertTrue(
+                migration_record_path(paths, "gcp/eve-ng@v1").is_file()
+            )
+
+    def test_import_is_idempotent_for_same_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "eve.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+
+            first = stage_migration_archive(
+                paths=paths,
+                payload=_eve_payload(),
+                platform="eve-ng",
+                archive=archive,
+            )
+            second = stage_migration_archive(
+                paths=paths,
+                payload=_eve_payload(),
+                platform="eve-ng",
+                archive=archive,
+            )
+
+        self.assertEqual(first["archive"]["path"], second["archive"]["path"])
+
+    def test_different_bundle_requires_force(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            first = Path(tmp) / "first.tar.gz"
+            second = Path(tmp) / "second.tar.gz"
+            _write_tar(first, {"0/first.unl": b"<lab />"})
+            _write_tar(second, {"0/second.unl": b"<lab />"})
+            stage_migration_archive(
+                paths=paths,
+                payload=_eve_payload(),
+                platform="eve-ng",
+                archive=first,
+            )
+
+            with self.assertRaisesRegex(ValueError, "already staged"):
+                stage_migration_archive(
+                    paths=paths,
+                    payload=_eve_payload(),
+                    platform="eve-ng",
+                    archive=second,
+                )
+
+    def test_node_state_change_creates_a_new_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "eve.tar.gz"
+            first_node_state = Path(tmp) / "nodes-first.tar.gz"
+            second_node_state = Path(tmp) / "nodes-second.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+            _write_tar(
+                first_node_state,
+                {"0/network/1/virtioa.qcow2": b"first"},
+            )
+            _write_tar(
+                second_node_state,
+                {"0/network/1/virtioa.qcow2": b"second"},
+            )
+
+            first = stage_migration_archive(
+                paths=paths,
+                payload=_eve_payload(),
+                platform="eve-ng",
+                archive=archive,
+                node_state=first_node_state,
+            )
+            second = stage_migration_archive(
+                paths=paths,
+                payload=_eve_payload(),
+                platform="eve-ng",
+                archive=archive,
+                node_state=second_node_state,
+                force=True,
+            )
+
+        self.assertNotEqual(first["node_state"]["path"], second["node_state"]["path"])
+        self.assertEqual(
+            second["supersedes"]["node_state_sha256"],
+            first["node_state"]["sha256"],
+        )
+
+    def test_platform_must_match_blueprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "gns3.tar.gz"
+            _write_tar(archive, {"projects/lab/project.gns3": b"{}"})
+
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                stage_migration_archive(
+                    paths=paths,
+                    payload=_eve_payload(),
+                    platform="gns3",
+                    archive=archive,
+                )
+
+    def test_record_outside_artifact_root_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "eve.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+            checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+            record_path = migration_record_path(paths, "gcp/eve-ng@v1")
+            record_path.parent.mkdir(parents=True)
+            record_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "kind": "hybridops/lab-migration",
+                        "status": "verified",
+                        "platform": "eve-ng",
+                        "blueprint_ref": "gcp/eve-ng@v1",
+                        "archive": {"path": str(archive), "sha256": checksum},
+                        "node_state": None,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "outside"):
+                load_migration_archive(paths=paths, payload=_eve_payload())
+
+    def test_gns3_payload_helper_is_valid(self) -> None:
+        self.assertEqual(_gns3_payload()["blueprint_ref"], "gcp/gns3@v1")
+
+    def test_import_rejects_insufficient_controller_disk_space(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = RuntimePaths.from_root(Path(tmp) / "runtime")
+            ensure_layout(paths)
+            archive = Path(tmp) / "eve.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+
+            with patch(
+                "hyops.lab.migration.shutil.disk_usage",
+                return_value=SimpleNamespace(free=1),
+            ), self.assertRaisesRegex(
+                ValueError,
+                "insufficient disk space for migration import",
+            ):
+                stage_migration_archive(
+                    paths=paths,
+                    payload=_eve_payload(),
+                    platform="eve-ng",
+                    archive=archive,
+                )
+
+
+class LabMigrationCaptureTest(TestCase):
+    def test_captures_eve_archive_and_node_state_over_ssh(self) -> None:
+        primary = _tar_bytes({"0/network.unl": b"<lab />"})
+        nodes = _tar_bytes({"0/network/1/virtioa.qcow2": b"overlay"})
+        streams = iter((primary, nodes))
+
+        def run_capture(argv, *, stdout, stderr, check):
+            self.assertEqual(argv[0], "ssh")
+            self.assertFalse(check)
+            self.assertEqual(stderr, subprocess.PIPE)
+            stdout.write(next(streams))
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.lab.migration.subprocess.run",
+            side_effect=run_capture,
+        ) as run:
+            output = Path(tmp) / "eve.tar.gz"
+            report = capture_existing_lab(
+                platform="eve-ng",
+                host="eve.example.test",
+                user="operator",
+                output=output,
+                include_node_state=True,
+            )
+
+            self.assertTrue(output.is_file())
+            self.assertTrue(Path(report["node_state"]["path"]).is_file())
+            self.assertEqual(report["definition_count"], 1)
+            self.assertEqual(run.call_count, 2)
+            for call in run.call_args_list:
+                remote = call.args[0][-1]
+                self.assertNotIn("systemctl stop", remote)
+                self.assertNotIn("rm ", remote)
+
+    def test_capture_failure_does_not_publish_partial_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.lab.migration.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["ssh"],
+                21,
+                b"",
+                b"EVE-NG QEMU nodes are running",
+            ),
+        ):
+            output = Path(tmp) / "eve.tar.gz"
+            with self.assertRaisesRegex(ValueError, "nodes are running"):
+                capture_existing_lab(
+                    platform="eve-ng",
+                    host="eve.example.test",
+                    output=output,
+                )
+
+            self.assertFalse(output.exists())
+
+    def test_capture_translates_late_disk_full_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            candidate = Path(tmp) / "capture.candidate"
+            with patch(
+                "hyops.lab.migration.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["ssh"], 1, b"", b"write failed: No space left on device"
+                ),
+            ), self.assertRaisesRegex(
+                ValueError,
+                "output filesystem became full",
+            ):
+                _capture_stream(["ssh"], candidate)
+
+    def test_capture_rejects_symbolic_link_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target.tar.gz"
+            target.write_bytes(b"existing")
+            output = Path(tmp) / "eve.tar.gz"
+            output.symlink_to(target)
+
+            with self.assertRaisesRegex(ValueError, "symbolic link"):
+                capture_existing_lab(
+                    platform="eve-ng",
+                    host="eve.example.test",
+                    output=output,
+                    force=True,
+                )
+
+            self.assertEqual(target.read_bytes(), b"existing")
+
+    def test_capture_cleans_candidate_when_companion_output_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "eve.tar.gz"
+            node_output = Path(tmp) / "nodes.tar.gz"
+            node_output.write_bytes(b"existing")
+
+            with self.assertRaisesRegex(ValueError, "output already exists"):
+                capture_existing_lab(
+                    platform="eve-ng",
+                    host="eve.example.test",
+                    output=output,
+                    include_node_state=True,
+                    node_state_output=node_output,
+                )
+
+            self.assertFalse(output.exists())
+            self.assertEqual(list(Path(tmp).glob("*.candidate")), [])
+
+    def test_gns3_image_capture_is_explicit(self) -> None:
+        primary = _tar_bytes({"projects/lab/project.gns3": b"{}"})
+
+        def run_capture(argv, *, stdout, stderr, check):
+            stdout.write(primary)
+            self.assertIn("images", argv[-1])
+            self.assertIn('cd "$root"', argv[-1])
+            self.assertIn("Insufficient disk space for lab capture", argv[-1])
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.lab.migration.subprocess.run",
+            side_effect=run_capture,
+        ):
+            report = capture_existing_lab(
+                platform="gns3",
+                host="gns3.example.test",
+                output=Path(tmp) / "gns3.tar.gz",
+                include_images=True,
+            )
+
+        self.assertEqual(report["platform"], "gns3")
+
+    def test_capture_reports_insufficient_output_disk_space(self) -> None:
+        def reject_capture(argv, *, stdout, stderr, check):
+            self.assertIn("Insufficient disk space for lab capture", argv[-1])
+            return subprocess.CompletedProcess(
+                argv,
+                23,
+                b"",
+                b"Insufficient disk space for lab capture: source requires at least "
+                b"1048576 bytes; output filesystem has 1 bytes available",
+            )
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.lab.migration.shutil.disk_usage",
+            return_value=SimpleNamespace(free=1),
+        ), patch(
+            "hyops.lab.migration.subprocess.run",
+            side_effect=reject_capture,
+        ):
+            output = Path(tmp) / "eve.tar.gz"
+            with self.assertRaisesRegex(
+                ValueError,
+                "Insufficient disk space for lab capture",
+            ):
+                capture_existing_lab(
+                    platform="eve-ng",
+                    host="eve.example.test",
+                    output=output,
+                )
+
+            self.assertFalse(output.exists())

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -21,6 +21,7 @@ from hyops.lab.migration import (
     capture_existing_lab,
     inspect_migration_archive,
     load_migration_archive,
+    load_migration_images,
     migration_record_path,
     stage_migration_archive,
 )
@@ -74,11 +75,7 @@ class LabMigrationInspectionTest(TestCase):
             node_state = Path(tmp) / "nodes.tar.gz"
             _write_tar(
                 archive,
-                {
-                    "0/network.unl": (
-                        b'<lab><node name="r1" image="vios-159" /></lab>'
-                    )
-                },
+                {"0/network.unl": (b'<lab><node name="r1" image="vios-159" /></lab>')},
             )
             _write_tar(node_state, {"0/network/1/virtioa.qcow2": b"overlay"})
 
@@ -134,8 +131,7 @@ class LabMigrationInspectionTest(TestCase):
                 archive,
                 {
                     "0/network.unl": (
-                        b'<!DOCTYPE lab [<!ENTITY x "expanded">]>'
-                        b"<lab><node name='&x;' /></lab>"
+                        b"<!DOCTYPE lab [<!ENTITY x \"expanded\">]><lab><node name='&x;' /></lab>"
                     )
                 },
             )
@@ -182,7 +178,9 @@ class LabMigrationInspectionTest(TestCase):
 
         self.assertTrue(report["images_included"])
         self.assertEqual(report["images"]["image_count"], 1)
-        self.assertEqual(report["warnings"], ["writable QEMU node state is not included"])
+        self.assertEqual(
+            report["warnings"], ["writable QEMU node state is not included"]
+        )
 
     def test_rejects_incomplete_eve_image_companion(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -205,15 +203,76 @@ class LabMigrationInspectionTest(TestCase):
                     images=images,
                 )
 
+    def test_rejects_unreferenced_eve_image_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            images = Path(tmp) / "images.tar.gz"
+            _write_tar(
+                archive,
+                {"0/network.unl": b'<lab><node type="qemu" image="vios" /></lab>'},
+            )
+            _write_tar(
+                images,
+                {
+                    "qemu/vios/virtioa.qcow2": b"required",
+                    "qemu/other/virtioa.qcow2": b"unreferenced",
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "unreferenced base"):
+                inspect_migration_archive(
+                    platform="eve-ng",
+                    archive=archive,
+                    images=images,
+                )
+
+    def test_rejects_iol_licence_material(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            images = Path(tmp) / "images.tar.gz"
+            _write_tar(
+                archive,
+                {"0/network.unl": b'<lab><node type="iol" image="router.bin" /></lab>'},
+            )
+            _write_tar(
+                images,
+                {
+                    "iol/bin/router.bin": b"image",
+                    "iol/bin/iourc": b"licence",
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "licence material"):
+                inspect_migration_archive(
+                    platform="eve-ng",
+                    archive=archive,
+                    images=images,
+                )
+
+    def test_rejects_image_under_the_wrong_eve_type_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            images = Path(tmp) / "images.tar.gz"
+            _write_tar(
+                archive,
+                {"0/network.unl": b'<lab><node type="qemu" image="vios" /></lab>'},
+            )
+            _write_tar(images, {"iol/bin/vios": b"wrong type"})
+
+            with self.assertRaisesRegex(ValueError, "missing a referenced base"):
+                inspect_migration_archive(
+                    platform="eve-ng",
+                    archive=archive,
+                    images=images,
+                )
+
     def test_inspects_gns3_projects_and_image_references(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             archive = Path(tmp) / "gns3.tar.gz"
             project = json.dumps(
                 {
                     "topology": {
-                        "nodes": [
-                            {"properties": {"hda_disk_image": "vios.qcow2"}}
-                        ]
+                        "nodes": [{"properties": {"hda_disk_image": "vios.qcow2"}}]
                     }
                 }
             ).encode()
@@ -269,6 +328,10 @@ class LabMigrationStagingTest(TestCase):
                 images=images,
             )
             loaded = load_migration_archive(paths=paths, payload=_eve_payload())
+            loaded_images = load_migration_images(
+                paths=paths,
+                payload=_eve_payload(),
+            )
 
             self.assertIsNotNone(loaded)
             (
@@ -291,10 +354,9 @@ class LabMigrationStagingTest(TestCase):
                 image_checksum,
                 hashlib.sha256(images.read_bytes()).hexdigest(),
             )
+            self.assertEqual(loaded_images, (image_path, image_checksum))
             self.assertEqual(record["status"], "verified")
-            self.assertTrue(
-                migration_record_path(paths, "gcp/eve-ng@v1").is_file()
-            )
+            self.assertTrue(migration_record_path(paths, "gcp/eve-ng@v1").is_file())
 
     def test_import_is_idempotent_for_same_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -432,12 +494,15 @@ class LabMigrationStagingTest(TestCase):
             archive = Path(tmp) / "eve.tar.gz"
             _write_tar(archive, {"0/network.unl": b"<lab />"})
 
-            with patch(
-                "hyops.lab.migration.shutil.disk_usage",
-                return_value=SimpleNamespace(free=1),
-            ), self.assertRaisesRegex(
-                ValueError,
-                "insufficient disk space for migration import",
+            with (
+                patch(
+                    "hyops.lab.migration.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=1),
+                ),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "insufficient disk space for migration import",
+                ),
             ):
                 stage_migration_archive(
                     paths=paths,
@@ -455,7 +520,9 @@ class LabMigrationCaptureTest(TestCase):
         )
         self.assertEqual(_format_bytes(11821371392), "11.0 GiB (11821371392 bytes)")
 
-    def test_assessment_reports_both_eve_streams_without_transferring_data(self) -> None:
+    def test_assessment_reports_both_eve_streams_without_transferring_data(
+        self,
+    ) -> None:
         script = _remote_capture_assessment_script(
             "eve-ng",
             include_node_state=True,
@@ -487,27 +554,33 @@ class LabMigrationCaptureTest(TestCase):
         )
 
     def test_rejects_invalid_capture_assessment(self) -> None:
-        with patch(
-            "hyops.lab.migration.subprocess.run",
-            return_value=subprocess.CompletedProcess(
-                ["ssh"],
-                0,
-                b"primary_bytes=4096\nunexpected=value\n",
-                b"",
+        with (
+            patch(
+                "hyops.lab.migration.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["ssh"],
+                    0,
+                    b"primary_bytes=4096\nunexpected=value\n",
+                    b"",
+                ),
             ),
-        ), self.assertRaisesRegex(ValueError, "invalid output"):
+            self.assertRaisesRegex(ValueError, "invalid output"),
+        ):
             _capture_requirements(["ssh"])
 
     def test_rejects_duplicate_capture_assessment_size(self) -> None:
-        with patch(
-            "hyops.lab.migration.subprocess.run",
-            return_value=subprocess.CompletedProcess(
-                ["ssh"],
-                0,
-                b"primary_bytes=4096\nprimary_bytes=8192\nnode_state_bytes=0\n",
-                b"",
+        with (
+            patch(
+                "hyops.lab.migration.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["ssh"],
+                    0,
+                    b"primary_bytes=4096\nprimary_bytes=8192\nnode_state_bytes=0\n",
+                    b"",
+                ),
             ),
-        ), self.assertRaisesRegex(ValueError, "duplicate size"):
+            self.assertRaisesRegex(ValueError, "duplicate size"),
+        ):
             _capture_requirements(["ssh"])
 
     def test_captures_eve_archive_and_node_state_over_ssh(self) -> None:
@@ -522,19 +595,24 @@ class LabMigrationCaptureTest(TestCase):
             stdout.write(next(streams))
             return subprocess.CompletedProcess(argv, 0, b"", b"")
 
-        with tempfile.TemporaryDirectory() as tmp, patch(
-            "hyops.lab.migration._capture_requirements",
-            return_value={
-                "primary_bytes": len(primary),
-                "node_state_bytes": len(nodes),
-                "image_bytes": 0,
-            },
-        ), patch(
-            "hyops.lab.migration._close_ssh_control",
-        ), patch(
-            "hyops.lab.migration.subprocess.run",
-            side_effect=run_capture,
-        ) as run:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch(
+                "hyops.lab.migration._capture_requirements",
+                return_value={
+                    "primary_bytes": len(primary),
+                    "node_state_bytes": len(nodes),
+                    "image_bytes": 0,
+                },
+            ),
+            patch(
+                "hyops.lab.migration._close_ssh_control",
+            ),
+            patch(
+                "hyops.lab.migration.subprocess.run",
+                side_effect=run_capture,
+            ) as run,
+        ):
             output = Path(tmp) / "eve.tar.gz"
             report = capture_existing_lab(
                 platform="eve-ng",
@@ -561,13 +639,16 @@ class LabMigrationCaptureTest(TestCase):
             self.assertEqual(len(control_paths), 1)
 
     def test_capture_failure_does_not_publish_partial_output(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp, patch(
-            "hyops.lab.migration.subprocess.run",
-            return_value=subprocess.CompletedProcess(
-                ["ssh"],
-                21,
-                b"",
-                b"EVE-NG QEMU nodes are running",
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch(
+                "hyops.lab.migration.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["ssh"],
+                    21,
+                    b"",
+                    b"EVE-NG QEMU nodes are running",
+                ),
             ),
         ):
             output = Path(tmp) / "eve.tar.gz"
@@ -583,33 +664,39 @@ class LabMigrationCaptureTest(TestCase):
     def test_capture_translates_late_disk_full_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             candidate = Path(tmp) / "capture.candidate"
-            with patch(
-                "hyops.lab.migration.subprocess.run",
-                return_value=subprocess.CompletedProcess(
-                    ["ssh"], 1, b"", b"write failed: No space left on device"
+            with (
+                patch(
+                    "hyops.lab.migration.subprocess.run",
+                    return_value=subprocess.CompletedProcess(
+                        ["ssh"], 1, b"", b"write failed: No space left on device"
+                    ),
                 ),
-            ), self.assertRaisesRegex(
-                ValueError,
-                "output filesystem became full",
+                self.assertRaisesRegex(
+                    ValueError,
+                    "output filesystem became full",
+                ),
             ):
                 _capture_stream(["ssh"], candidate)
 
     def test_capture_translates_remote_capacity_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             candidate = Path(tmp) / "capture.candidate"
-            with patch(
-                "hyops.lab.migration.subprocess.run",
-                return_value=subprocess.CompletedProcess(
-                    ["ssh"],
-                    23,
-                    b"",
-                    b"Insufficient disk space for lab capture: source requires "
-                    b"at least 171627474944 bytes; output filesystem has "
-                    b"11821371392 bytes available",
+            with (
+                patch(
+                    "hyops.lab.migration.subprocess.run",
+                    return_value=subprocess.CompletedProcess(
+                        ["ssh"],
+                        23,
+                        b"",
+                        b"Insufficient disk space for lab capture: source requires "
+                        b"at least 171627474944 bytes; output filesystem has "
+                        b"11821371392 bytes available",
+                    ),
                 ),
-            ), self.assertRaisesRegex(
-                ValueError,
-                r"159\.8 GiB.*11\.0 GiB",
+                self.assertRaisesRegex(
+                    ValueError,
+                    r"159\.8 GiB.*11\.0 GiB",
+                ),
             ):
                 _capture_stream(["ssh"], candidate)
 
@@ -650,34 +737,33 @@ class LabMigrationCaptureTest(TestCase):
 
     def test_captures_referenced_eve_images_as_a_companion(self) -> None:
         primary = _tar_bytes(
-            {
-                "0/network.unl": (
-                    b'<lab><node type="qemu" image="vios-159" /></lab>'
-                )
-            }
+            {"0/network.unl": (b'<lab><node type="qemu" image="vios-159" /></lab>')}
         )
-        images = _tar_bytes(
-            {"qemu/vios-159/virtioa.qcow2": b"base image"}
-        )
+        images = _tar_bytes({"qemu/vios-159/virtioa.qcow2": b"base image"})
         streams = iter((primary, images))
 
         def run_capture(argv, *, stdout, stderr, check):
             stdout.write(next(streams))
             return subprocess.CompletedProcess(argv, 0, b"", b"")
 
-        with tempfile.TemporaryDirectory() as tmp, patch(
-            "hyops.lab.migration._capture_requirements",
-            return_value={
-                "primary_bytes": len(primary),
-                "node_state_bytes": 0,
-                "image_bytes": len(images),
-            },
-        ), patch(
-            "hyops.lab.migration._close_ssh_control",
-        ), patch(
-            "hyops.lab.migration.subprocess.run",
-            side_effect=run_capture,
-        ) as run:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch(
+                "hyops.lab.migration._capture_requirements",
+                return_value={
+                    "primary_bytes": len(primary),
+                    "node_state_bytes": 0,
+                    "image_bytes": len(images),
+                },
+            ),
+            patch(
+                "hyops.lab.migration._close_ssh_control",
+            ),
+            patch(
+                "hyops.lab.migration.subprocess.run",
+                side_effect=run_capture,
+            ) as run,
+        ):
             output = Path(tmp) / "eve.tar.gz"
             report = capture_existing_lab(
                 platform="eve-ng",
@@ -703,18 +789,23 @@ class LabMigrationCaptureTest(TestCase):
             self.assertIn("Insufficient disk space for lab capture", argv[-1])
             return subprocess.CompletedProcess(argv, 0, b"", b"")
 
-        with tempfile.TemporaryDirectory() as tmp, patch(
-            "hyops.lab.migration._capture_requirements",
-            return_value={
-                "primary_bytes": len(primary),
-                "node_state_bytes": 0,
-                "image_bytes": 0,
-            },
-        ), patch(
-            "hyops.lab.migration._close_ssh_control",
-        ), patch(
-            "hyops.lab.migration.subprocess.run",
-            side_effect=run_capture,
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch(
+                "hyops.lab.migration._capture_requirements",
+                return_value={
+                    "primary_bytes": len(primary),
+                    "node_state_bytes": 0,
+                    "image_bytes": 0,
+                },
+            ),
+            patch(
+                "hyops.lab.migration._close_ssh_control",
+            ),
+            patch(
+                "hyops.lab.migration.subprocess.run",
+                side_effect=run_capture,
+            ),
         ):
             report = capture_existing_lab(
                 platform="gns3",
@@ -726,21 +817,27 @@ class LabMigrationCaptureTest(TestCase):
         self.assertEqual(report["platform"], "gns3")
 
     def test_capture_reports_insufficient_output_disk_space(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp, patch(
-            "hyops.lab.migration.shutil.disk_usage",
-            return_value=SimpleNamespace(free=1),
-        ), patch(
-            "hyops.lab.migration._capture_requirements",
-            return_value={
-                "primary_bytes": 1048576,
-                "node_state_bytes": 0,
-                "image_bytes": 0,
-            },
-        ), patch(
-            "hyops.lab.migration._close_ssh_control",
-        ), patch(
-            "hyops.lab.migration._capture_stream",
-        ) as capture_stream:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch(
+                "hyops.lab.migration.shutil.disk_usage",
+                return_value=SimpleNamespace(free=1),
+            ),
+            patch(
+                "hyops.lab.migration._capture_requirements",
+                return_value={
+                    "primary_bytes": 1048576,
+                    "node_state_bytes": 0,
+                    "image_bytes": 0,
+                },
+            ),
+            patch(
+                "hyops.lab.migration._close_ssh_control",
+            ),
+            patch(
+                "hyops.lab.migration._capture_stream",
+            ) as capture_stream,
+        ):
             output = Path(tmp) / "eve.tar.gz"
             with self.assertRaisesRegex(
                 ValueError,
@@ -802,7 +899,9 @@ class LabMigrationCaptureTest(TestCase):
             self.assertEqual(assessment.returncode, 0, assessment.stderr.decode())
             self.assertGreater(int(assessment.stdout), 0)
             self.assertEqual(capture.returncode, 0, capture.stderr.decode())
-            with tarfile.open(fileobj=io.BytesIO(capture.stdout), mode="r:gz") as handle:
+            with tarfile.open(
+                fileobj=io.BytesIO(capture.stdout), mode="r:gz"
+            ) as handle:
                 members = handle.getnames()
 
         self.assertIn("qemu/vios-159/virtioa.qcow2", members)

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -20,6 +20,7 @@ from hyops.lab.migration import (
     _capture_stream,
     _format_bytes,
     _remote_capture_assessment_script,
+    _run_quiescence_script,
     capture_existing_lab,
     inspect_migration_archive,
     load_migration_archive,
@@ -143,6 +144,77 @@ class LabMigrationInspectionTest(TestCase):
         self.assertGreater(report["archive"]["expanded_size_bytes"], 0)
         self.assertEqual(report["node_state"]["overlay_count"], 1)
         self.assertGreater(report["node_state"]["expanded_size_bytes"], 0)
+        self.assertIn(
+            "node-state archive has no verified guest-quiescence evidence",
+            report["warnings"],
+        )
+
+    def test_reads_persisted_eve_quiescence_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            node_state = Path(tmp) / "nodes.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+            _write_tar(
+                node_state,
+                {
+                    "0/network/1/virtioa.qcow2": b"overlay",
+                    "hybridops/capture.json": json.dumps(
+                        {
+                            "schema": "hybridops.eve-node-state-capture/v1",
+                            "quiescence": {
+                                "method": "operator-script",
+                                "qemu_processes_absent": True,
+                                "verified_at": "2026-09-01T09:00:00Z",
+                                "script_sha256": "a" * 64,
+                            },
+                        }
+                    ).encode(),
+                },
+            )
+
+            report = inspect_migration_archive(
+                platform="eve-ng",
+                archive=archive,
+                node_state=node_state,
+            )
+
+        self.assertEqual(
+            report["node_state"]["capture_consistency"], "guest-quiesced"
+        )
+        self.assertEqual(
+            report["node_state"]["quiescence"]["method"], "operator-script"
+        )
+        self.assertEqual(report["node_state"]["overlay_count"], 1)
+
+    def test_rejects_invalid_eve_quiescence_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            node_state = Path(tmp) / "nodes.tar.gz"
+            _write_tar(archive, {"0/network.unl": b"<lab />"})
+            _write_tar(
+                node_state,
+                {
+                    "0/network/1/virtioa.qcow2": b"overlay",
+                    "hybridops/capture.json": json.dumps(
+                        {
+                            "schema": "hybridops.eve-node-state-capture/v1",
+                            "quiescence": {
+                                "method": "operator-script",
+                                "qemu_processes_absent": False,
+                                "verified_at": "2026-09-01T09:00:00Z",
+                                "script_sha256": "a" * 64,
+                            },
+                        }
+                    ).encode(),
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "does not verify stopped"):
+                inspect_migration_archive(
+                    platform="eve-ng",
+                    archive=archive,
+                    node_state=node_state,
+                )
 
     def test_rejects_unsafe_archive_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -754,6 +826,95 @@ class LabMigrationStagingTest(TestCase):
 
 
 class LabMigrationCaptureTest(TestCase):
+    def test_scripted_capture_assesses_source_before_stopping_qemu(self) -> None:
+        script = _remote_capture_assessment_script(
+            "eve-ng",
+            include_node_state=True,
+            allow_running_eve_nodes=True,
+        )
+
+        self.assertNotIn("pgrep", script)
+        self.assertIn("node_state_bytes", script)
+
+    def test_runs_quiescence_script_and_verifies_stopped_qemu(self) -> None:
+        calls: list[dict[str, object]] = []
+
+        def run(argv, **kwargs):
+            calls.append({"argv": argv, **kwargs})
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("hyops.lab.migration.subprocess.run", side_effect=run),
+        ):
+            evidence = _run_quiescence_script(
+                host="eve.example.test",
+                user="operator",
+                port=22,
+                identity_file=None,
+                become=True,
+                payload=b"#!/bin/sh\nexit 0\n",
+                script_sha256="a" * 64,
+                timeout_s=60,
+                control_path=Path(tmp) / "control",
+                progress=None,
+            )
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["input"], b"#!/bin/sh\nexit 0\n")
+        self.assertNotIn("#!/bin/sh", " ".join(calls[0]["argv"]))
+        self.assertIn("timeout", " ".join(calls[0]["argv"]))
+        self.assertIn("qemu-system", " ".join(calls[1]["argv"]))
+        self.assertEqual(evidence["method"], "operator-script")
+        self.assertEqual(evidence["script_sha256"], "a" * 64)
+
+    def test_quiescence_script_failure_does_not_expose_output(self) -> None:
+        failure = subprocess.CompletedProcess(
+            ["ssh"],
+            7,
+            b"private output",
+            b"private error",
+        )
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("hyops.lab.migration.subprocess.run", return_value=failure),
+            self.assertRaisesRegex(ValueError, "failed with status 7") as raised,
+        ):
+            _run_quiescence_script(
+                host="eve.example.test",
+                user="operator",
+                port=22,
+                identity_file=None,
+                become=False,
+                payload=b"exit 7\n",
+                script_sha256="b" * 64,
+                timeout_s=60,
+                control_path=Path(tmp) / "control",
+                progress=None,
+            )
+
+        self.assertNotIn("private", str(raised.exception))
+
+    def test_quiescence_timeout_does_not_capture_source_state(self) -> None:
+        failure = subprocess.CompletedProcess(["ssh"], 124, b"", b"")
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("hyops.lab.migration.subprocess.run", return_value=failure),
+            self.assertRaisesRegex(ValueError, "quiescence timed out"),
+        ):
+            _run_quiescence_script(
+                host="eve.example.test",
+                user="operator",
+                port=22,
+                identity_file=None,
+                become=False,
+                payload=b"sleep 600\n",
+                script_sha256="c" * 64,
+                timeout_s=60,
+                control_path=Path(tmp) / "control",
+                progress=None,
+            )
+
     def test_formats_capacity_for_operator_output(self) -> None:
         self.assertEqual(
             _format_bytes(171627474944),

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -4,6 +4,7 @@ import hashlib
 import io
 import json
 import subprocess
+import sys
 import tarfile
 import tempfile
 from pathlib import Path
@@ -12,6 +13,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from hyops.lab.migration import (
+    _EVE_IMAGE_CAPTURE_PROGRAM,
     _capture_requirements,
     _capture_stream,
     _format_bytes,
@@ -155,6 +157,54 @@ class LabMigrationInspectionTest(TestCase):
                     node_state=node_state,
                 )
 
+    def test_inspects_referenced_eve_image_companion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            images = Path(tmp) / "images.tar.gz"
+            _write_tar(
+                archive,
+                {
+                    "0/network.unl": (
+                        b'<lab><node type="qemu" image="vios-159" /></lab>'
+                    )
+                },
+            )
+            _write_tar(
+                images,
+                {"qemu/vios-159/virtioa.qcow2": b"base image"},
+            )
+
+            report = inspect_migration_archive(
+                platform="eve-ng",
+                archive=archive,
+                images=images,
+            )
+
+        self.assertTrue(report["images_included"])
+        self.assertEqual(report["images"]["image_count"], 1)
+        self.assertEqual(report["warnings"], ["writable QEMU node state is not included"])
+
+    def test_rejects_incomplete_eve_image_companion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            images = Path(tmp) / "images.tar.gz"
+            _write_tar(
+                archive,
+                {
+                    "0/network.unl": (
+                        b'<lab><node type="qemu" image="vios-159" /></lab>'
+                    )
+                },
+            )
+            _write_tar(images, {"qemu/other/virtioa.qcow2": b"base image"})
+
+            with self.assertRaisesRegex(ValueError, "missing a referenced base"):
+                inspect_migration_archive(
+                    platform="eve-ng",
+                    archive=archive,
+                    images=images,
+                )
+
     def test_inspects_gns3_projects_and_image_references(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             archive = Path(tmp) / "gns3.tar.gz"
@@ -198,8 +248,17 @@ class LabMigrationStagingTest(TestCase):
             ensure_layout(paths)
             archive = Path(tmp) / "eve.tar.gz"
             node_state = Path(tmp) / "nodes.tar.gz"
-            _write_tar(archive, {"0/network.unl": b"<lab />"})
+            images = Path(tmp) / "images.tar.gz"
+            _write_tar(
+                archive,
+                {
+                    "0/network.unl": (
+                        b'<lab><node type="qemu" image="vios-159" /></lab>'
+                    )
+                },
+            )
             _write_tar(node_state, {"0/network/1/virtioa.qcow2": b"overlay"})
+            _write_tar(images, {"qemu/vios-159/virtioa.qcow2": b"base"})
 
             record = stage_migration_archive(
                 paths=paths,
@@ -207,17 +266,30 @@ class LabMigrationStagingTest(TestCase):
                 platform="eve-ng",
                 archive=archive,
                 node_state=node_state,
+                images=images,
             )
             loaded = load_migration_archive(paths=paths, payload=_eve_payload())
 
             self.assertIsNotNone(loaded)
-            primary, checksum, node_path, node_checksum = loaded
+            (
+                primary,
+                checksum,
+                node_path,
+                node_checksum,
+                image_path,
+                image_checksum,
+            ) = loaded
             self.assertTrue(primary.is_file())
             self.assertTrue(node_path.is_file())
             self.assertEqual(checksum, hashlib.sha256(archive.read_bytes()).hexdigest())
             self.assertEqual(
                 node_checksum,
                 hashlib.sha256(node_state.read_bytes()).hexdigest(),
+            )
+            self.assertTrue(image_path.is_file())
+            self.assertEqual(
+                image_checksum,
+                hashlib.sha256(images.read_bytes()).hexdigest(),
             )
             self.assertEqual(record["status"], "verified")
             self.assertTrue(
@@ -399,7 +471,7 @@ class LabMigrationCaptureTest(TestCase):
             return_value=subprocess.CompletedProcess(
                 ["ssh"],
                 0,
-                b"primary_bytes=4096\nnode_state_bytes=8192\n",
+                b"primary_bytes=4096\nnode_state_bytes=8192\nimage_bytes=16384\n",
                 b"",
             ),
         ):
@@ -407,7 +479,11 @@ class LabMigrationCaptureTest(TestCase):
 
         self.assertEqual(
             requirements,
-            {"primary_bytes": 4096, "node_state_bytes": 8192},
+            {
+                "primary_bytes": 4096,
+                "node_state_bytes": 8192,
+                "image_bytes": 16384,
+            },
         )
 
     def test_rejects_invalid_capture_assessment(self) -> None:
@@ -451,6 +527,7 @@ class LabMigrationCaptureTest(TestCase):
             return_value={
                 "primary_bytes": len(primary),
                 "node_state_bytes": len(nodes),
+                "image_bytes": 0,
             },
         ), patch(
             "hyops.lab.migration._close_ssh_control",
@@ -571,6 +648,51 @@ class LabMigrationCaptureTest(TestCase):
             self.assertFalse(output.exists())
             self.assertEqual(list(Path(tmp).glob("*.candidate")), [])
 
+    def test_captures_referenced_eve_images_as_a_companion(self) -> None:
+        primary = _tar_bytes(
+            {
+                "0/network.unl": (
+                    b'<lab><node type="qemu" image="vios-159" /></lab>'
+                )
+            }
+        )
+        images = _tar_bytes(
+            {"qemu/vios-159/virtioa.qcow2": b"base image"}
+        )
+        streams = iter((primary, images))
+
+        def run_capture(argv, *, stdout, stderr, check):
+            stdout.write(next(streams))
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.lab.migration._capture_requirements",
+            return_value={
+                "primary_bytes": len(primary),
+                "node_state_bytes": 0,
+                "image_bytes": len(images),
+            },
+        ), patch(
+            "hyops.lab.migration._close_ssh_control",
+        ), patch(
+            "hyops.lab.migration.subprocess.run",
+            side_effect=run_capture,
+        ) as run:
+            output = Path(tmp) / "eve.tar.gz"
+            report = capture_existing_lab(
+                platform="eve-ng",
+                host="eve.example.test",
+                output=output,
+                include_images=True,
+            )
+
+            image_output = Path(report["images"]["path"])
+            self.assertTrue(output.is_file())
+            self.assertTrue(image_output.is_file())
+            self.assertEqual(image_output.name, "eve.images.tar.gz")
+            self.assertEqual(report["images"]["image_count"], 1)
+            self.assertEqual(run.call_count, 2)
+
     def test_gns3_image_capture_is_explicit(self) -> None:
         primary = _tar_bytes({"projects/lab/project.gns3": b"{}"})
 
@@ -583,7 +705,11 @@ class LabMigrationCaptureTest(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp, patch(
             "hyops.lab.migration._capture_requirements",
-            return_value={"primary_bytes": len(primary), "node_state_bytes": 0},
+            return_value={
+                "primary_bytes": len(primary),
+                "node_state_bytes": 0,
+                "image_bytes": 0,
+            },
         ), patch(
             "hyops.lab.migration._close_ssh_control",
         ), patch(
@@ -605,7 +731,11 @@ class LabMigrationCaptureTest(TestCase):
             return_value=SimpleNamespace(free=1),
         ), patch(
             "hyops.lab.migration._capture_requirements",
-            return_value={"primary_bytes": 1048576, "node_state_bytes": 0},
+            return_value={
+                "primary_bytes": 1048576,
+                "node_state_bytes": 0,
+                "image_bytes": 0,
+            },
         ), patch(
             "hyops.lab.migration._close_ssh_control",
         ), patch(
@@ -624,3 +754,84 @@ class LabMigrationCaptureTest(TestCase):
 
             self.assertFalse(output.exists())
             capture_stream.assert_not_called()
+
+    def test_remote_eve_image_capture_selects_only_referenced_bases(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            labs = root / "labs"
+            addons = root / "addons"
+            labs.mkdir()
+            (labs / "network.unl").write_text(
+                '<lab><node type="qemu" image="vios-159" /></lab>',
+                encoding="utf-8",
+            )
+            selected = addons / "qemu/vios-159"
+            selected.mkdir(parents=True)
+            (selected / "virtioa.qcow2").write_bytes(b"selected")
+            unused = addons / "qemu/unused"
+            unused.mkdir(parents=True)
+            (unused / "virtioa.qcow2").write_bytes(b"unused")
+
+            assessment = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    _EVE_IMAGE_CAPTURE_PROGRAM,
+                    "assess",
+                    str(labs),
+                    str(addons),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            capture = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    _EVE_IMAGE_CAPTURE_PROGRAM,
+                    "capture",
+                    str(labs),
+                    str(addons),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            self.assertEqual(assessment.returncode, 0, assessment.stderr.decode())
+            self.assertGreater(int(assessment.stdout), 0)
+            self.assertEqual(capture.returncode, 0, capture.stderr.decode())
+            with tarfile.open(fileobj=io.BytesIO(capture.stdout), mode="r:gz") as handle:
+                members = handle.getnames()
+
+        self.assertIn("qemu/vios-159/virtioa.qcow2", members)
+        self.assertNotIn("qemu/unused/virtioa.qcow2", members)
+
+    def test_remote_eve_image_capture_rejects_symlinked_lab_definition(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            labs = root / "labs"
+            addons = root / "addons"
+            labs.mkdir()
+            addons.mkdir()
+            definition = root / "network.unl"
+            definition.write_text("<lab />", encoding="utf-8")
+            (labs / "network.unl").symlink_to(definition)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    _EVE_IMAGE_CAPTURE_PROGRAM,
+                    "assess",
+                    str(labs),
+                    str(addons),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b"must not be a symbolic link", result.stderr)

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -12,7 +12,10 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from hyops.lab.migration import (
+    _capture_requirements,
     _capture_stream,
+    _format_bytes,
+    _remote_capture_assessment_script,
     capture_existing_lab,
     inspect_migration_archive,
     load_migration_archive,
@@ -120,6 +123,22 @@ class LabMigrationInspectionTest(TestCase):
             )
 
             with self.assertRaisesRegex(ValueError, "relative to /opt/unetlab/labs"):
+                inspect_migration_archive(platform="eve-ng", archive=archive)
+
+    def test_rejects_eve_definition_with_entity_declaration(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "eve.tar.gz"
+            _write_tar(
+                archive,
+                {
+                    "0/network.unl": (
+                        b'<!DOCTYPE lab [<!ENTITY x "expanded">]>'
+                        b"<lab><node name='&x;' /></lab>"
+                    )
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "DTD or entity declaration"):
                 inspect_migration_archive(platform="eve-ng", archive=archive)
 
     def test_rejects_invalid_eve_node_state_layout(self) -> None:
@@ -357,6 +376,64 @@ class LabMigrationStagingTest(TestCase):
 
 
 class LabMigrationCaptureTest(TestCase):
+    def test_formats_capacity_for_operator_output(self) -> None:
+        self.assertEqual(
+            _format_bytes(171627474944),
+            "159.8 GiB (171627474944 bytes)",
+        )
+        self.assertEqual(_format_bytes(11821371392), "11.0 GiB (11821371392 bytes)")
+
+    def test_assessment_reports_both_eve_streams_without_transferring_data(self) -> None:
+        script = _remote_capture_assessment_script(
+            "eve-ng",
+            include_node_state=True,
+        )
+
+        self.assertIn("primary_bytes=", script)
+        self.assertIn("node_state_bytes=", script)
+        self.assertNotIn("tar --", script)
+
+    def test_parses_capture_assessment(self) -> None:
+        with patch(
+            "hyops.lab.migration.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["ssh"],
+                0,
+                b"primary_bytes=4096\nnode_state_bytes=8192\n",
+                b"",
+            ),
+        ):
+            requirements = _capture_requirements(["ssh"])
+
+        self.assertEqual(
+            requirements,
+            {"primary_bytes": 4096, "node_state_bytes": 8192},
+        )
+
+    def test_rejects_invalid_capture_assessment(self) -> None:
+        with patch(
+            "hyops.lab.migration.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["ssh"],
+                0,
+                b"primary_bytes=4096\nunexpected=value\n",
+                b"",
+            ),
+        ), self.assertRaisesRegex(ValueError, "invalid output"):
+            _capture_requirements(["ssh"])
+
+    def test_rejects_duplicate_capture_assessment_size(self) -> None:
+        with patch(
+            "hyops.lab.migration.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["ssh"],
+                0,
+                b"primary_bytes=4096\nprimary_bytes=8192\nnode_state_bytes=0\n",
+                b"",
+            ),
+        ), self.assertRaisesRegex(ValueError, "duplicate size"):
+            _capture_requirements(["ssh"])
+
     def test_captures_eve_archive_and_node_state_over_ssh(self) -> None:
         primary = _tar_bytes({"0/network.unl": b"<lab />"})
         nodes = _tar_bytes({"0/network/1/virtioa.qcow2": b"overlay"})
@@ -370,6 +447,14 @@ class LabMigrationCaptureTest(TestCase):
             return subprocess.CompletedProcess(argv, 0, b"", b"")
 
         with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.lab.migration._capture_requirements",
+            return_value={
+                "primary_bytes": len(primary),
+                "node_state_bytes": len(nodes),
+            },
+        ), patch(
+            "hyops.lab.migration._close_ssh_control",
+        ), patch(
             "hyops.lab.migration.subprocess.run",
             side_effect=run_capture,
         ) as run:
@@ -386,10 +471,17 @@ class LabMigrationCaptureTest(TestCase):
             self.assertTrue(Path(report["node_state"]["path"]).is_file())
             self.assertEqual(report["definition_count"], 1)
             self.assertEqual(run.call_count, 2)
+            control_paths = set()
             for call in run.call_args_list:
+                control_paths.update(
+                    item.split("=", 1)[1]
+                    for item in call.args[0]
+                    if item.startswith("ControlPath=")
+                )
                 remote = call.args[0][-1]
                 self.assertNotIn("systemctl stop", remote)
                 self.assertNotIn("rm ", remote)
+            self.assertEqual(len(control_paths), 1)
 
     def test_capture_failure_does_not_publish_partial_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, patch(
@@ -422,6 +514,25 @@ class LabMigrationCaptureTest(TestCase):
             ), self.assertRaisesRegex(
                 ValueError,
                 "output filesystem became full",
+            ):
+                _capture_stream(["ssh"], candidate)
+
+    def test_capture_translates_remote_capacity_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            candidate = Path(tmp) / "capture.candidate"
+            with patch(
+                "hyops.lab.migration.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["ssh"],
+                    23,
+                    b"",
+                    b"Insufficient disk space for lab capture: source requires "
+                    b"at least 171627474944 bytes; output filesystem has "
+                    b"11821371392 bytes available",
+                ),
+            ), self.assertRaisesRegex(
+                ValueError,
+                r"159\.8 GiB.*11\.0 GiB",
             ):
                 _capture_stream(["ssh"], candidate)
 
@@ -471,6 +582,11 @@ class LabMigrationCaptureTest(TestCase):
             return subprocess.CompletedProcess(argv, 0, b"", b"")
 
         with tempfile.TemporaryDirectory() as tmp, patch(
+            "hyops.lab.migration._capture_requirements",
+            return_value={"primary_bytes": len(primary), "node_state_bytes": 0},
+        ), patch(
+            "hyops.lab.migration._close_ssh_control",
+        ), patch(
             "hyops.lab.migration.subprocess.run",
             side_effect=run_capture,
         ):
@@ -484,27 +600,21 @@ class LabMigrationCaptureTest(TestCase):
         self.assertEqual(report["platform"], "gns3")
 
     def test_capture_reports_insufficient_output_disk_space(self) -> None:
-        def reject_capture(argv, *, stdout, stderr, check):
-            self.assertIn("Insufficient disk space for lab capture", argv[-1])
-            return subprocess.CompletedProcess(
-                argv,
-                23,
-                b"",
-                b"Insufficient disk space for lab capture: source requires at least "
-                b"1048576 bytes; output filesystem has 1 bytes available",
-            )
-
         with tempfile.TemporaryDirectory() as tmp, patch(
             "hyops.lab.migration.shutil.disk_usage",
             return_value=SimpleNamespace(free=1),
         ), patch(
-            "hyops.lab.migration.subprocess.run",
-            side_effect=reject_capture,
-        ):
+            "hyops.lab.migration._capture_requirements",
+            return_value={"primary_bytes": 1048576, "node_state_bytes": 0},
+        ), patch(
+            "hyops.lab.migration._close_ssh_control",
+        ), patch(
+            "hyops.lab.migration._capture_stream",
+        ) as capture_stream:
             output = Path(tmp) / "eve.tar.gz"
             with self.assertRaisesRegex(
                 ValueError,
-                "Insufficient disk space for lab capture",
+                "insufficient disk space for lab capture",
             ):
                 capture_existing_lab(
                     platform="eve-ng",
@@ -513,3 +623,4 @@ class LabMigrationCaptureTest(TestCase):
                 )
 
             self.assertFalse(output.exists())
+            capture_stream.assert_not_called()

--- a/hyops/lab/tests/test_migration.py
+++ b/hyops/lab/tests/test_migration.py
@@ -587,6 +587,7 @@ class LabMigrationCaptureTest(TestCase):
         primary = _tar_bytes({"0/network.unl": b"<lab />"})
         nodes = _tar_bytes({"0/network/1/virtioa.qcow2": b"overlay"})
         streams = iter((primary, nodes))
+        progress_events = []
 
         def run_capture(argv, *, stdout, stderr, check):
             self.assertEqual(argv[0], "ssh")
@@ -620,6 +621,7 @@ class LabMigrationCaptureTest(TestCase):
                 user="operator",
                 output=output,
                 include_node_state=True,
+                progress=progress_events.append,
             )
 
             self.assertTrue(output.is_file())
@@ -637,6 +639,18 @@ class LabMigrationCaptureTest(TestCase):
                 self.assertNotIn("systemctl stop", remote)
                 self.assertNotIn("rm ", remote)
             self.assertEqual(len(control_paths), 1)
+            self.assertEqual(progress_events[0]["phase"], "assessment_started")
+            self.assertEqual(progress_events[1]["phase"], "assessment_finished")
+            self.assertEqual(
+                [
+                    event["stage"]
+                    for event in progress_events
+                    if event["phase"] == "stream_finished"
+                ],
+                ["lab_definitions", "node_state"],
+            )
+            self.assertEqual(progress_events[-1]["phase"], "verification_finished")
+            self.assertEqual(progress_events[-1]["status"], "ok")
 
     def test_capture_failure_does_not_publish_partial_output(self) -> None:
         with (
@@ -677,6 +691,37 @@ class LabMigrationCaptureTest(TestCase):
                 ),
             ):
                 _capture_stream(["ssh"], candidate)
+
+    def test_capture_stream_reports_written_bytes(self) -> None:
+        events = []
+        payload = b"captured archive"
+
+        def run_capture(argv, *, stdout, stderr, check):
+            stdout.write(payload)
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch(
+                "hyops.lab.migration.subprocess.run",
+                side_effect=run_capture,
+            ),
+        ):
+            candidate = Path(tmp) / "capture.candidate"
+            _capture_stream(
+                ["ssh"],
+                candidate,
+                stage="node_state",
+                expected_source_bytes=4096,
+                progress=events.append,
+            )
+
+        self.assertEqual(events[0]["phase"], "stream_started")
+        self.assertEqual(events[0]["stage"], "node_state")
+        self.assertEqual(events[0]["expected_source_bytes"], 4096)
+        self.assertEqual(events[-1]["phase"], "stream_finished")
+        self.assertEqual(events[-1]["status"], "ok")
+        self.assertEqual(events[-1]["bytes_written"], len(payload))
 
     def test_capture_translates_remote_capacity_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/hyops/runtime/proc.py
+++ b/hyops/runtime/proc.py
@@ -470,6 +470,7 @@ def run_capture_stream(
 
     rc = 1
     interrupted = False
+    timed_out = False
     try:
         rc = int(p.wait(timeout=timeout_s))
     except KeyboardInterrupt:
@@ -496,11 +497,16 @@ def run_capture_stream(
         except Exception:
             rc = 130
     except subprocess.TimeoutExpired:
+        timed_out = True
         try:
             p.kill()
         except Exception:
             pass
-        rc = int(p.wait(timeout=10))
+        try:
+            p.wait(timeout=10)
+        except Exception:
+            pass
+        rc = 124
     finally:
         heartbeat_stop.set()
         t_out.join(timeout=2)
@@ -516,13 +522,24 @@ def run_capture_stream(
                 pass
 
     dur = int((time.time() - start) * 1000)
+    timeout_message = ""
+    if timed_out:
+        timeout_message = f"command timed out after {timeout_s} seconds\n"
+        with err_path.open("a", encoding="utf-8") as timeout_log:
+            timeout_log.write(timeout_message)
+        if tee_path is not None:
+            try:
+                with tee_path.open("a", encoding="utf-8") as timeout_log:
+                    timeout_log.write(timeout_message)
+            except Exception:
+                pass
     r = ProcResult(
         argv=list(argv),
         cwd=cwd,
         rc=rc,
         duration_ms=dur,
         stdout="",
-        stderr="",
+        stderr=timeout_message,
     )
     _write_result_envelope(evidence_dir, label, r, redact=redact)
     if stream_progress.enabled:

--- a/hyops/runtime/proc.py
+++ b/hyops/runtime/proc.py
@@ -6,11 +6,12 @@ maintainer: HybridOps.Tech
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 import os
 from pathlib import Path
 import signal
-from typing import Mapping, Sequence
+from typing import Callable, Iterator, Mapping, Sequence
 import subprocess
 import sys
 import threading
@@ -19,6 +20,34 @@ import time
 from hyops.runtime.redact import redact_text
 from hyops.runtime.progress import ProgressDisplay, concise_enabled
 from hyops.runtime.state import write_json_atomic
+
+
+StreamObserver = Callable[[str, str], None]
+_stream_observers: set[StreamObserver] = set()
+_stream_observers_lock = threading.Lock()
+
+
+@contextmanager
+def observe_stream_output(observer: StreamObserver) -> Iterator[None]:
+    """Observe redacted output from streamed child processes in this runtime."""
+
+    with _stream_observers_lock:
+        _stream_observers.add(observer)
+    try:
+        yield
+    finally:
+        with _stream_observers_lock:
+            _stream_observers.discard(observer)
+
+
+def _notify_stream_observers(stream: str, line: str) -> None:
+    with _stream_observers_lock:
+        observers = tuple(_stream_observers)
+    for observer in observers:
+        try:
+            observer(stream, line)
+        except Exception:
+            pass
 
 
 @dataclass(frozen=True)
@@ -319,6 +348,7 @@ def run_capture_stream(
             with dst.open("a", encoding="utf-8", errors="replace") as f:
                 for line in src:
                     token = redact_text(line) if redact else line
+                    _notify_stream_observers(stream, token)
                     f.write(token)
                     f.flush()
                     if tee_f:

--- a/hyops/runtime/tests/test_proc_progress.py
+++ b/hyops/runtime/tests/test_proc_progress.py
@@ -67,6 +67,22 @@ class CapturedProcessProgressTests(unittest.TestCase):
         self.assertEqual(result.rc, 127)
         self.assertIn("command not found", error_text)
 
+    def test_streamed_command_timeout_uses_standard_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            result = proc.run_capture_stream(
+                ["bash", "-lc", "sleep 1"],
+                evidence_dir=evidence_dir,
+                label="timed_out_command",
+                timeout_s=0.01,
+            )
+            error_text = (evidence_dir / "timed_out_command.stderr.txt").read_text(
+                encoding="utf-8"
+            )
+
+        self.assertEqual(result.rc, 124)
+        self.assertIn("command timed out after 0.01 seconds", error_text)
+
     def test_quick_capture_does_not_start_progress_outside_tty(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, patch.object(
             proc, "concise_enabled", return_value=False

--- a/hyops/tests/test_ansible_connectivity.py
+++ b/hyops/tests/test_ansible_connectivity.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from hyops.drivers.config.ansible.connectivity import connectivity_check, probe_ssh_auth
+from hyops.drivers.config.ansible.inventory import write_inventory
+
+
+class AnsibleConnectivityTests(TestCase):
+    def test_gcp_iap_inventory_disables_ssh_multiplexing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            inventory = Path(tmp) / "inventory.ini"
+            error = write_inventory(
+                inventory,
+                {
+                    "target_user": "opsadmin",
+                    "ssh_access_mode": "gcp-iap",
+                    "inventory_groups": {
+                        "targets": [
+                            {
+                                "name": "eve-ng-01",
+                                "host": "10.80.50.2",
+                                "gcp_iap_instance": "eve-ng-01",
+                                "gcp_iap_project_id": "project-1",
+                                "gcp_iap_zone": "europe-west2-b",
+                            }
+                        ]
+                    },
+                },
+            )
+
+            self.assertEqual(error, "")
+            rendered = inventory.read_text(encoding="utf-8")
+            self.assertIn("ansible_ssh_args='-o ControlMaster=no -o ControlPath=none'", rendered)
+            self.assertIn("-o ServerAliveInterval=15", rendered)
+            self.assertIn("-o ServerAliveCountMax=2", rendered)
+
+    @patch("hyops.drivers.config.ansible.connectivity.run_capture")
+    @patch("hyops.drivers.config.ansible.connectivity.shutil.which")
+    def test_ssh_probe_checks_passwordless_become(self, which, run_capture) -> None:
+        which.side_effect = lambda command: f"/usr/bin/{command}"
+        run_capture.return_value = SimpleNamespace(rc=0, stdout="", stderr="")
+
+        ok, error = probe_ssh_auth(
+            target_host="10.80.50.2",
+            target_user="opsadmin",
+            target_port=22,
+            ssh_private_key_file="/tmp/id_ed25519",
+            proxy_host="",
+            proxy_user="",
+            proxy_port=0,
+            timeout_s=5,
+            cwd="/tmp",
+            env={},
+            evidence_dir=Path("/tmp/evidence"),
+            redact=True,
+            label="connectivity",
+            become=True,
+            become_user="root",
+        )
+
+        self.assertTrue(ok)
+        self.assertEqual(error, "")
+        argv = run_capture.call_args.args[0]
+        self.assertEqual(argv[-1], "sudo -n -u root true")
+
+    @patch("hyops.drivers.config.ansible.connectivity.probe_ssh_auth")
+    def test_connectivity_passes_become_contract_to_probe(self, probe) -> None:
+        probe.return_value = (True, "")
+        with TemporaryDirectory() as tmp:
+            ok, error = connectivity_check(
+                command_name="apply",
+                inputs={
+                    "target_user": "opsadmin",
+                    "become": True,
+                    "become_user": "root",
+                    "ssh_access_mode": "gcp-iap",
+                    "inventory_groups": {
+                        "targets": [
+                            {
+                                "name": "eve-ng-01",
+                                "host": "10.80.50.2",
+                                "gcp_iap_instance": "eve-ng-01",
+                                "gcp_iap_project_id": "project-1",
+                                "gcp_iap_zone": "europe-west2-b",
+                            }
+                        ]
+                    },
+                },
+                runtime_root=Path(tmp),
+                cwd=tmp,
+                env={},
+                evidence_dir=Path(tmp) / "evidence",
+                redact=True,
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(error, "")
+        self.assertTrue(probe.call_args.kwargs["become"])
+        self.assertEqual(probe.call_args.kwargs["become_user"], "root")
+

--- a/hyops/tests/test_ansible_policy.py
+++ b/hyops/tests/test_ansible_policy.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from hyops.drivers.config.ansible.config import resolve_execution_timeout
+
+
+class AnsibleExecutionPolicyTests(TestCase):
+    def test_module_timeout_overrides_profile_default(self):
+        timeout, error = resolve_execution_timeout(
+            {"execution_timeout_s": 14400},
+            default=3600,
+        )
+
+        self.assertEqual(timeout, 14400)
+        self.assertEqual(error, "")
+
+    def test_module_timeout_is_bounded(self):
+        timeout, error = resolve_execution_timeout(
+            {"execution_timeout_s": 86401},
+            default=3600,
+        )
+
+        self.assertEqual(timeout, 3600)
+        self.assertIn("between 60 and 86400", error)
+
+    def test_profile_timeout_remains_default(self):
+        timeout, error = resolve_execution_timeout({}, default=3600)
+
+        self.assertEqual(timeout, 3600)
+        self.assertEqual(error, "")

--- a/hyops/tests/test_ansible_results.py
+++ b/hyops/tests/test_ansible_results.py
@@ -164,6 +164,78 @@ class AnsibleResultHintTests(unittest.TestCase):
         self.assertIn("Stop all active lab nodes", hint)
         self.assertIn("No resources were destroyed", hint)
 
+    def test_eve_ng_archive_reports_existing_image_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            (evidence_dir / "ansible_apply.stdout.txt").write_text(
+                'fatal: [eve-ng-01]: FAILED! => {"msg": "EVE-NG image '
+                "content already exists at iol/bin/test.bin; use "
+                '--overwrite-images only when replacement is intended"}\n',
+                encoding="utf-8",
+            )
+
+            hint = ansible_error_hint(
+                command_name="apply",
+                module_ref="platform/linux/eve-ng-lab-archive",
+                inputs={},
+                evidence_dir=evidence_dir,
+                label="ansible_apply",
+            )
+
+        self.assertEqual(
+            hint,
+            "EVE-NG image content already exists at iol/bin/test.bin. "
+            "Rerun with --overwrite-images only when replacement is intended.",
+        )
+
+    def test_eve_ng_archive_reports_existing_lab_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            (evidence_dir / "ansible_apply.stdout.txt").write_text(
+                'fatal: [eve-ng-01]: FAILED! => {"msg": "EVE-NG lab content '
+                "already exists at student/lab.unl. Set "
+                'eveng_lab_archive_overwrite=true only when replacing it is intended."}\n',
+                encoding="utf-8",
+            )
+
+            hint = ansible_error_hint(
+                command_name="apply",
+                module_ref="platform/linux/eve-ng-lab-archive",
+                inputs={},
+                evidence_dir=evidence_dir,
+                label="ansible_apply",
+            )
+
+        self.assertEqual(
+            hint,
+            "EVE-NG lab content already exists at student/lab.unl. "
+            "Rerun with --overwrite-labs only when replacement is intended.",
+        )
+
+    def test_eve_ng_archive_reports_existing_node_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp)
+            (evidence_dir / "ansible_apply.stdout.txt").write_text(
+                'fatal: [eve-ng-01]: FAILED! => {"msg": "EVE-NG node state '
+                "already exists: 0/lab/1/virtioa.qcow2. Enable overwrite only "
+                'when replacement is intended."}\n',
+                encoding="utf-8",
+            )
+
+            hint = ansible_error_hint(
+                command_name="apply",
+                module_ref="platform/linux/eve-ng-lab-archive",
+                inputs={},
+                evidence_dir=evidence_dir,
+                label="ansible_apply",
+            )
+
+        self.assertEqual(
+            hint,
+            "EVE-NG node state already exists at 0/lab/1/virtioa.qcow2. "
+            "Rerun with --overwrite-labs only when replacement is intended.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/hyops/tests/test_cli.py
+++ b/hyops/tests/test_cli.py
@@ -34,6 +34,7 @@ PUBLIC_COMMANDS = (
     "import",
     "init",
     "inventory",
+    "lab",
     "module",
     "plan",
     "preflight",
@@ -102,6 +103,12 @@ class CliRoutingTests(unittest.TestCase):
         result = run_cli("blueprint", "--help")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("edit", result.stdout)
+
+    def test_lab_migration_help_lists_capture_inspect_and_import(self) -> None:
+        result = run_cli("lab", "migrate", "--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for command in ("capture", "inspect", "import"):
+            self.assertIn(command, result.stdout)
 
     def test_device_web_help_includes_multi_target_controls(self) -> None:
         result = run_cli("blueprint", "device", "web", "--help")

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -86,6 +86,7 @@ def validate(inputs: dict[str, Any]) -> None:
     include_node_state = data.get("eveng_lab_archive_include_node_state")
     restore_node_state = data.get("eveng_lab_archive_restore_node_state")
     stop_running_nodes = data.get("eveng_lab_archive_stop_running_nodes")
+    guest_quiesced = data.get("eveng_lab_archive_guest_quiesced")
     if not isinstance(include_node_state, bool):
         raise ValueError(
             "inputs.eveng_lab_archive_include_node_state must be a boolean"
@@ -98,11 +99,9 @@ def validate(inputs: dict[str, Any]) -> None:
         raise ValueError(
             "inputs.eveng_lab_archive_stop_running_nodes must be a boolean"
         )
-    if stop_running_nodes:
+    if not isinstance(guest_quiesced, bool):
         raise ValueError(
-            "inputs.eveng_lab_archive_stop_running_nodes is not supported; "
-            "shut down stateful guests inside the guest and stop the remaining "
-            "EVE-NG nodes before export"
+            "inputs.eveng_lab_archive_guest_quiesced must be a boolean"
         )
     capture_device_configs = data.get("eveng_lab_archive_capture_device_configs")
     if not isinstance(capture_device_configs, bool):

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -98,10 +98,11 @@ def validate(inputs: dict[str, Any]) -> None:
         raise ValueError(
             "inputs.eveng_lab_archive_stop_running_nodes must be a boolean"
         )
-    if stop_running_nodes and (action != "export" or not include_node_state):
+    if stop_running_nodes:
         raise ValueError(
-            "inputs.eveng_lab_archive_stop_running_nodes requires an export "
-            "that includes node state"
+            "inputs.eveng_lab_archive_stop_running_nodes is not supported; "
+            "shut down stateful guests inside the guest and stop the remaining "
+            "EVE-NG nodes before export"
         )
     capture_device_configs = data.get("eveng_lab_archive_capture_device_configs")
     if not isinstance(capture_device_configs, bool):

--- a/hyops/validators/platform/linux/eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/eve_ng_lab_archive.py
@@ -103,6 +103,20 @@ def validate(inputs: dict[str, Any]) -> None:
         raise ValueError(
             "inputs.eveng_lab_archive_guest_quiesced must be a boolean"
         )
+    quiesce_script_path = data.get("eveng_lab_archive_quiesce_script_path")
+    if not isinstance(quiesce_script_path, str):
+        raise ValueError(
+            "inputs.eveng_lab_archive_quiesce_script_path must be a string"
+        )
+    quiesce_timeout_s = data.get("eveng_lab_archive_quiesce_timeout_s")
+    if (
+        isinstance(quiesce_timeout_s, bool)
+        or not isinstance(quiesce_timeout_s, int)
+        or not 1 <= quiesce_timeout_s <= 3600
+    ):
+        raise ValueError(
+            "inputs.eveng_lab_archive_quiesce_timeout_s must be between 1 and 3600"
+        )
     capture_device_configs = data.get("eveng_lab_archive_capture_device_configs")
     if not isinstance(capture_device_configs, bool):
         raise ValueError(

--- a/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
@@ -60,10 +60,16 @@ class EveNgLabArchiveValidatorTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must be empty"):
             validate(inputs)
 
-    def test_automatic_node_shutdown_is_rejected(self) -> None:
+    def test_legacy_automatic_node_shutdown_setting_is_accepted(self) -> None:
         inputs = valid_inputs()
+        inputs["eveng_lab_archive_include_node_state"] = True
         inputs["eveng_lab_archive_stop_running_nodes"] = True
-        with self.assertRaisesRegex(ValueError, "is not supported"):
+        validate(inputs)
+
+    def test_guest_quiescence_must_be_boolean(self) -> None:
+        inputs = valid_inputs()
+        inputs["eveng_lab_archive_guest_quiesced"] = "yes"
+        with self.assertRaisesRegex(ValueError, "must be a boolean"):
             validate(inputs)
 
     def test_saved_configuration_capture_is_valid_for_export(self) -> None:

--- a/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
+++ b/hyops/validators/platform/linux/tests/test_eve_ng_lab_archive.py
@@ -60,17 +60,11 @@ class EveNgLabArchiveValidatorTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must be empty"):
             validate(inputs)
 
-    def test_node_shutdown_requires_node_state_export(self) -> None:
+    def test_automatic_node_shutdown_is_rejected(self) -> None:
         inputs = valid_inputs()
         inputs["eveng_lab_archive_stop_running_nodes"] = True
-        with self.assertRaisesRegex(ValueError, "requires an export"):
+        with self.assertRaisesRegex(ValueError, "is not supported"):
             validate(inputs)
-
-    def test_node_shutdown_is_valid_for_node_state_export(self) -> None:
-        inputs = valid_inputs()
-        inputs["eveng_lab_archive_include_node_state"] = True
-        inputs["eveng_lab_archive_stop_running_nodes"] = True
-        validate(inputs)
 
     def test_saved_configuration_capture_is_valid_for_export(self) -> None:
         inputs = valid_inputs()

--- a/modules/platform/linux/containerlab-recovery/spec.yml
+++ b/modules/platform/linux/containerlab-recovery/spec.yml
@@ -34,6 +34,7 @@ inputs:
     connectivity_check: true
     connectivity_timeout_s: 5
     connectivity_wait_s: 0
+    execution_timeout_s: 14400
     required_env: []
     required_env_destroy: []
     load_vault_env: false

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -34,6 +34,20 @@ Blueprint teardown supplies the acknowledgement from
 `hyops blueprint destroy --guest-quiesced`. It is scoped to that operation and
 must not be stored as a permanent blueprint input.
 
+An operator action can replace the manual acknowledgement:
+
+```bash
+hyops blueprint destroy \
+  --env demo-lab \
+  --ref gcp/eve-ng@v1 \
+  --archive-before-destroy \
+  --quiesce-script ./quiesce-lab.sh \
+  --execute
+```
+
+The script runs on the EVE-NG host. HybridOps then verifies that no QEMU guest
+remains active and records the script checksum with the archive evidence.
+
 To refresh saved device configurations before export, enable:
 
 ```yaml

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -48,4 +48,16 @@ eveng_lab_archive_node_state_expected_sha256: <sha256>
 
 Existing lab content and runtime disks remain protected unless overwrite is explicitly enabled.
 
+A staged migration can also supply a checksummed image companion. The runtime
+restores those referenced bases before lab definitions and QEMU overlays:
+
+```yaml
+eveng_lab_archive_restore_images: true
+eveng_lab_archive_images_path: <verified-image-archive>
+eveng_lab_archive_images_expected_sha256: <sha256>
+```
+
+Image companions contain referenced QEMU, IOL or Dynamips bases only. They do
+not contain IOL licence material.
+
 EVE-NG blueprints use this contract as their archive-before-release path. A later deployment with `--restore-labs` selects and verifies the retained environment archive before restoration.

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -89,4 +89,9 @@ Image companions contain referenced QEMU, IOL or Dynamips bases only. They do
 not contain IOL licence material. Image replacement is staged and promoted as
 a separate transaction when overwrite is enabled explicitly.
 
+Restore validates captured QCOW2 state without repairing or rewriting it.
+Archive integrity does not guarantee that an appliance can boot its writable
+state on a different hypervisor target. The restored guest must pass its own
+boot and service checks before the migration is accepted.
+
 EVE-NG blueprints use this contract as their archive-before-release path. A later deployment with `--restore-labs` selects and verifies the retained environment archive before restoration.

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -55,9 +55,11 @@ restores those referenced bases before lab definitions and QEMU overlays:
 eveng_lab_archive_restore_images: true
 eveng_lab_archive_images_path: <verified-image-archive>
 eveng_lab_archive_images_expected_sha256: <sha256>
+eveng_lab_archive_overwrite_images: false
 ```
 
 Image companions contain referenced QEMU, IOL or Dynamips bases only. They do
-not contain IOL licence material.
+not contain IOL licence material. Image replacement is staged and promoted as
+a separate transaction when overwrite is enabled explicitly.
 
 EVE-NG blueprints use this contract as their archive-before-release path. A later deployment with `--restore-labs` selects and verifies the retained environment archive before restoration.

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -21,10 +21,14 @@ For stopped-QEMU state, enable:
 
 ```yaml
 eveng_lab_archive_include_node_state: true
-eveng_lab_archive_stop_running_nodes: true
+eveng_lab_archive_stop_running_nodes: false
 ```
 
-The archive role stops running QEMU nodes, validates their overlay disks and creates a separately checksummed node-state companion archive. Base images remain independently managed and are paired with the restored overlays on the reconstructed host.
+Shut down stateful guests inside their operating systems, then stop the EVE-NG
+nodes. The archive role rejects running QEMU processes, validates the overlay
+disks and creates a separately checksummed node-state companion archive. Base
+images remain independently managed and are paired with the restored overlays
+on the reconstructed host.
 
 To refresh saved device configurations before export, enable:
 

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -21,7 +21,7 @@ For stopped-QEMU state, enable:
 
 ```yaml
 eveng_lab_archive_include_node_state: true
-eveng_lab_archive_stop_running_nodes: false
+eveng_lab_archive_guest_quiesced: true
 ```
 
 Shut down stateful guests inside their operating systems, then stop the EVE-NG

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -30,6 +30,10 @@ disks and creates a separately checksummed node-state companion archive. Base
 images remain independently managed and are paired with the restored overlays
 on the reconstructed host.
 
+Blueprint teardown supplies the acknowledgement from
+`hyops blueprint destroy --guest-quiesced`. It is scoped to that operation and
+must not be stored as a permanent blueprint input.
+
 To refresh saved device configurations before export, enable:
 
 ```yaml

--- a/modules/platform/linux/eve-ng-lab-archive/README.md
+++ b/modules/platform/linux/eve-ng-lab-archive/README.md
@@ -30,23 +30,28 @@ disks and creates a separately checksummed node-state companion archive. Base
 images remain independently managed and are paired with the restored overlays
 on the reconstructed host.
 
-Blueprint teardown supplies the acknowledgement from
-`hyops blueprint destroy --guest-quiesced`. It is scoped to that operation and
-must not be stored as a permanent blueprint input.
+Blueprint teardown supplies the acknowledgement from an environment action or
+from `hyops blueprint destroy --guest-quiesced`. Manual acknowledgement is
+scoped to that operation and must not be stored as a permanent blueprint input.
 
-An operator action can replace the manual acknowledgement:
+Configure the environment action once:
 
 ```bash
+hyops blueprint quiescence edit \
+  --env demo-lab \
+  --ref gcp/eve-ng@v1
+
 hyops blueprint destroy \
   --env demo-lab \
   --ref gcp/eve-ng@v1 \
   --archive-before-destroy \
-  --quiesce-script ./quiesce-lab.sh \
   --execute
 ```
 
-The script runs on the EVE-NG host. HybridOps then verifies that no QEMU guest
-remains active and records the script checksum with the archive evidence.
+Core stores the action under the environment configuration and discovers it on
+subsequent teardown. The script runs on the EVE-NG host. HybridOps then verifies
+that no QEMU guest remains active and records the script checksum with the
+archive evidence. `--quiesce-script` remains an operation-specific override.
 
 To refresh saved device configurations before export, enable:
 

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -57,6 +57,8 @@ inputs:
     eveng_lab_archive_restore_images: false
     eveng_lab_archive_stop_running_nodes: false
     eveng_lab_archive_guest_quiesced: false
+    eveng_lab_archive_quiesce_script_path: ""
+    eveng_lab_archive_quiesce_timeout_s: 300
     eveng_lab_archive_node_state_root: "/opt/unetlab/tmp"
     eveng_lab_archive_node_state_path: ""
     eveng_lab_archive_node_state_expected_sha256: ""
@@ -98,6 +100,9 @@ outputs:
     - eveng_lab_archive_node_state_archive_path
     - eveng_lab_archive_node_state_sha256
     - eveng_lab_archive_node_state_files
+    - eveng_lab_archive_quiescence_method
+    - eveng_lab_archive_quiescence_script_sha256
+    - eveng_lab_archive_quiescence_verified_at
     - eveng_lab_archive_images_included
     - eveng_lab_archive_images_archive_path
     - eveng_lab_archive_images_sha256

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -36,6 +36,7 @@ inputs:
     connectivity_check: true
     connectivity_timeout_s: 5
     connectivity_wait_s: 0
+    execution_timeout_s: 14400
 
     required_env: []
     required_env_destroy: []

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -49,6 +49,7 @@ inputs:
     eveng_lab_archive_path: ""
     eveng_lab_archive_expected_sha256: ""
     eveng_lab_archive_overwrite: false
+    eveng_lab_archive_overwrite_images: false
     eveng_lab_archive_remote_dir: "/tmp/hyops-eveng-lab-archive"
     eveng_lab_archive_include_node_state: false
     eveng_lab_archive_restore_node_state: false
@@ -95,6 +96,9 @@ outputs:
     - eveng_lab_archive_node_state_archive_path
     - eveng_lab_archive_node_state_sha256
     - eveng_lab_archive_node_state_files
+    - eveng_lab_archive_images_included
+    - eveng_lab_archive_images_archive_path
+    - eveng_lab_archive_images_sha256
 
 probes: []
 constraints: []

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -55,6 +55,7 @@ inputs:
     eveng_lab_archive_restore_node_state: false
     eveng_lab_archive_restore_images: false
     eveng_lab_archive_stop_running_nodes: false
+    eveng_lab_archive_guest_quiesced: false
     eveng_lab_archive_node_state_root: "/opt/unetlab/tmp"
     eveng_lab_archive_node_state_path: ""
     eveng_lab_archive_node_state_expected_sha256: ""

--- a/modules/platform/linux/eve-ng-lab-archive/spec.yml
+++ b/modules/platform/linux/eve-ng-lab-archive/spec.yml
@@ -52,10 +52,17 @@ inputs:
     eveng_lab_archive_remote_dir: "/tmp/hyops-eveng-lab-archive"
     eveng_lab_archive_include_node_state: false
     eveng_lab_archive_restore_node_state: false
+    eveng_lab_archive_restore_images: false
     eveng_lab_archive_stop_running_nodes: false
     eveng_lab_archive_node_state_root: "/opt/unetlab/tmp"
     eveng_lab_archive_node_state_path: ""
     eveng_lab_archive_node_state_expected_sha256: ""
+    eveng_lab_archive_images_root: "/opt/unetlab/addons"
+    eveng_lab_archive_images_owner: "root"
+    eveng_lab_archive_images_group: "root"
+    eveng_lab_archive_images_path: ""
+    eveng_lab_archive_images_expected_sha256: ""
+    eveng_lab_archive_fixpermissions_command: "/opt/unetlab/wrappers/unl_wrapper -a fixpermissions"
     eveng_lab_archive_qemu_img: "/opt/qemu/bin/qemu-img"
     eveng_lab_archive_capture_device_configs: false
     eveng_lab_archive_activate_saved_configs: true

--- a/modules/platform/linux/gns3-lab-archive/spec.yml
+++ b/modules/platform/linux/gns3-lab-archive/spec.yml
@@ -36,6 +36,7 @@ inputs:
     connectivity_check: true
     connectivity_timeout_s: 5
     connectivity_wait_s: 0
+    execution_timeout_s: 14400
 
     required_env:
       - "GNS3_SERVER_PASSWORD"

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -70,6 +70,12 @@
               eveng_lab_archive_results.node_state_sha256 | default(''),
             'eveng_lab_archive_node_state_files':
               eveng_lab_archive_results.node_state_files | default(0),
+            'eveng_lab_archive_quiescence_method':
+              eveng_lab_archive_results.quiescence_method | default(''),
+            'eveng_lab_archive_quiescence_script_sha256':
+              eveng_lab_archive_results.quiescence_script_sha256 | default(''),
+            'eveng_lab_archive_quiescence_verified_at':
+              eveng_lab_archive_results.quiescence_verified_at | default(''),
             'eveng_lab_archive_images_included':
               eveng_lab_archive_results.images_included | default(false),
             'eveng_lab_archive_images_archive_path':

--- a/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
+++ b/packs/config/ansible/linux/common/platform/48-eve-ng-lab-archive@v1.0/stack/playbook.yml
@@ -69,5 +69,11 @@
             'eveng_lab_archive_node_state_sha256':
               eveng_lab_archive_results.node_state_sha256 | default(''),
             'eveng_lab_archive_node_state_files':
-              eveng_lab_archive_results.node_state_files | default(0)
+              eveng_lab_archive_results.node_state_files | default(0),
+            'eveng_lab_archive_images_included':
+              eveng_lab_archive_results.images_included | default(false),
+            'eveng_lab_archive_images_archive_path':
+              eveng_lab_archive_results.images_archive_path | default(''),
+            'eveng_lab_archive_images_sha256':
+              eveng_lab_archive_results.images_sha256 | default('')
           } | to_json }}


### PR DESCRIPTION
## Summary

- capture and verify existing EVE-NG, GNS3 and Containerlab lab state
- preserve definitions, writable node state and referenced EVE-NG images as separate verified streams
- import migration bundles into an environment-bound restore lifecycle
- assess capacity before transfer or replacement and report capture, import and restore progress
- require explicit EVE-NG guest quiescence and reject active QEMU before node-state capture
- support environment-managed quiescence actions with per-operation overrides
- constrain EVE-NG node-state capture to disks referenced by selected lab definitions
- print the access, credential and support commands after successful deployment

## Validation

- Core CI passed on the previous migration head
- reviewed migration, destroy, restore, EVE-NG and presentation suite: 132 tests passed
- earlier full Core suite: 499 tests passed
- fresh Proxmox-to-GCP capture verified one lab definition, four stopped overlays and four referenced base images
- IOL, vEOS and Ubuntu state booted after restore
- F5 BIG-IP 11.6 writable-overlay portability remains unsupported and is recorded in the operator documentation

## Dependencies

- [hybridops.helper#34](https://github.com/hybridops-tech/ansible-collection-helper/pull/34)
- [hybridops.app#32](https://github.com/hybridops-tech/ansible-collection-app/pull/32)

## Scope

- [x] This pull request is focused on one change.
- [x] I have not included credentials, tokens, private addresses, or customer data.
- [x] I updated documentation, examples, or tests where the change needs them.
