### PR TITLE
chore: prepare v0.1.5 release candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,12 +82,15 @@ jobs:
         shell: bash
         run: |
           export HYOPS_RELEASE_LABEL="${GITHUB_REF_NAME#v}"
+          export HYOPS_RELEASE_VERSION="$(
+            python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])'
+          )"
           bash pkg/build_release.sh
           TARBALL="$(ls -1 dist/releases/hybridops-core-*.tar.gz | head -n 1)"
           PKG="dist/releases/hybridops-core-${HYOPS_RELEASE_LABEL}-macos-${{ matrix.architecture }}.pkg"
           bash pkg/build_macos_pkg.sh \
             --archive "${TARBALL}" \
-            --version "${HYOPS_RELEASE_LABEL}" \
+            --version "${HYOPS_RELEASE_VERSION}" \
             --output "${PKG}"
           PKG_DIR="$(dirname "${PKG}")"
           PKG_NAME="$(basename "${PKG}")"
@@ -195,5 +198,9 @@ jobs:
           if gh release view "${tag}" >/dev/null 2>&1; then
             gh release upload "${tag}" "${assets[@]}" --clobber
           else
-            gh release create "${tag}" "${assets[@]}" --generate-notes --verify-tag
+            release_args=(--generate-notes --verify-tag)
+            if [[ "${tag}" == *-* ]]; then
+              release_args+=(--prerelease)
+            fi
+            gh release create "${tag}" "${assets[@]}" "${release_args[@]}"
           fi

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 
 This changelog records significant operator-facing capabilities, lifecycle changes, compatibility fixes, and release engineering updates. Individual commits and maintenance-only changes remain available through the linked comparisons.
 
-## Unreleased
+## [v0.1.5-rc.1] - 2026-09-02
 
 ### Added
 
@@ -201,6 +201,7 @@ This changelog records significant operator-facing capabilities, lifecycle chang
 - Hardened destroy-time validation, replay safety, validator cleanup, image and template flows, database services, edge networking, and release installation.
 - Added shell, Python, YAML, infrastructure, installation, and release quality gates.
 
+[v0.1.5-rc.1]: https://github.com/hybridops-tech/hybridops-core/compare/v0.1.4...v0.1.5-rc.1
 [v0.1.4]: https://github.com/hybridops-tech/hybridops-core/compare/v0.1.3...v0.1.4
 [v0.1.3]: https://github.com/hybridops-tech/hybridops-core/compare/v0.1.2...v0.1.3
 [v0.1.2]: https://github.com/hybridops-tech/hybridops-core/compare/v0.1.1...v0.1.2

--- a/hyops/__init__.py
+++ b/hyops/__init__.py
@@ -5,4 +5,4 @@ maintainer: HybridOps.Tech
 """
 
 __all__ = ["__version__"]
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hybridops-core"
-version = "0.1.4"
+version = "0.1.5"
 description = "HybridOps.Core runtime scaffold"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- set the Core runtime version to 0.1.5
- publish the migration lifecycle changes as v0.1.5-rc.1
- keep release labels separate from the numeric macOS package version
- mark hyphenated release tags as GitHub pre-releases

## Validation

- `bash tools/ci/check-python.sh`
- `bash pkg/verify_release.sh dist/releases/hybridops-core-0.1.5-rc.1.tar.gz`
- workflow YAML parse
- release and update regression tests

The full repository quality workflow remains authoritative for lint and cross-platform package validation.